### PR TITLE
add forecast endpoints

### DIFF
--- a/sfa_api/__init__.py
+++ b/sfa_api/__init__.py
@@ -37,9 +37,11 @@ def create_app(config_name='ProductionConfig'):
                       content_security_policy_nonce_in=['script-src'])
 
     from sfa_api.observations import obs_blp
+    from sfa_api.forecasts import forecast_blp
     from sfa_api.sites import site_blp
     app.register_blueprint(obs_blp)
     app.register_blueprint(site_blp)
+    app.register_blueprint(forecast_blp)
     with app.test_request_context():
         for k, view in app.view_functions.items():
             if k == 'static':

--- a/sfa_api/demo.py
+++ b/sfa_api/demo.py
@@ -9,7 +9,7 @@ class Site(object):
     latitude = 42.19
     longitude = -122.70
     elevation = 595
-    station_id = 94040
+    provider_api_id = 94040
     abbreviation = 'AS'
     timezone = 'Etc/GMT+8'
     attribution = ''
@@ -19,8 +19,8 @@ class Site(object):
 class Observation(object):
     """Container for serializing observation metadata.
     """
-    uuid = '123e4567-e89b-12d3-a456-426655440000'
-    variable = 'ghi'
+    obs_id = '123e4567-e89b-12d3-a456-426655440000'
+    type = 'ghi'
     site_id = '123e4567-e89b-12d3-a456-426655440001'
     name = 'Ashland OR, ghi'
     site = Site()
@@ -37,7 +37,7 @@ class TimeseriesValue(object):
 class Forecast(object):
     """Object for serializing forecast metadata.
     """
-    uuid = "f79e4f84-e2c3-11e8-9f32-f2801f1b9fd1"
+    forecast_id = "f79e4f84-e2c3-11e8-9f32-f2801f1b9fd1"
     variable = 'ghi'
     site_id = '123e4567-e89b-12d3-a456-426655440001'
     name = 'Ashland OR, ghi'

--- a/sfa_api/demo.py
+++ b/sfa_api/demo.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 # TODO: Replace the static demo content in these classes.
 class Site(object):
     """Object for serializing site metadata.
@@ -21,11 +22,23 @@ class Observation(object):
     uuid = '123e4567-e89b-12d3-a456-426655440000'
     variable = 'ghi'
     site_id = '123e4567-e89b-12d3-a456-426655440001'
+    name = 'Ashland OR, ghi'
     site = Site()
 
 
-class ObservationValue(object):
-    """Object for serializing observation's timeseries data.
+class TimeseriesValue(object):
+    """Object for serializing timeseries data.
     """
-    timestamp = '2018-11-05T18:19:33+00:00'
+    timestamp = datetime.strptime('2018-11-05T18:19:33+0000','%Y-%m-%dT%H:%M:%S%z')
     value = 35
+    questionable = False
+
+
+class Forecast(object):
+    """Object for serializing forecast metadata.
+    """
+    uuid = "f79e4f84-e2c3-11e8-9f32-f2801f1b9fd1"
+    variable = 'ghi'
+    site_id = '123e4567-e89b-12d3-a456-426655440001'
+    name = 'Ashland OR, ghi'
+    site = Site()

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -2,10 +2,10 @@ from flask import Blueprint
 from flask.views import MethodView
 
 
-from sfa_api import spec
-from sfa_api.schema import (ForecastValueSchema,
-                            ForecastSchema, ForecastResponseSchema,
-                            ForecastLinksSchema)
+from sfa_api import spec, ma
+from sfa_api.schema import SiteSchema, ForecastValueSchema, \
+                           ForecastPostSchema, ForecastSchema, \
+                           ForecastLinksSchema
 from sfa_api.demo import Forecast, TimeseriesValue
 
 
@@ -28,7 +28,7 @@ class AllForecastsView(MethodView):
           401:
             $ref: '#/components/responses/401-Unauthorized'
         """
-        forecasts = [Forecast() for i in range(3)]
+        forecasts = [ Forecast() for i in range(3)]
         return ForecastSchema(many=True).jsonify(forecasts)
 
     def post(self, *args):
@@ -60,7 +60,6 @@ class AllForecastsView(MethodView):
         forecast = Forecast()
         return ForecastResponseSchema().jsonify(forecast)
 
-
 class ForecastView(MethodView):
     def get(self, forecast_id, *args):
         """
