### PR TITLE
Forecast Blueprint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ flask
 marshmallow
 flask-marshmallow
 flask-talisman
-apispec
+apispec>=1.0.0
 apispec-webframeworks
 webargs
 gunicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ marshmallow
 flask-marshmallow
 flask-talisman
 apispec
+apispec-webframeworks
 webargs
 gunicorn
 gevent

--- a/sfa_api/__init__.py
+++ b/sfa_api/__init__.py
@@ -46,7 +46,7 @@ def create_app(config_name='ProductionConfig'):
         for k, view in app.view_functions.items():
             if k == 'static':
                 continue
-            spec.add_path(view=view)
+            spec.path(view=view)
 
     @app.route('/openapi.yaml')
     def get_apispec_yaml():

--- a/sfa_api/demo/demo.py
+++ b/sfa_api/demo/demo.py
@@ -46,12 +46,14 @@ class ObservationTimeseriesValue(object):
     value = 35
     quality_flag = 0
 
+
 class ForecastTimeseriesValue(object):
     """Object for serializing timeseries data.
     """
     timestamp = datetime.strptime('2018-11-05T18:19:33+0000',
                                   '%Y-%m-%dT%H:%M:%S%z')
     value = 35
+
 
 class Forecast(object):
     """Object for serializing forecast metadata.

--- a/sfa_api/demo/demo.py
+++ b/sfa_api/demo/demo.py
@@ -38,7 +38,7 @@ class Observation(object):
     site = Site()
 
 
-class TimeseriesValue(object):
+class ObservationTimeseriesValue(object):
     """Object for serializing timeseries data.
     """
     timestamp = datetime.strptime('2018-11-05T18:19:33+0000',
@@ -46,6 +46,12 @@ class TimeseriesValue(object):
     value = 35
     quality_flag = 0
 
+class ForecastTimeseriesValue(object):
+    """Object for serializing timeseries data.
+    """
+    timestamp = datetime.strptime('2018-11-05T18:19:33+0000',
+                                  '%Y-%m-%dT%H:%M:%S%z')
+    value = 35
 
 class Forecast(object):
     """Object for serializing forecast metadata.

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -1,3 +1,4 @@
+import pdb
 from flask import Blueprint, request, jsonify, make_response, url_for
 from flask.views import MethodView
 from io import StringIO
@@ -33,7 +34,7 @@ class AllForecastsView(MethodView):
             $ref: '#/components/responses/401-Unauthorized'
         """
         forecasts = storage.list_forecasts()
-        return jsonify(ForecastSchema(many=True).dump(forecasts))
+        return jsonify(ForecastSchema(many=True).dump(forecasts).data)
 
     def post(self, *args):
         """
@@ -69,7 +70,7 @@ class AllForecastsView(MethodView):
         else:
             forecast_id = storage.store_forecast(forecast)
             response = make_response('Forecast created.', 201)