@@ -84,6 +83,7 @@ class ForecastView(MethodView):
             $ref: '#/components/responses/404-NotFound'
         """
         return ForecastLinksSchema().jsonify(Forecast())
+
 
     def delete(self, forecast_id, *args):
         """
@@ -128,8 +128,9 @@ class ForecastValuesView(MethodView):
           404:
             $ref: '#/components/responses/404-NotFound'
         """
-        forecast_values = [TimeseriesValue() for i in range(3)]
+        forecast_values = [ TimeseriesValue() for i in range(3) ]
         return ForecastValueSchema(many=True).jsonify(forecast_values)
+
 
     def post(self, forecast_id, *args):
         """
@@ -198,6 +199,7 @@ class ForecastMetadataView(MethodView):
         """
         return ForecastSchema().jsonify(Forecast())
 
+
     def put(self, forecast_id, *args):
         """
         ---
@@ -236,9 +238,6 @@ forecast_blp = Blueprint(
     'forecasts', 'forecasts', url_prefix="/forecasts",
 )
 forecast_blp.add_url_rule('/', view_func=AllForecastsView.as_view('all'))
-forecast_blp.add_url_rule('/<forecast_id>',
-                          view_func=ForecastView.as_view('single'))
-forecast_blp.add_url_rule('/<forecast_id>/values',
-                          view_func=ForecastValuesView.as_view('values'))
-forecast_blp.add_url_rule('/<forecast_id>/metadata',
-                          view_func=ForecastMetadataView.as_view('metadata'))
+forecast_blp.add_url_rule('/<forecast_id>', view_func=ForecastView.as_view('single'))
+forecast_blp.add_url_rule('/<forecast_id>/values', view_func=ForecastValuesView.as_view('values'))
+forecast_blp.add_url_rule('/<forecast_id>/metadata',view_func=ForecastMetadataView.as_view('metadata'))

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -4,7 +4,7 @@ from flask.views import MethodView
 
 from sfa_api import spec
 from sfa_api.schema import (ForecastValueSchema,
-                            ForecastSchema, ForecastResponseSchema,
+                            ForecastSchema,
                             ForecastLinksSchema)
 from sfa_api.demo import Forecast, TimeseriesValue
 
@@ -58,7 +58,7 @@ class AllForecastsView(MethodView):
             $ref: '#/components/responses/401-Unauthorized'
         """
         forecast = Forecast()
-        return ForecastResponseSchema().jsonify(forecast)
+        return ForecastSchema().jsonify(forecast)
 
 
 class ForecastView(MethodView):

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -2,10 +2,10 @@ from flask import Blueprint
 from flask.views import MethodView
 
 
-from sfa_api import spec, ma
-from sfa_api.schema import SiteSchema, ForecastValueSchema, \
-                           ForecastPostSchema, ForecastSchema, \
-                           ForecastLinksSchema
+from sfa_api import spec
+from sfa_api.schema import (ForecastValueSchema,
+                            ForecastSchema, ForecastResponseSchema,
+                            ForecastLinksSchema)
 from sfa_api.demo import Forecast, TimeseriesValue
 
 
@@ -28,7 +28,7 @@ class AllForecastsView(MethodView):
           401:
             $ref: '#/components/responses/401-Unauthorized'
         """
-        forecasts = [ Forecast() for i in range(3)]
+        forecasts = [Forecast() for i in range(3)]
         return ForecastSchema(many=True).jsonify(forecasts)
 
     def post(self, *args):
@@ -60,6 +60,7 @@ class AllForecastsView(MethodView):
         forecast = Forecast()
         return ForecastResponseSchema().jsonify(forecast)
 
+
 class ForecastView(MethodView):
     def get(self, forecast_id, *args):
         """
@@ -83,7 +84,6 @@ class ForecastView(MethodView):
             $ref: '#/components/responses/404-NotFound'
         """
         return ForecastLinksSchema().jsonify(Forecast())
-
 
     def delete(self, forecast_id, *args):
         """
@@ -128,9 +128,8 @@ class ForecastValuesView(MethodView):
           404:
             $ref: '#/components/responses/404-NotFound'
         """
-        forecast_values = [ TimeseriesValue() for i in range(3) ]
+        forecast_values = [TimeseriesValue() for i in range(3)]
         return ForecastValueSchema(many=True).jsonify(forecast_values)
-
 
     def post(self, forecast_id, *args):
         """
@@ -199,7 +198,6 @@ class ForecastMetadataView(MethodView):
         """
         return ForecastSchema().jsonify(Forecast())
 
-
     def put(self, forecast_id, *args):
         """
         ---
@@ -238,6 +236,9 @@ forecast_blp = Blueprint(
     'forecasts', 'forecasts', url_prefix="/forecasts",
 )
 forecast_blp.add_url_rule('/', view_func=AllForecastsView.as_view('all'))
-forecast_blp.add_url_rule('/<forecast_id>', view_func=ForecastView.as_view('single'))
-forecast_blp.add_url_rule('/<forecast_id>/values', view_func=ForecastValuesView.as_view('values'))
-forecast_blp.add_url_rule('/<forecast_id>/metadata',view_func=ForecastMetadataView.as_view('metadata'))
+forecast_blp.add_url_rule('/<forecast_id>',
+                          view_func=ForecastView.as_view('single'))
+forecast_blp.add_url_rule('/<forecast_id>/values',
+                          view_func=ForecastValuesView.as_view('values'))
+forecast_blp.add_url_rule('/<forecast_id>/metadata',
+                          view_func=ForecastMetadataView.as_view('metadata'))

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -1,0 +1,269 @@
+from flask import Blueprint
+from flask.views import MethodView
+
+
+from sfa_api import spec, ma
+from sfa_api.sites import SiteSchema
+from sfa_api.demo import Forecast, TimeseriesValue
+
+
+@spec.define_schema('ForecastValue')
+class ForecastValueSchema(ma.Schema):
+    class Meta:
+        strict = True
+        ordered = True
+    timestamp = ma.DateTime(description="ISO 8601 Datetime")
+    value = ma.Float(description="Value of the measurement")
+    questionable = ma.Boolean(description="Whether the value is questionable",
+                              default=False, missing=False)
+
+
+@spec.define_schema('ForecastDefinition')
+class ForecastPostSchema(ma.Schema):
+    class Meta:
+        strict = True
+        ordered = True
+    type = ma.String(
+        description="Type of variable forecasted",
+        required=True)
+    site_id = ma.UUID(description="UUID of associated site",
+                      required=True)
+    name = ma.String(description="Human friendly name for forecast",
+                     required=True)
+
+
+@spec.define_schema('ForecastMetadata')
+class ForecastSchema(ForecastPostSchema):
+    site = ma.Nested(SiteSchema)
+    uuid = ma.UUID()
+
+
+@spec.define_schema('ForecastLinks')
+class ForecastLinkSchema(ma.Schema):
+    class Meta:
+        string = True
+        ordered = True
+    uuid = ma.UUID()
+    _links = ma.Hyperlinks({
+        'metadata': ma.AbsoluteURLFor('forecasts.metadata',
+                                      forecast_id='<uuid>'),
+        'values': ma.AbsoluteURLFor('forecasts.values',
+                                    forecast_id='<uuid>')
+    })
+
+
+class AllForecastsView(MethodView):
+    def get(self, *args):
+        """
+        ---
+        summary: List forecasts
+        tags:
+        - Forecasts
+        responses:
+          200:
+            description:
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ForecastMetadata'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+        """
+        forecasts = [ Forecast() for i in range(3)]
+        return ForecastSchema(many=True).jsonify(forecasts)
+
+    def post(self, *args):
+        """
+        ---
+        summary: Create forecast
+        tags:
+        - Forecasts
+        description: Create a new Forecast by posting metadata
+        requestBody:
+          desctiption: JSON representation of an observation.
+          required: True
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForecastDefinition'
+        responses:
+          201:
+            description: Forecast created successfully
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ForecastMetadata'
+          400:
+            $ref: '#/components/responses/400-BadRequest'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+        """
+        forecast = Forecast()
+        return ForecastResponseSchema().jsonify(forecast)
+
+class ForecastView(MethodView):
+    def get(self, forecast_id, *args):
+        """
+        ---
+        summary: Get Forecast options
+        description: List options available for Forecast.
+        tags:
+        - Forecasts
+        parameters:
+        - $ref: '#/components/parameters/forecast_id'
+        responses:
+          200:
+            description: Forecast options retrieved sucessfully.
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ForecastLinks'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+        """
+        return ForecastLinkSchema().jsonify(Forecast())
+
+
+    def delete(self, forecast_id, *args):
+        """
+        ---
+        summary: Delete forecast
+        description: Delete a Forecast, including its values and metadata.
+        tags:
+        - Forecasts
+        parameters:
+        - $ref: '#/components/parameters/forecast_id'
+        responses:
+          200:
+            description: Forecast deleted sucessfully.
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+        """
+        return f'Delete forecast {forecast_id}'
+
+
+class ForecastValuesView(MethodView):
+    def get(self, forecast_id, *args):
+        """
+        ---
+        summary: Get Forecast data
+        description: Get the timeseries values from the Forecast entry.
+        tags:
+        - Forecasts
+        parameters:
+        - $ref: '#/components/parameters/forecast_id'
+        responses:
+          200:
+            content:
+              applciation/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ForecastValue'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+        """
+        forecast_values = [ TimeseriesValue() for i in range(3) ]
+        return ForecastValueSchema(many=True).jsonify(forecast_values)
+
+
+    def post(self, forecast_id, *args):
+        """
+        ---
+        summary: Add Forecast data
+        description: Add new timeseries values to Forecast entry.
+        tags:
+        - Forecasts
+        parameters:
+        - $ref: '#/components/parameters/forecast_id'
+        requestBody:
+          required: True
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ForecastValue'
+        responses:
+          201:
+            $ref: '#/components/responses/201-Created'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+        """
+        return
+
+
+class ForecastMetadataView(MethodView):
+    def get(self, forecast_id, *args):
+        """
+        ---
+        summary: Get Forecast metadata
+        tags:
+        - Forecasts
+        parameters:
+        - $ref: '#/components/parameters/forecast_id'
+        responses:
+          200:
+            description: Successfully retrieved Forecasts.
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ForecastMetadata'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+        """
+        return ForecastSchema().jsonify(Forecast())
+
+
+    def put(self, forecast_id, *args):
+        """
+        ---
+        summary: Update forecast metadata
+        tags:
+        - Forecasts
+        parameters:
+        - $ref: '#/components/parameters/forecast_id'
+        requestBody:
+          description: JSON representation of a forecast's metadata.
+          required: True
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForecastDefinition'
+        responses:
+          200:
+           description: Forecast updated successfully.
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+        """
+        return
+
+
+spec.add_parameter('forecast_id', 'path',
+                   type='string',
+                   description="Forecast's unique identifier.",
+                   required='true')
+
+forecast_blp = Blueprint(
+    'forecasts', 'forecasts', url_prefix="/forecasts",
+)
+forecast_blp.add_url_rule('/', view_func=AllForecastsView.as_view('all'))
+forecast_blp.add_url_rule('/<forecast_id>', view_func=ForecastView.as_view('single'))
+forecast_blp.add_url_rule('/<forecast_id>/values', view_func=ForecastValuesView.as_view('values'))
+forecast_blp.add_url_rule('/<forecast_id>/metadata',view_func=ForecastMetadataView.as_view('metadata'))

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -227,7 +227,10 @@ class ForecastMetadataView(MethodView):
 
 
 spec.add_parameter('forecast_id', 'path',
-                   type='string',
+                   schema={
+                       'type': 'string',
+                       'format': 'uuid'
+                   },
                    description="Forecast's unique identifier.",
                    required='true')
 

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -229,7 +229,10 @@ class ObservationMetadataView(MethodView):
 
 # Add path parameters used by these endpoints to the spec.
 spec.add_parameter('obs_id', 'path',
-                   type='string',
+                   schema={
+                       'type': 'string',
+                       'format': 'uuid'
+                   },
                    description="Resource's unique identifier.",
                    required='true')
 

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -2,10 +2,9 @@ from flask import Blueprint
 from flask.views import MethodView
 
 