-            response.headsers['Location'] = url_for('forecasts.single',
+            response.headers['Location'] = url_for('forecasts.single',
                                                     forecast_id=forecast_id)
             return response
 
@@ -99,7 +100,7 @@ class ForecastView(MethodView):
         forecast = storage.read_forecast(forecast_id)
         if forecast is None:
             return 404
-        return jsonify(ForecastLinksSchema().dump(forecast))
+        return jsonify(ForecastLinksSchema().dump(forecast).data)
 
     def delete(self, forecast_id, *args):
         """
@@ -143,6 +144,13 @@ class ForecastValuesView(MethodView):
                   type: array
                   items:
                     $ref: '#/components/schemas/ForecastValue'
+              text/csv:
+                schema:
+                  type: string
+                example: |-
+                  timestamp,value
+                  2018-10-29T12:00:00Z,32.93
+                  2018-10-29T13:00:00Z,25.17
           401:
             $ref: '#/components/responses/401-Unauthorized'
           404:
@@ -283,32 +291,32 @@ class ForecastMetadataView(MethodView):
             $ref: '#/components/responses/404-NotFound'
         """
         forecast = storage.read_forecast(forecast_id)
-        return jsonify(ForecastSchema().dump(forecast))
+        return jsonify(ForecastSchema().dump(forecast).data)
 
-    def put(self, forecast_id, *args):
-        """
-        ---
-        summary: Update forecast metadata
-        tags:
-        - Forecasts
-        parameters:
-        - $ref: '#/components/parameters/forecast_id'
-        requestBody:
-          description: JSON representation of a forecast's metadata.
-          required: True
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForecastDefinition'
-        responses:
-          200:
-           description: Forecast updated successfully.
-          401:
-            $ref: '#/components/responses/401-Unauthorized'
-          404:
-            $ref: '#/components/responses/404-NotFound'
-        """
-        return
+    #def put(self, forecast_id, *args):
+    #    """
+    #    ---
+    #    summary: Update forecast metadata
+    #    tags:
+    #    - Forecasts
+    #    parameters:
+    #    - $ref: '#/components/parameters/forecast_id'
+    #    requestBody:
+    #      description: JSON representation of a forecast's metadata.
+    #      required: True
+    #      content:
+    #        application/json:
+    #          schema:
+    #            $ref: '#/components/schemas/ForecastDefinition'
+    #    responses:
+    #      200:
+    #       description: Forecast updated successfully.
+    #      401:
+    #        $ref: '#/components/responses/401-Unauthorized'
+    #      404:
+    #        $ref: '#/components/responses/404-NotFound'
+    #    """
+    #    return
 
 
 spec.components.parameter(

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -292,32 +292,7 @@ class ForecastMetadataView(MethodView):
         """
         forecast = storage.read_forecast(forecast_id)
         return jsonify(ForecastSchema().dump(forecast).data)
-
-    #def put(self, forecast_id, *args):
-    #    """
-    #    ---
-    #    summary: Update forecast metadata
-    #    tags:
-    #    - Forecasts
-    #    parameters:
-    #    - $ref: '#/components/parameters/forecast_id'
-    #    requestBody:
-    #      description: JSON representation of a forecast's metadata.
-    #      required: True
-    #      content:
-    #        application/json:
-    #          schema:
-    #            $ref: '#/components/schemas/ForecastDefinition'
-    #    responses:
-    #      200:
-    #       description: Forecast updated successfully.
-    #      401:
-    #        $ref: '#/components/responses/401-Unauthorized'
-    #      404:
-    #        $ref: '#/components/responses/404-NotFound'
-    #    """
-    #    return
-
+    
 
 spec.components.parameter(
     'forecast_id', 'path',

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -1,4 +1,3 @@
-import pdb
 from flask import Blueprint, request, jsonify, make_response, url_for
 from flask.views import MethodView
 from io import StringIO
@@ -71,7 +70,7 @@ class AllForecastsView(MethodView):
             forecast_id = storage.store_forecast(forecast)
             response = make_response('Forecast created.', 201)
             response.headers['Location'] = url_for('forecasts.single',
-                                                    forecast_id=forecast_id)
+                                                   forecast_id=forecast_id)
             return response
 
 
@@ -292,7 +291,7 @@ class ForecastMetadataView(MethodView):
         """
         forecast = storage.read_forecast(forecast_id)
         return jsonify(ForecastSchema().dump(forecast).data)
-    
+
 
 spec.components.parameter(
     'forecast_id', 'path',

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -1,12 +1,16 @@
-from flask import Blueprint
+from flask import Blueprint, request, jsonify, make_response, url_for
 from flask.views import MethodView
+from io import StringIO
+from marshmallow import ValidationError
+import pandas as pd
 
 
 from sfa_api import spec
 from sfa_api.schema import (ForecastValueSchema,
                             ForecastSchema,
+                            ForecastPostSchema,
                             ForecastLinksSchema)
-from sfa_api.demo import Forecast, TimeseriesValue
+from sfa_api.utils import storage
 
 
 class AllForecastsView(MethodView):
@@ -28,8 +32,8 @@ class AllForecastsView(MethodView):
           401:
             $ref: '#/components/responses/401-Unauthorized'
         """
-        forecasts = [Forecast() for i in range(3)]
-        return ForecastSchema(many=True).jsonify(forecasts)
+        forecasts = storage.list_forecasts()
+        return jsonify(ForecastSchema(many=True).dump(forecasts))
 
     def post(self, *args):
         """
@@ -57,8 +61,17 @@ class AllForecastsView(MethodView):
           401:
             $ref: '#/components/responses/401-Unauthorized'
         """
-        forecast = Forecast()
-        return ForecastSchema().jsonify(forecast)
+        data = request.get_json()
+        try:
+            forecast = ForecastPostSchema().loads(data)
+        except ValidationError as err:
+            return jsonify(err.messages), 400
+        else:
+            forecast_id = storage.store_forecast(forecast)
+            response = make_response('Forecast created.', 201)
+            response.headsers['Location'] = url_for('forecasts.single',
+                                                    forecast_id=forecast_id)
+            return response
 
 
 class ForecastView(MethodView):
@@ -83,7 +96,10 @@ class ForecastView(MethodView):
           404:
             $ref: '#/components/responses/404-NotFound'
         """
-        return ForecastLinksSchema().jsonify(Forecast())
+        forecast = storage.read_forecast(forecast_id)
+        if forecast is None:
+            return 404
+        return jsonify(ForecastLinksSchema().dump(forecast))
 
     def delete(self, forecast_id, *args):
         """
@@ -102,7 +118,8 @@ class ForecastView(MethodView):
           404:
             $ref: '#/components/responses/404-NotFound'
         """
-        return f'Delete forecast {forecast_id}'
+        deletion_result = storage.delete_forecast(forecast_id)
+        return deletion_result
 
 
 class ForecastValuesView(MethodView):
@@ -115,6 +132,9 @@ class ForecastValuesView(MethodView):
         - Forecasts
         parameters:
         - $ref: '#/components/parameters/forecast_id'
+        - $ref: '#/components/parameters/start_time'
+        - $ref: '#/components/parameters/end_time'
+        - $ref: '#/components/parameters/accepts'
         responses:
           200:
             content:
@@ -128,8 +148,32 @@ class ForecastValuesView(MethodView):
           404:
             $ref: '#/components/responses/404-NotFound'
         """
-        forecast_values = [TimeseriesValue() for i in range(3)]
-        return ForecastValueSchema(many=True).jsonify(forecast_values)
+        errors = []
+        start = request.args.get('start', None)
+        end = request.args.get('end', None)
+        if start is not None:
+            try:
+                start = pd.Timestamp(start)
+            except ValueError:
+                errors.append('Invalid start date format')
+        if end is not None:
+            try:
+                end = pd.Timestamp(end)
+            except ValueError:
+                errors.append('Invalid end date format')
+        if errors:
+            return jsonify({'errors': errors}), 400
+        values = storage.read_forecast_values(forecast_id, start, end)
+        data = ForecastValueSchema(many=True).dump(values).data
+        accepts = request.accept_mimetypes.best_match(['application/json',
+                                                       'text/csv'])
+        if accepts == 'application/json':
+            return jsonify(data)
+        else:
+            csv_data = pd.DataFrame(data).to_csv(index=False)
+            response = make_response(csv_data, 200)
+            response.mimetype = 'text/csv'
+            return response
 
     def post(self, forecast_id, *args):
         """
@@ -171,7 +215,48 @@ class ForecastValuesView(MethodView):
           404:
             $ref: '#/components/responses/404-NotFound'
         """
-        return
+        if request.content_type == 'application/json':
+            raw_data = request.get_json()
+            try:
+                raw_values = raw_data['values']
+            except (TypeError, KeyError):
+                return 'Supplied JSON does not contain "values" field.', 400
+            try:
+                forecast_df = pd.DataFrame(raw_values)
+            except ValueError:
+                return 'Malformed JSON', 400
+        elif request.content_type == 'text/csv':
+            raw_data = StringIO(request.get_data(as_text=True))
+            try:
+                forecast_df = pd.read_csv(raw_data, comment='#')
+            except pd.errors.EmptyDataError:
+                return 'Malformed CSV', 400
+            raw_data.close()
+        else:
+            return 'Invalid Content-type.', 400
+        errors = []
+        try:
+            forecast_df['value'] = pd.to_numeric(forecast_df['value'],
+                                                 downcast='float')
+        except ValueError:
+            errors.append('Invalid item in "value" field.')
+        except KeyError:
+            errors.append('Missing "value" field.')
+
+        try:
+            forecast_df['timestamp'] = pd.to_datetime(
+                forecast_df['timestamp'],
+                utc=True)
+        except ValueError:
+            errors.append('Invalid item in "timestamp" field.')
+        except KeyError:
+            errors.append('Missing "timestamp" field.')
+
+        if errors:
+            return jsonify({'errors': errors}), 400
+
+        stored = storage.store_forecast_values(forecast_id, forecast_df)
+        return stored, 201
 
 
 class ForecastMetadataView(MethodView):
@@ -197,7 +282,8 @@ class ForecastMetadataView(MethodView):
           404:
             $ref: '#/components/responses/404-NotFound'
         """
-        return ForecastSchema().jsonify(Forecast())
+        forecast = storage.read_forecast(forecast_id)
+        return jsonify(ForecastSchema().dump(forecast))
 
     def put(self, forecast_id, *args):
         """
@@ -225,13 +311,16 @@ class ForecastMetadataView(MethodView):
         return
 
 
-spec.add_parameter('forecast_id', 'path',
-                   schema={
-                       'type': 'string',
-                       'format': 'uuid'
-                   },
-                   description="Forecast's unique identifier.",
-                   required='true')
+spec.components.parameter(
+    'forecast_id', 'path',
+    {
+        'schema': {
+            'type': 'string',
+            'format': 'uuid'
+        },
+        'description': "Forecast's unique identifier.",
+        'required': 'true'
+    })
 
 forecast_blp = Blueprint(
     'forecasts', 'forecasts', url_prefix="/forecasts",

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -32,7 +32,7 @@ class AllObservationsView(MethodView):
             $ref: '#/components/responses/401-Unauthorized'
         """
         observations = storage.list_observations()
-        return ObservationSchema(many=True).jsonify(observations)
+        return jsonify(ObservationSchema(many=True).dump(observations))
 
     def post(self, *args):
         """
@@ -99,7 +99,7 @@ class ObservationView(MethodView):
         if observation is None:
             return 404
 
-        return ObservationLinksSchema().jsonify(observation)
+        return jsonify(ObservationLinksSchema().dump(observation))
 
     def delete(self, obs_id, *args):
         """
@@ -132,6 +132,9 @@ class ObservationValuesView(MethodView):
         - Observations
         parameters:
           - $ref: '#/components/parameters/obs_id'
+          - $ref: '#/components/parameters/start_time'
+          - $ref: '#/components/parameters/end_time'
+          - $ref: '#/components/parameters/accepts'
         responses:
           200:
             content:
@@ -140,6 +143,14 @@ class ObservationValuesView(MethodView):
                   type: array
                   items:
                     $ref: '#/components/schemas/ObservationValue'
+              text/csv:
+                schema:
+                  type: string
+                example: |-
+                  timestamp,value,quality_flag
+                  2018-10-29T12:00:00Z,32.93,0
+                  2018-10-29T13:00:00Z,25.17,0
+
           401:
             $ref: '#/components/responses/401-Unauthorized'
           404:
@@ -161,7 +172,16 @@ class ObservationValuesView(MethodView):
         if errors:
             return jsonify({'errors': errors}), 400
         values = storage.read_observation_values(obs_id, start, end)
-        return ObservationValueSchema(many=True).jsonify(values)
+        data = ObservationValueSchema(many=True).dump(values).data
+        accepts = request.accept_mimetypes.best_match(['application/json',
+                                                       'text/csv'])
+        if accepts == 'application/json':
+            return jsonify(data)
+        else:
+            csv_data = pd.DataFrame(data).to_csv(index=False)
+            response = make_response(csv_data, 200)
+            response.mimetype = 'text/csv'
+            return response
 
     def post(self, obs_id, *args):
         """
@@ -280,7 +300,7 @@ class ObservationMetadataView(MethodView):
              $ref: '#/components/responses/404-NotFound'
         """
         observation = storage.read_observation(obs_id)
-        return ObservationSchema().jsonify(observation)
+        return jsonify(ObservationSchema().dump(observation))
 
     def put(self, obs_id, *args):
         """
@@ -311,13 +331,16 @@ class ObservationMetadataView(MethodView):
 
 
 # Add path parameters used by these endpoints to the spec.
-spec.add_parameter('obs_id', 'path',
-                   schema={
-                       'type': 'string',
-                       'format': 'uuid'
-                   },
-                   description="Resource's unique identifier.",
-                   required='true')
+spec.components.parameter(
+    'obs_id', 'path',
+    {
+        'schema': {
+            'type': 'string',
+            'format': 'uuid',
+        },
+        'description': "Resource's unique identifier.",
+        'required': 'true'
+    })
 
 obs_blp = Blueprint(
     'observations', 'observations', url_prefix='/observations',

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -1,3 +1,4 @@
+import pdb
 from flask import Blueprint, request, jsonify, make_response, url_for
 from flask.views import MethodView
 from io import StringIO
@@ -99,7 +100,7 @@ class ObservationView(MethodView):
         if observation is None:
             return 404
 
-        return jsonify(ObservationLinksSchema().dump(observation))
+        return ObservationLinksSchema().jsonify(observation)
 
     def delete(self, obs_id, *args):
         """
@@ -300,7 +301,7 @@ class ObservationMetadataView(MethodView):
              $ref: '#/components/responses/404-NotFound'
         """
         observation = storage.read_observation(obs_id)
-        return jsonify(ObservationSchema().dump(observation))
+        return jsonify(ObservationSchema().dump(observation).data)
 
     def put(self, obs_id, *args):
         """

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -303,33 +303,6 @@ class ObservationMetadataView(MethodView):
         observation = storage.read_observation(obs_id)
         return jsonify(ObservationSchema().dump(observation).data)
 
-    def put(self, obs_id, *args):
-        """
-        TODO: MAY NOT MAKE SENSE TO KEEP if schema is so simple
-        ---
-        summary: Update observation metadata.
-        description: Update an observation's metadata.
-        tags:
-          - Observations
-        parameters:
-          - $ref: '#/components/parameters/obs_id'
-        requestBody:
-          description: JSON representation of an observation's metadata.
-          required: True
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ObservationDefinition'
-        responses:
-          200:
-            description: Observation updated successfully.
-          401:
-            $ref: '#/components/responses/401-Unauthorized'
-          404:
-            $ref: '#/components/responses/404-NotFound'
-        """
-        return
-
 
 # Add path parameters used by these endpoints to the spec.
 spec.components.parameter(

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -1,4 +1,3 @@
-import pdb
 from flask import Blueprint, request, jsonify, make_response, url_for
 from flask.views import MethodView
 from io import StringIO
@@ -33,7 +32,7 @@ class AllObservationsView(MethodView):
             $ref: '#/components/responses/401-Unauthorized'
         """
         observations = storage.list_observations()
-        return jsonify(ObservationSchema(many=True).dump(observations))
+        return jsonify(ObservationSchema(many=True).dump(observations).data)
 
     def post(self, *args):
         """
@@ -100,7 +99,7 @@ class ObservationView(MethodView):
         if observation is None:
             return 404
 
-        return ObservationLinksSchema().jsonify(observation)
+        return jsonify(ObservationLinksSchema().dump(observation).data)
 
     def delete(self, obs_id, *args):
         """

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -251,7 +251,7 @@ class ForecastPostSchema(ma.Schema):
             pd.Timedelta(data)
         except ValueError:
             raise ValidationError('Invalid time format.')
-    
+
     @validates('interval_length')
     def validate_interval_length(self, data):
         try:

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -7,13 +7,13 @@ from sfa_api import spec, ma
 VARIABLES = ['ghi', 'dni', 'dhi', 'temp_air', 'wind_speed',
              'poa', 'ac_power', 'dc_power']
 VARIABLE_FIELD = variable = ma.String(
-        title='Variable',
-        description="The variable being forecast",
-        required=True,
-        validate=validate.OneOf(VARIABLES))
+    title='Variable',
+    description="The variable being forecast",
+    required=True,
+    validate=validate.OneOf(VARIABLES))
 EXTRA_PARAMETERS_FIELD = ma.String(
-        title='Extra Parameters',
-        description='Additional user specified parameters.')
+    title='Extra Parameters',
+    description='Additional user specified parameters.')
 
 
 # Sites

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -1,16 +1,21 @@
-from marshmallow import validate
+import time
 
+from marshmallow import validate, validates
+from marshmallow.exceptions import ValidationError
+import pandas as pd
 
 from sfa_api import spec, ma
 
 
 VARIABLES = ['ghi', 'dni', 'dhi', 'temp_air', 'wind_speed',
              'poa', 'ac_power', 'dc_power']
-VARIABLE_FIELD = variable = ma.String(
+VALUE_TYPES = ['interval_mean', 'instantaneous']
+VARIABLE_FIELD = ma.String(
     title='Variable',
     description="The variable being forecast",
     required=True,
     validate=validate.OneOf(VARIABLES))
+
 EXTRA_PARAMETERS_FIELD = ma.String(
     title='Extra Parameters',
     description='Additional user specified parameters.')
@@ -236,8 +241,37 @@ class ForecastPostSchema(ma.Schema):
     value_type = ma.String(
         title='Value Type',
         description="Value type (e.g. mean, max, 95th percentile, instantaneous)",  # NOQA
+        validate=validate.OneOf(VALUE_TYPES)
     )
     extra_parameters = EXTRA_PARAMETERS_FIELD
+
+    @validates('lead_time_to_start')
+    def validate_lead_time(self, data):
+        try:
+            pd.Timedelta(data)
+        except ValueError:
+            raise ValidationError('Invalid time format.')
+    
+    @validates('interval_length')
+    def validate_interval_length(self, data):
+        try:
+            pd.Timedelta(data)
+        except ValueError:
+            raise ValidationError('Invalid time format.')
+
+    @validates('run_length')
+    def validate_run_length(self, data):
+        try:
+            pd.Timedelta(data)
+        except ValueError:
+            raise ValidationError('Invalid time format.')
+
+    @validates('issue_time_of_day')
+    def validate_issue_time(self, data):
+        try:
+            time.strptime(data, '%H:%M')
+        except ValueError:
+            raise ValidationError('Time not in HH:MM format.')
 
 
 @spec.define_schema('ForecastMetadata')

--- a/sfa_api/sites.py
+++ b/sfa_api/sites.py
@@ -29,7 +29,7 @@ class AllSitesView(MethodView):
             $ref: '#/components/responses/401-Unauthorized'
         """
         sites = [Site() for i in range(3)]
-        return SiteResponseSchema(many=True).jsonify(sites)
+        return jsonify(SiteResponseSchema(many=True).dump(sites).data)
 
     def post(self, *args):
         """
@@ -57,7 +57,7 @@ class AllSitesView(MethodView):
           401:
             $ref: '#/components/responses/401-Unauthorized'
         """
-        return SiteResponseSchema().jsonify(Site())
+        return jsonify(SiteResponseSchema().dump(Site()).data)
 
 
 class SiteView(MethodView):
@@ -83,7 +83,7 @@ class SiteView(MethodView):
         """
         # TODO: replace demo data
         demo_obs = Site()
-        return SiteResponseSchema().jsonify(demo_obs)
+        return jsonify(SiteResponseSchema().dump(demo_obs).data)
 
     def delete(self, site_id, *args):
         """
@@ -104,32 +104,6 @@ class SiteView(MethodView):
         """
         # TODO: replace demo response
         return f'{site_id} deleted.'
-
-    def put(self, site_id, *args):
-        """
-        ---
-        summary: Update site
-        description: Update a site's metadata.
-        tags:
-          - Sites
-        parameters:
-          - $ref: '#/components/parameters/site_id'
-        requestBody:
-          description: JSON representation of an site's metadata.
-          required: True
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SiteDefinition'
-        responses:
-          200:
-            description: Site updated successfully.
-          401:
-            $ref: '#/components/responses/401-Unauthorized'
-          404:
-            $ref: '#/components/responses/404-NotFound'
-        """
-        return
 
 
 class SiteObservations(MethodView):
@@ -159,7 +133,7 @@ class SiteObservations(MethodView):
              $ref: '#/components/responses/404-NotFound'
         """
         observations = [Observation() for i in range(3)]
-        return ObservationSchema(many=True).jsonify(observations)
+        return jsonify(ObservationSchema(many=True).dump(observations).data)
 
 
 class SiteForecasts(MethodView):
@@ -189,7 +163,7 @@ class SiteForecasts(MethodView):
              $ref: '#/components/responses/404-NotFound'
         """
         forecasts = [Forecast() for i in range(3)]
-        return ForecastSchema(many=True).jsonify(forecasts)
+        return ForecastSchema(many=True).dump(forecasts)
 
 
 spec.components.parameter(

--- a/sfa_api/sites.py
+++ b/sfa_api/sites.py
@@ -1,4 +1,4 @@
-from flask import Blueprint
+from flask import Blueprint, jsonify
 from flask.views import MethodView
 
 

--- a/sfa_api/sites.py
+++ b/sfa_api/sites.py
@@ -138,7 +138,8 @@ class SiteObservations(MethodView):
         ---
         summary: Get site observations
         description: >
-          Get metadata for all observations associated with site that user has access to
+          Get metadata for all observations associated with site
+          that user has access to.
         tags:
         - Sites
         parameters:
@@ -167,7 +168,8 @@ class SiteForecasts(MethodView):
         ---
         summary: Get site forecasts
         description: >
-          Get metadata for all forecasts associated with site that user has access to
+          Get metadata for all forecasts associated with site that
+          user has access to.
         tags:
         - Sites
         parameters:
@@ -190,14 +192,16 @@ class SiteForecasts(MethodView):
         return ForecastSchema(many=True).jsonify(forecasts)
 
 
-spec.add_parameter('site_id', 'path',
-                   schema={
-                       'type': 'string',
-                       'format': 'uuid'
-                   },
-                   description="Site's unique identifier.",
-                   required='true')
-
+spec.components.parameter(
+    'site_id', 'path',
+    {
+        'schema': {
+            'type': 'string',
+            'format': 'uuid'
+        },
+        'description': "Site's unique identifier.",
+        'required': 'true'
+    })
 
 site_blp = Blueprint(
     'sites', 'sites', url_prefix='/sites',

--- a/sfa_api/sites.py
+++ b/sfa_api/sites.py
@@ -5,7 +5,7 @@ from flask.views import MethodView
 from sfa_api import spec
 from sfa_api.schema import (SiteResponseSchema,
                             ForecastSchema, ObservationSchema)
-from sfa_api.demo import Site, Observation, Forecast
+from sfa_api.demo.demo import Site, Observation, Forecast
 
 
 class AllSitesView(MethodView):

--- a/sfa_api/spec.py
+++ b/sfa_api/spec.py
@@ -1,6 +1,6 @@
 import apispec
 from apispec.ext.marshmallow import MarshmallowPlugin
-from apispec.ext.flask import FlaskPlugin
+from apispec_webframeworks.flask import FlaskPlugin
 from flask_marshmallow.fields import URLFor, AbsoluteURLFor, Hyperlinks
 
 
@@ -12,7 +12,7 @@ class APISpec(apispec.APISpec):
 
     def define_schema(self, name):
         def decorator(schema, **kwargs):
-            self.definition(name, schema=schema, **kwargs)
+            self.components.schema(name, schema=schema, **kwargs)
             return schema
         return decorator
 
@@ -60,6 +60,35 @@ spec_components = {
                     'audience': 'https://api.solarforecastarbiter.org'
                 }
             }
+        }
+    },
+    'parameters': {
+        'start_time': {
+            'in': 'query',
+            'name': 'start_time',
+            'description': 'End of the period for which to request data.',
+            'schema': {
+                'type': 'string',
+                'format': 'datetime',
+            },
+        },
+        'end_time': {
+            'name': 'end_time',
+            'in': 'query',
+            'description': 'End of the period for which to request data.',
+            'schema': {
+                'type': 'string',
+                'format': 'datetime',
+            },
+        },
+        'accepts': {
+            'name': 'Accepts',
+            'in': 'header',
+            'description': 'The mimetype the API should return "application/json" or "text/csv".',
+            'schema': {
+                'type': 'string',
+                'required': 'true',
+            },
         }
     }
 }

--- a/sfa_api/test/test_forecast.py
+++ b/sfa_api/test/test_forecast.py
@@ -1,0 +1,180 @@
+import pandas as pd
+import pytest
+
+
+import json
+import sfa_api
+
+
+VALID_FORECAST_JSON = {
+    "extra_parameters": '{"instrument": "Ascension Technology Rotating Shadowband Pyranometer"}', # NOQA
+    "name": "DA Power",
+    "site_id": "123e4567-e89b-12d3-a456-426655440001",
+    "variable": "ac_power",
+    "interval_label": "beginning",
+    "issue_time_of_day": "12:00",
+    "lead_time_to_start": "1 hour",
+    "interval_length": "1 minute",
+    "run_length": "1 hour",
+    "value_type": "interval_mean",
+}
+
+def copy_update(json, key, value):
+    new_json = json.copy()
+    new_json[key] = value
+    return new_json
+
+
+INVALID_VARIABLE = copy_update(VALID_FORECAST_JSON,'variable', 'invalid')
+INVALID_INTERVAL_LABEL = copy_update(VALID_FORECAST_JSON, 'interval_label', 'invalid')
+INVALID_ISSUE_TIME = copy_update(VALID_FORECAST_JSON, 'issue_time_of_day', 'invalid')
+INVALID_LEAD_TIME = copy_update(VALID_FORECAST_JSON, 'lead_time_to_start', 'invalid')
+INVALID_INTERVAL_LENGTH = copy_update(VALID_FORECAST_JSON, 'interval_length', 'invalid')
+INVALID_RUN_LENGTH = copy_update(VALID_FORECAST_JSON, 'run_length', 'invalid')
+INVALID_VALUE_TYPE = copy_update(VALID_FORECAST_JSON, 'value_type', 'invalid')
+
+
+empty_json_response = '{"interval_length":["Missing data for required field."],"issue_time_of_day":["Missing data for required field."],"lead_time_to_start":["Missing data for required field."],"name":["Missing data for required field."],"run_length":["Missing data for required field."],"site_id":["Missing data for required field."],"variable":["Missing data for required field."]}\n' # NOQA
+
+@pytest.fixture()
+def uuid():
+    return '123e4567-e89b-12d3-a456-426655440000'
+
+
+@pytest.mark.parametrize('payload,message,status_code', [
+    (VALID_FORECAST_JSON, 'Forecast created.', 201),
+    (INVALID_VARIABLE, '{"variable":["Not a valid choice."]}\n', 400),
+    (INVALID_INTERVAL_LABEL, '{"interval_label":["Not a valid choice."]}\n',
+     400),
+    (INVALID_ISSUE_TIME, '{"issue_time_of_day":["Time not in HH:MM format."]}\n', 400),
+    (INVALID_LEAD_TIME, '{"lead_time_to_start":["Invalid time format."]}\n', 400),
+    (INVALID_INTERVAL_LENGTH, '{"interval_length":["Invalid time format."]}\n', 400),
+    (INVALID_RUN_LENGTH, '{"run_length":["Invalid time format."]}\n', 400),
+    (INVALID_VALUE_TYPE, '{"value_type":["Not a valid choice."]}\n', 400),
+    ({}, empty_json_response, 400)
+])
+def test_forecast_post(api, payload, message, status_code):
+    r = api.post('/forecasts/',
+                 base_url='https://localhost',
+                 json=json.dumps(payload))
+    assert r.status_code == status_code
+    assert r.get_data(as_text=True) == message
+    if status_code == 201:
+        assert 'Location' in r.headers
+    else:
+        assert 'Location' not in r.headers
+
+
+def test_get_forecast_links(api, uuid):
+    r = api.get(f'/forecasts/{uuid}',
+                base_url='https://localhost')
+    response = r.get_json()
+    assert 'forecast_id' in response
+    assert '_links' in response
+
+
+def test_get_forecast_metadata(api, uuid):
+    r = api.get(f'/forecasts/{uuid}/metadata',
+                base_url='https://localhost')
+    response = r.get_json()
+    assert 'forecast_id' in response
+    assert 'variable' in response
+    assert 'name' in response
+    assert 'site_id' in response
+
+
+VALID_VALUE_JSON = {
+    'id': '123e4567-e89b-12d3-a456-426655440000',
+    'values': [
+        {'timestamp': "2019-01-22T17:54:36Z",
+         'value': 1},
+        {'timestamp': "2019-01-22T17:55:36Z",
+         'value': '32.96'},
+        {'timestamp': "2019-01-22T17:56:36Z",
+         'value': 3}
+    ]
+}
+WRONG_DATE_FORMAT_VALUE_JSON = {
+    'values': [
+        {'timestamp': '20-2-3T11111F',
+         'value': 3},
+    ]
+}
+NON_NUMERICAL_VALUE_JSON = {
+    'values': [
+        {'timestamp': "2019-01-22T17:56:36Z",
+         'value': 'four'},
+    ]
+}
+VALID_CSV = "#I am a header comment, I am going to be ignored\ntimestamp,value\n2018-10-29T12:04:23Z,32.93\n2018-10-29T12:05:23Z,32.93\n2018-10-29T12:06:23Z,32.93\n2018-10-29T12:07:23Z,32.93\n" # NOQA
+WRONG_DATE_FORMAT_CSV = "timestamp,value\nksdfjgn,32.93"
+NON_NUMERICAL_VALUE_CSV = "timestamp,value\n2018-10-29T12:04:23Z,fgh" # NOQA
+
+
+# TODO: mock retrieval request to return a static forecast for testing
+def test_post_forecast_values_valid_json(api, uuid):
+    r = api.post(f'/forecasts/{uuid}/values',
+                 base_url='https://localhost',
+                 json=VALID_VALUE_JSON)
+    assert r.status_code == 201
+
+
+def test_post_json_storage_call(api, uuid, mocker):
+    storage = mocker.patch('sfa_api.utils.storage.store_forecast_values')
+    storage.return_value = uuid
+    r = api.post(f'/forecasts/{uuid}/values',
+            base_url='https://localhost',
+            json=VALID_VALUE_JSON)
+    storage.assert_called()
+
+@pytest.mark.parametrize('payload', [
+    'taco',
+    {},
+    WRONG_DATE_FORMAT_VALUE_JSON,
+    NON_NUMERICAL_VALUE_JSON,
+])
+def test_post_forecast_values_invalid_json(api, payload, uuid):
+    r = api.post(f'/forecasts/{uuid}/values',
+                 base_url='https://localhost',
+                 json=payload)
+    assert r.status_code == 400
+
+
+@pytest.mark.parametrize('payload', [
+    'taco',
+    '',
+    WRONG_DATE_FORMAT_CSV,
+    NON_NUMERICAL_VALUE_CSV,
+])
+def test_post_forecast_values_invalid_csv(api, payload, uuid):
+    r = api.post(f'/forecasts/{uuid}/values',
+                 base_url='https://localhost',
+                 headers={'Content-Type': 'text/csv'},
+                 data=payload)
+    assert r.status_code == 400
+
+
+def test_post_forecast_values_valid_csv(api, uuid):
+    r = api.post(f'/forecasts/{uuid}/values',
+                 base_url='https://localhost',
+                 headers={'Content-Type': 'text/csv'},
+                 data=VALID_CSV)
+    assert r.status_code == 201
+
+
+@pytest.mark.parametrize('start,end,code,mimetype', [
+    ('bad-date', 'also_bad', 400, 'application/json'),
+    ('2019-01-30T12:00:00Z', '2019-01-30T12:00:00Z', 200, 'application/json'),
+    ('bad-date', 'also_bad', 400, 'text/csv'),
+    ('2019-01-30T12:00:00Z', '2019-01-30T12:00:00Z', 200, 'text/csv'),
+])
+def test_get_forecast_values_json(api, start, end, code, mimetype, uuid):
+    r = api.get(f'/forecasts/{uuid}/values',
+                base_url='https://localhost',
+                headers={'Accept': mimetype},
+                query_string={'start': start, 'end': end})
+    assert r.status_code == code
+    if code == 400:
+        assert r.mimetype == 'application/json'
+    else:
+        assert r.mimetype == mimetype

--- a/sfa_api/test/test_forecast.py
+++ b/sfa_api/test/test_forecast.py
@@ -1,9 +1,7 @@
-import pandas as pd
 import pytest
 
 
 import json
-import sfa_api
 
 
 VALID_FORECAST_JSON = {
@@ -19,22 +17,31 @@ VALID_FORECAST_JSON = {
     "value_type": "interval_mean",
 }
 
+
 def copy_update(json, key, value):
     new_json = json.copy()
     new_json[key] = value
     return new_json
 
 
-INVALID_VARIABLE = copy_update(VALID_FORECAST_JSON,'variable', 'invalid')
-INVALID_INTERVAL_LABEL = copy_update(VALID_FORECAST_JSON, 'interval_label', 'invalid')
-INVALID_ISSUE_TIME = copy_update(VALID_FORECAST_JSON, 'issue_time_of_day', 'invalid')
-INVALID_LEAD_TIME = copy_update(VALID_FORECAST_JSON, 'lead_time_to_start', 'invalid')
-INVALID_INTERVAL_LENGTH = copy_update(VALID_FORECAST_JSON, 'interval_length', 'invalid')
-INVALID_RUN_LENGTH = copy_update(VALID_FORECAST_JSON, 'run_length', 'invalid')
-INVALID_VALUE_TYPE = copy_update(VALID_FORECAST_JSON, 'value_type', 'invalid')
+INVALID_VARIABLE = copy_update(VALID_FORECAST_JSON,
+                               'variable', 'invalid')
+INVALID_INTERVAL_LABEL = copy_update(VALID_FORECAST_JSON,
+                                     'interval_label', 'invalid')
+INVALID_ISSUE_TIME = copy_update(VALID_FORECAST_JSON,
+                                 'issue_time_of_day', 'invalid')
+INVALID_LEAD_TIME = copy_update(VALID_FORECAST_JSON,
+                                'lead_time_to_start', 'invalid')
+INVALID_INTERVAL_LENGTH = copy_update(VALID_FORECAST_JSON,
+                                      'interval_length', 'invalid')
+INVALID_RUN_LENGTH = copy_update(VALID_FORECAST_JSON,
+                                 'run_length', 'invalid')
+INVALID_VALUE_TYPE = copy_update(VALID_FORECAST_JSON,
+                                 'value_type', 'invalid')
 
 
 empty_json_response = '{"interval_length":["Missing data for required field."],"issue_time_of_day":["Missing data for required field."],"lead_time_to_start":["Missing data for required field."],"name":["Missing data for required field."],"run_length":["Missing data for required field."],"site_id":["Missing data for required field."],"variable":["Missing data for required field."]}\n' # NOQA
+
 
 @pytest.fixture()
 def uuid():
@@ -46,9 +53,9 @@ def uuid():
     (INVALID_VARIABLE, '{"variable":["Not a valid choice."]}\n', 400),
     (INVALID_INTERVAL_LABEL, '{"interval_label":["Not a valid choice."]}\n',
      400),
-    (INVALID_ISSUE_TIME, '{"issue_time_of_day":["Time not in HH:MM format."]}\n', 400),
-    (INVALID_LEAD_TIME, '{"lead_time_to_start":["Invalid time format."]}\n', 400),
-    (INVALID_INTERVAL_LENGTH, '{"interval_length":["Invalid time format."]}\n', 400),
+    (INVALID_ISSUE_TIME, '{"issue_time_of_day":["Time not in HH:MM format."]}\n', 400), # NOQA
+    (INVALID_LEAD_TIME, '{"lead_time_to_start":["Invalid time format."]}\n', 400), # NOQA
+    (INVALID_INTERVAL_LENGTH, '{"interval_length":["Invalid time format."]}\n', 400), # NOQA
     (INVALID_RUN_LENGTH, '{"run_length":["Invalid time format."]}\n', 400),
     (INVALID_VALUE_TYPE, '{"value_type":["Not a valid choice."]}\n', 400),
     ({}, empty_json_response, 400)
@@ -122,10 +129,11 @@ def test_post_forecast_values_valid_json(api, uuid):
 def test_post_json_storage_call(api, uuid, mocker):
     storage = mocker.patch('sfa_api.utils.storage.store_forecast_values')
     storage.return_value = uuid
-    r = api.post(f'/forecasts/{uuid}/values',
-            base_url='https://localhost',
-            json=VALID_VALUE_JSON)
+    api.post(f'/forecasts/{uuid}/values',
+             base_url='https://localhost',
+             json=VALID_VALUE_JSON)
     storage.assert_called()
+
 
 @pytest.mark.parametrize('payload', [
     'taco',

--- a/sfa_api/test/test_observation.py
+++ b/sfa_api/test/test_observation.py
@@ -1,22 +1,28 @@
-import pandas as pd
 import pytest
 
 
 import json
-import sfa_api
 
 
-VALID_JSON = {
+VALID_OBS_JSON = {
     "extra_parameters": '{"instrument": "Ascension Technology Rotating Shadowband Pyranometer"}', # NOQA
     "name": "Ashland OR, ghi",
     "site_id": "123e4567-e89b-12d3-a456-426655440001",
     "variable": "ghi",
     "interval_label": "beginning"
 }
-INVALID_VARIABLE = VALID_JSON.copy()
-INVALID_VARIABLE['variable'] = 'banana'
-INVALID_INTERVAL_LABEL = VALID_JSON.copy()
-INVALID_INTERVAL_LABEL['interval_label'] = 'up'
+
+
+def copy_update(json, key, value):
+    new_json = json.copy()
+    new_json[key] = value
+    return new_json
+
+
+INVALID_VARIABLE = copy_update(VALID_OBS_JSON,
+                               'variable', 'invalid')
+INVALID_INTERVAL_LABEL = copy_update(VALID_OBS_JSON,
+                                     'interval_label', 'invalid')
 
 
 empty_json_response = '{"interval_label":["Missing data for required field."],"name":["Missing data for required field."],"site_id":["Missing data for required field."],"variable":["Missing data for required field."]}\n' # NOQA
@@ -28,7 +34,7 @@ def uuid():
 
 
 @pytest.mark.parametrize('payload,message,status_code', [
-    (VALID_JSON, 'Observation created.', 201),
+    (VALID_OBS_JSON, 'Observation created.', 201),
     (INVALID_VARIABLE, '{"variable":["Not a valid choice."]}\n', 400),
     (INVALID_INTERVAL_LABEL, '{"interval_label":["Not a valid choice."]}\n',
      400),
@@ -117,8 +123,8 @@ def test_post_json_storage_call(api, uuid, mocker):
     storage = mocker.patch('sfa_api.utils.storage.store_observation_values')
     storage.return_value = uuid
     api.post(f'/observations/{uuid}/values',
-            base_url='https://localhost',
-            json=VALID_JSON)
+             base_url='https://localhost',
+             json=VALID_JSON)
     storage.assert_called()
 
 

--- a/sfa_api/test/test_observation.py
+++ b/sfa_api/test/test_observation.py
@@ -113,17 +113,13 @@ def test_post_observation_values_valid_json(api, uuid):
     assert r.status_code == 201
 
 
-def test_post_json_storage_call(api, mocker):
-    mocker.patch('sfa_api.utils.storage.store_observation_values')
-    data = pd.DataFrame(VALID_JSON['values'])
-    data['timestamp'] = pd.to_datetime(data['timestamp'], utc=True)
-    data['value'] = pd.to_numeric(data['value'], downcast="float")
-    api.get('/observations/7365da38-2ee5-46ed-bd48-c84c4cc5a6c8/values',
+def test_post_json_storage_call(api, uuid, mocker):
+    storage = mocker.patch('sfa_api.utils.storage.store_observation_values')
+    storage.return_value = uuid
+    api.post(f'/observations/{uuid}/values',
             base_url='https://localhost',
             json=VALID_JSON)
-    sfa_api.utils.storage.store_observation_values.asser_called_with(
-        obs_id='7365da38-2ee5-46ed-bd48-c84c4cc5a6c8',
-        observation_df=data)
+    storage.assert_called()
 
 
 @pytest.mark.parametrize('payload', [

--- a/sfa_api/utils/storage.py
+++ b/sfa_api/utils/storage.py
@@ -34,7 +34,7 @@ def read_observation_values(obs_id, start=None, end=None):
         End of the peried for which to request data.
 
     """
-    return [demo.TimeseriesValue for i in range(5)]
+    return [demo.ObservationTimeseriesValue for i in range(5)]
 
 
 def store_observation(observation):
@@ -114,7 +114,7 @@ def read_forecast_values(forecast_id, start=None, end=None):
         End of the peried for which to request data.
 
     """
-    return [demo.TimeseriesValue for i in range(5)]
+    return [demo.ForecastTimeseriesValue for i in range(5)]
 
 
 def store_forecast(forecast):

--- a/sfa_api/utils/storage.py
+++ b/sfa_api/utils/storage.py
@@ -14,7 +14,7 @@ def store_observation_values(obs_id, observation_df):
     Returns
     -------
     string
-        The UUID of the newly created resource
+        The UUID of the associated observation
     """
     # Method stub for storing observation time-series in the database.
 
@@ -44,7 +44,7 @@ def store_observation(observation):
     observation: dictionary
         A dictionary of observation fields to insert.
     """
-    return 200
+    return demo.Observation.obs_id
 
 
 def read_observation(obs_id):
@@ -56,7 +56,7 @@ def read_observation(obs_id):
 
     Returns
     -------
-
+    Observation or None
     """
     return demo.Observation
 
@@ -78,3 +78,83 @@ def list_observations():
     """Lists all observations a user has access to.
     """
     return [demo.Observation() for i in range(5)]
+
+
+# Forecasts
+def store_forecast_values(forecast_id, forecast_df):
+    """Insert the forecast data into the database.
+
+    Parameters
+    ----------
+    forecast_id: string
+        UUID of the associated forecast.
+    forecast_df: DataFrame
+        Dataframe with DatetimeIndex and value column.
+
+    Returns
+    -------
+    string
+        The UUID of the associated forecast
+    """
+    # Method stub for storing forecast time-series in the database.
+
+    return demo.Forecast.forecast_id
+
+
+def read_forecast_values(forecast_id, start=None, end=None):
+    """Read forecast values between start and end.
+
+    Parameters
+    ----------
+    forecast_id: string
+        UUID of associated forecast.
+    start: datetime
+        Beginning of the period for which to request data.
+    end: datetime
+        End of the peried for which to request data.
+
+    """
+    return [demo.TimeseriesValue for i in range(5)]
+
+
+def store_forecast(forecast):
+    """
+    Parameters
+    ----------
+    forecast: dictionary
+        A dictionary of forecast fields to insert.
+    """
+    return demo.Forecast.forecast_id
+
+
+def read_forecast(forecast_id):
+    """
+    Parameters
+    ----------
+    forecast_id: String
+        UUID of the forecast to retrieve
+
+    Returns
+    -------
+
+    """
+    return demo.Forecast
+
+
+def delete_forecast(forecast_id):
+    """
+    Parameters
+    ----------
+    forecast_id: String
+        UUID of Forecast to delete
+
+    Returns
+    -------
+    """
+    return 200
+
+
+def list_forecasts():
+    """Lists all forecasts a user has access to.
+    """
+    return [demo.Forecast() for i in range(5)]

--- a/sfa_api/utils/storage.py
+++ b/sfa_api/utils/storage.py
@@ -1,4 +1,4 @@
-from sfa_api import demo
+from sfa_api.demo import demo
 
 
 def store_observation_values(obs_id, observation_df):


### PR DESCRIPTION
Fleshed out the forecast endpoint with the same basic validation as observations. Added support for requesting CSV values with the 'Accepts' header to both forecasts and observations, also updated our specification to work with the APISpec v1.0.0 release.

Still needs testing and the additional validation noted in #29.

Aims to close #36, #35 & #29 