-from sfa_api import spec
-from sfa_api.schema import (ObservationSchema, ObservationLinksSchema,
-                            ObservationValueSchema)
-
+from sfa_api import spec, ma
+from sfa_api.schema import SiteSchema, ObservationSchema, \
+                           ObservationPostSchema, ObservationLinksSchema
 from sfa_api.demo import Observation, TimeseriesValue
 
 
@@ -30,7 +29,7 @@ class AllObservationsView(MethodView):
             $ref: '#/components/responses/401-Unauthorized'
         """
         # TODO: replace demo response, also do not allow top-level json array
-        observations = [Observation() for i in range(5)]
+        observations = [ Observation() for i in range(5) ]
         return ObservationSchema().jsonify(observations)
 
     def post(self, *args):
@@ -132,7 +131,7 @@ class ObservationValuesView(MethodView):
           404:
             $ref: '#/components/responses/404-NotFound'
         """
-        values = [TimeseriesValue() for i in range(5)]
+        values = [ TimeseriesValue() for i in range(5) ]
         return ObservationValueSchema(many=True).jsonify(values)
 
     def post(self, obs_id, *args):

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -2,9 +2,10 @@ from flask import Blueprint
 from flask.views import MethodView
 
 
-from sfa_api import spec, ma
-from sfa_api.schema import SiteSchema, ObservationSchema, \
-                           ObservationPostSchema, ObservationLinksSchema
+from sfa_api import spec
+from sfa_api.schema import (ObservationSchema, ObservationLinksSchema,
+                            ObservationValueSchema)
+
 from sfa_api.demo import Observation, TimeseriesValue
 
 
@@ -29,7 +30,7 @@ class AllObservationsView(MethodView):
             $ref: '#/components/responses/401-Unauthorized'
         """
         # TODO: replace demo response, also do not allow top-level json array
-        observations = [ Observation() for i in range(5) ]
+        observations = [Observation() for i in range(5)]
         return ObservationSchema().jsonify(observations)
 
     def post(self, *args):
@@ -131,7 +132,7 @@ class ObservationValuesView(MethodView):
           404:
             $ref: '#/components/responses/404-NotFound'
         """
-        values = [ TimeseriesValue() for i in range(5) ]
+        values = [TimeseriesValue() for i in range(5)]
         return ObservationValueSchema(many=True).jsonify(values)
 
     def post(self, obs_id, *args):

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -3,53 +3,9 @@ from flask.views import MethodView
 
 
 from sfa_api import spec, ma
-from sfa_api.sites import SiteSchema
+from sfa_api.schema import SiteSchema, ObservationSchema, \
+                           ObservationPostSchema, ObservationLinksSchema
 from sfa_api.demo import Observation, TimeseriesValue
-
-
-@spec.define_schema('ObservationValue')
-class ObservationValueSchema(ma.Schema):
-    class Meta:
-        strict = True
-        ordered = True
-    timestamp = ma.DateTime(description="ISO 8601 Datetime")
-    value = ma.Float(description="Value of the measurement")
-    questionable = ma.Boolean(description="Whether the value is questionable",
-                              default=False, missing=False)
-
-
-@spec.define_schema('ObservationDefinition')
-class ObservationPostSchema(ma.Schema):
-    class Meta:
-        strict = True
-        ordered = True
-    type = ma.String(
-        description="Type of variable recorded by this observation",
-        required=True)
-    site_id = ma.UUID(description="UUID the assocaiated site",
-                      required=True)
-    name = ma.String(description='Human friendly name for the observation',
-                     required=True)
-
-
-@spec.define_schema('ObservationMetadata')
-class ObservationSchema(ObservationPostSchema):
-    site = ma.Nested(SiteSchema)
-    uuid = ma.UUID()
-
-
-@spec.define_schema('ObservationLinks')
-class ObservationLinksSchema(ma.Schema):
-    class Meta:
-        strict = True
-        ordered = True
-    uuid = ma.UUID()
-    _links = ma.Hyperlinks({
-        'metadata': ma.AbsoluteURLFor('observations.metadata',
-                                      obs_id='<uuid>'),
-        'values': ma.AbsoluteURLFor('observations.values',
-                                    obs_id='<uuid>')
-    })
 
 
 class AllObservationsView(MethodView):
@@ -271,7 +227,6 @@ class ObservationMetadataView(MethodView):
         return
 
 
-iam_a_variable = "hi"
 # Add path parameters used by these endpoints to the spec.
 spec.add_parameter('obs_id', 'path',
                    type='string',

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -1,0 +1,128 @@
+from sfa_api import spec, ma
+
+# Sites
+@spec.define_schema('SiteDefinition')
+class SiteSchema(ma.Schema):
+    class Meta:
+        strict = True
+        ordered = True
+    name = ma.String(description="Name of the Site",
+                     required=True)
+    latitude = ma.Float(description="Latitude in degrees North",
+                        required=True)
+    longitude = ma.Float(
+        description="Longitude in degrees East of the Prime Meridian",
+        required=True)
+    elevation = ma.Float(description="Elevation in meters",
+                         required=True)
+    provider_api_id = ma.String(
+        description="Unique ID used by data provider")
+    abbreviation = ma.String(
+        description="Abbreviated station name used by data provider")
+    timezone = ma.String(description="Timezone",
+                         required=True)
+    attribution = ma.String(
+        description="Attribution to be included in derived works")
+    provider = ma.String(description="Data provider")
+
+
+@spec.define_schema('SiteMetadata')
+class SiteResponseSchema(SiteSchema):
+    site_id = ma.UUID(required=True)
+
+
+# Observations
+@spec.define_schema('ObservationValue')
+class ObservationValueSchema(ma.Schema):
+    class Meta:
+        strict = True
+        ordered = True
+    timestamp = ma.DateTime(description="ISO 8601 Datetime")
+    value = ma.Float(description="Value of the measurement")
+    questionable = ma.Boolean(description="Whether the value is questionable",
+                              default=False, missing=False)
+
+
+@spec.define_schema('ObservationDefinition')
+class ObservationPostSchema(ma.Schema):
+    class Meta:
+        strict = True
+        ordered = True
+    type = ma.String(
+        description="Type of variable recorded by this observation",
+        required=True)
+    site_id = ma.UUID(description="UUID the assocaiated site",
+                      required=True)
+    name = ma.String(description='Human friendly name for the observation',
+                     required=True)
+
+
+@spec.define_schema('ObservationMetadata')
+class ObservationSchema(ObservationPostSchema):
+    site = ma.Nested(SiteSchema)
+    obs_id = ma.UUID()
+
+
+@spec.define_schema('ObservationLinks')
+class ObservationLinksSchema(ma.Schema):
+    class Meta:
+        strict = True
+        ordered = True
+    obs_id = ma.UUID()
+    _links = ma.Hyperlinks({
+        'metadata': ma.AbsoluteURLFor('observations.metadata',
+                                      obs_id='<obs_id>'),
+        'values': ma.AbsoluteURLFor('observations.values',
+                                    obs_id='<obd_id>')
+    })
+
+# Forecasts
+@spec.define_schema('ForecastValue')
+class ForecastValueSchema(ma.Schema):
+    class Meta:
+        strict = True
+        ordered = True
+    timestamp = ma.DateTime(description="ISO 8601 Datetime")
+    value = ma.Float(description="Value of the measurement")
+    questionable = ma.Boolean(description="Whether the value is questionable",
+                              default=False, missing=False)
+
+
+@spec.define_schema('ForecastDefinition')
+class ForecastPostSchema(ma.Schema):
+    class Meta:
+        strict = True
+        ordered = True
+    type = ma.String(
+        description="Type of variable forecasted",
+        required=True)
+    site_id = ma.UUID(description="UUID of the associated site",
+                      required=True)
+    name = ma.String(description="Human friendly name for forecast",
+                     required=True)
+
+
+@spec.define_schema('ForecastMetadata')
+class ForecastSchema(ForecastPostSchema):
+    site = ma.Nested(SiteSchema)
+    type = ma.String(description="Type of variable forecasted")
+    lead_time = ma.String(description="Lead time to start of forecast")
+    duration = ma.String(description="Interval duration")
+    intervals =  ma.Integer(description="Intervals per submission")
+    issue_frequency = ma.String(description="Forecast issue frequency")
+    value_type = ma.String(description="Value type (e.g. mean, max, 95th percentile, instantaneous)")
+    forecast_id = ma.UUID()
+
+
+@spec.define_schema('ForecastLinks')
+class ForecastLinksSchema(ma.Schema):
+    class Meta:
+        string = True
+        ordered = True
+    forecast_id = ma.UUID()
+    _links = ma.Hyperlinks({
+        'metadata': ma.AbsoluteURLFor('forecasts.metadata',
+                                      forecast_id='<forecast_id>'),
+        'values': ma.AbsoluteURLFor('forecasts.values',
+                                    forecast_id='<forecast_id>')
+    })

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -1,5 +1,6 @@
 from sfa_api import spec, ma
 
+
 # Sites
 @spec.define_schema('SiteDefinition')
 class SiteSchema(ma.Schema):
@@ -93,24 +94,29 @@ class ForecastPostSchema(ma.Schema):
     class Meta:
         strict = True
         ordered = True
-    type = ma.String(
-        description="Type of variable forecasted",
-        required=True)
     site_id = ma.UUID(description="UUID of the associated site",
                       required=True)
     name = ma.String(description="Human friendly name for forecast",
                      required=True)
+    type = ma.String(
+        description="Type of variable forecasted",
+        required=True)
+    lead_time = ma.String(description="Lead time to start of forecast",
+                          required=True)
+    duration = ma.String(description="Interval duration",
+                         required=True)
+    intervals =  ma.Integer(description="Intervals per submission",
+                            required=True)
+    issue_frequency = ma.String(description="Forecast issue frequency",
+                                required=True)
+    value_type = ma.String(
+        description="Value type (e.g. mean, max, 95th percentile, instantaneous)",  # NOQA
+        required=True)
 
 
 @spec.define_schema('ForecastMetadata')
 class ForecastSchema(ForecastPostSchema):
     site = ma.Nested(SiteSchema)
-    type = ma.String(description="Type of variable forecasted")
-    lead_time = ma.String(description="Lead time to start of forecast")
-    duration = ma.String(description="Interval duration")
-    intervals =  ma.Integer(description="Intervals per submission")
-    issue_frequency = ma.String(description="Forecast issue frequency")
-    value_type = ma.String(description="Value type (e.g. mean, max, 95th percentile, instantaneous)")
     forecast_id = ma.UUID()
 
 

--- a/sfa_api/sites.py
+++ b/sfa_api/sites.py
@@ -3,7 +3,7 @@ from flask.views import MethodView
 
 
 from sfa_api import spec, ma
-from sfa_api.demo import Site
+from sfa_api.demo import Site, Observation, Forecast
 
 
 @spec.define_schema('SiteDefinition')
@@ -185,7 +185,7 @@ class SiteObservations(MethodView):
           404:
              $ref: '#/components/responses/404-NotFound'
         """
-        return
+        return f'List Observations for {site_id}'
 
 
 class SiteForecasts(MethodView):
@@ -206,12 +206,14 @@ class SiteForecasts(MethodView):
               application/json:
                 schema:
                   type: array
+                  items:
+                    $ref: '#/componens/schemas/ForecastMetadata'
           401:
             $ref: '#/components/responses/401-Unauthorized'
           404:
              $ref: '#/components/responses/404-NotFound'
         """
-        return
+        return f'List Forecasts for site {site_id}'
 
 
 spec.add_parameter('site_id', 'path',

--- a/sfa_api/sites.py
+++ b/sfa_api/sites.py
@@ -3,37 +3,9 @@ from flask.views import MethodView
 
 
 from sfa_api import spec, ma
+from sfa_api.schema import SiteSchema, SiteResponseSchema, \
+                           ForecastSchema, ObservationSchema
 from sfa_api.demo import Site, Observation, Forecast
-
-
-@spec.define_schema('SiteDefinition')
-class SiteSchema(ma.Schema):
-    class Meta:
-        strict = True
-        ordered = True
-    name = ma.String(description="Name of the Site",
-                     required=True)
-    latitude = ma.Float(description="Latitude in degrees North",
-                        required=True)
-    longitude = ma.Float(
-        description="Longitude in degrees East of the Prime Meridian",
-        required=True)
-    elevation = ma.Float(description="Elevation in meters",
-                         required=True)
-    station_id = ma.String(
-        description="Unique ID used by data provider")
-    abbreviation = ma.String(
-        description="Abbreviated station name used by data provider")
-    timezone = ma.String(description="Timezone",
-                         required=True)
-    attribution = ma.String(
-        description="Attribution to be included in derived works")
-    provider = ma.String(description="Data provider")
-
-
-@spec.define_schema('SiteMetadata')
-class SiteResponseSchema(SiteSchema):
-    site_id = ma.UUID(required=True)
 
 
 class AllSitesView(MethodView):
@@ -185,7 +157,8 @@ class SiteObservations(MethodView):
           404:
              $ref: '#/components/responses/404-NotFound'
         """
-        return f'List Observations for {site_id}'
+        observations = [ Observation() for i in range(3) ]
+        return ObservationSchema(many=True).jsonify(observations)
 
 
 class SiteForecasts(MethodView):
@@ -207,13 +180,14 @@ class SiteForecasts(MethodView):
                 schema:
                   type: array
                   items:
-                    $ref: '#/componens/schemas/ForecastMetadata'
+                    $ref: '#/components/schemas/ForecastMetadata'
           401:
             $ref: '#/components/responses/401-Unauthorized'
           404:
              $ref: '#/components/responses/404-NotFound'
         """
-        return f'List Forecasts for site {site_id}'
+        forecasts = [ Forecast() for i in range(3) ]
+        return ForecastSchema(many=True).jsonify(forecasts)
 
 
 spec.add_parameter('site_id', 'path',

--- a/sfa_api/sites.py
+++ b/sfa_api/sites.py
@@ -2,9 +2,9 @@ from flask import Blueprint
 from flask.views import MethodView
 
 
-from sfa_api import spec
-from sfa_api.schema import (SiteResponseSchema,
-                            ForecastSchema, ObservationSchema)
+from sfa_api import spec, ma
+from sfa_api.schema import SiteSchema, SiteResponseSchema, \
+                           ForecastSchema, ObservationSchema
 from sfa_api.demo import Site, Observation, Forecast
 
 
@@ -157,7 +157,7 @@ class SiteObservations(MethodView):
           404:
              $ref: '#/components/responses/404-NotFound'
         """
-        observations = [Observation() for i in range(3)]
+        observations = [ Observation() for i in range(3) ]
         return ObservationSchema(many=True).jsonify(observations)
 
 
@@ -186,7 +186,7 @@ class SiteForecasts(MethodView):
           404:
              $ref: '#/components/responses/404-NotFound'
         """
-        forecasts = [Forecast() for i in range(3)]
+        forecasts = [ Forecast() for i in range(3) ]
         return ForecastSchema(many=True).jsonify(forecasts)
 
 

--- a/sfa_api/sites.py
+++ b/sfa_api/sites.py
@@ -191,7 +191,10 @@ class SiteForecasts(MethodView):
 
 
 spec.add_parameter('site_id', 'path',
-                   type='string',
+                   schema={
+                       'type': 'string',
+                       'format': 'uuid'
+                   },
                    description="Site's unique identifier.",
                    required='true')
 

--- a/sfa_api/sites.py
+++ b/sfa_api/sites.py
@@ -2,9 +2,9 @@ from flask import Blueprint
 from flask.views import MethodView
 
 
-from sfa_api import spec, ma
-from sfa_api.schema import SiteSchema, SiteResponseSchema, \
-                           ForecastSchema, ObservationSchema
+from sfa_api import spec
+from sfa_api.schema import (SiteResponseSchema,
+                            ForecastSchema, ObservationSchema)
 from sfa_api.demo import Site, Observation, Forecast
 
 
@@ -157,7 +157,7 @@ class SiteObservations(MethodView):
           404:
              $ref: '#/components/responses/404-NotFound'
         """
-        observations = [ Observation() for i in range(3) ]
+        observations = [Observation() for i in range(3)]
         return ObservationSchema(many=True).jsonify(observations)
 
 
@@ -186,7 +186,7 @@ class SiteForecasts(MethodView):
           404:
              $ref: '#/components/responses/404-NotFound'
         """
-        forecasts = [ Forecast() for i in range(3) ]
+        forecasts = [Forecast() for i in range(3)]
         return ForecastSchema(many=True).jsonify(forecasts)
 
 


### PR DESCRIPTION
I did find an issue while trying to update the fx/obs return values from sites. Trying to import the Forecast or Observation schemas throws an ImportError,  I think because of the import of siteschema creating a cycle. 

I could move the schema into their own module and each flask view module could import the ones they need to avoid the cycle?