### PR TITLE
Post validation

### DIFF
--- a/sfa_api/demo/__init__.py
+++ b/sfa_api/demo/__init__.py
@@ -82,7 +82,8 @@ def store_observation(observation):
     observation: dictionary
         A dictionary of observation fields to insert.
     """
-    if read_site(str(observation['site_id'])) is None:
+    observation['site_id'] = str(observation['site_id'])
+    if read_site(observation['site_id']) is None:
         return None
     obs_id = str(uuid.uuid1())
     observation['obs_id'] = obs_id
@@ -199,7 +200,8 @@ def store_forecast(forecast):
     forecast: dictionary
         A dictionary of forecast fields to insert.
     """
-    if read_site(str(forecast['site_id'])) is None:
+    forecast['site_id'] = str(forecast['site_id'])
+    if read_site(forecast['site_id']) is None:
         return None
     forecast_id = str(uuid.uuid1())
     forecast['forecast_id'] = forecast_id

--- a/sfa_api/demo/forecasts.py
+++ b/sfa_api/demo/forecasts.py
@@ -6,9 +6,10 @@ static_forecasts = {
         "site_id": "123e4567-e89b-12d3-a456-426655440001",
         "variable": "ac_power",
         "issue_time_of_day": "06:00",
-        "issue_frequency": "1 day",
+        "interval_length": 5,
+        "run_length": 86400,
         "interval_label": "beginning",
-        "lead_time_to_start": "1 hour",
+        "lead_time_to_start": "60",
         "value_type": "mean",
     },
     'f8dd49fa-23e2-48a0-862b-ba0af6dec276': {
@@ -18,9 +19,10 @@ static_forecasts = {
         "site_id": "123e4567-e89b-12d3-a456-426655440002",
         "variable": "ac_power",
         "issue_time_of_day": "12:00",
-        "issue_frequency": "1 hour",
+        "run_length": 60,
+        "interval_length": 1,
         "interval_label": "beginning",
-        "lead_time_to_start": "1 hour",
+        "lead_time_to_start": 60,
         "value_type": "mean",
     }
 }

--- a/sfa_api/demo/forecasts.py
+++ b/sfa_api/demo/forecasts.py
@@ -7,7 +7,7 @@ static_forecasts = {
         "variable": "ac_power",
         "issue_time_of_day": "06:00",
         "interval_length": 5,
-        "run_length": 86400,
+        "run_length": 1440,
         "interval_label": "beginning",
         "lead_time_to_start": "60",
         "value_type": "mean",

--- a/sfa_api/demo/observations.py
+++ b/sfa_api/demo/observations.py
@@ -9,7 +9,8 @@ static_observations = {
         "site_id": "123e4567-e89b-12d3-a456-426655440001",
         "variable": "ghi",
         "value_type": "interval_mean",
-        "interval_label": "beginning"
+        "interval_label": "beginning",
+        "interval_length": 5
     },
     "9cfa4aa2-7d0f-4f6f-a1c1-47f75e1d226f": {
         "extra_parameters": {
@@ -21,7 +22,8 @@ static_observations = {
         "site_id": "123e4567-e89b-12d3-a456-426655440001",
         "variable": "dhi",
         "value_type": "interval_mean",
-        "interval_label": "beginning"
+        "interval_label": "beginning",
+        "interval_length": 5
     },
     "9ce9715c-bd91-47b7-989f-50bb558f1eb9": {
         "extra_parameters": {
@@ -33,7 +35,8 @@ static_observations = {
         "site_id": "123e4567-e89b-12d3-a456-426655440001",
         "variable": "dni",
         "value_type": "interval_mean",
-        "interval_label": "beginning"
+        "interval_label": "beginning",
+        "interval_length": 5
     },
     "e0da0dea-9482-4073-84de-f1b12c304d23": {
         "extra_parameters": {
@@ -45,7 +48,8 @@ static_observations = {
         "site_id": "d2018f1d-82b1-422a-8ec4-4e8b3fe92a4a",
         "variable": "ghi",
         "value_type": "interval_mean",
-        "interval_label": "beginning"
+        "interval_label": "beginning",
+        "interval_length": 5
     },
     "b1dfe2cb-9c8e-43cd-afcf-c5a6feaf81e2": {
         "extra_parameters": {
@@ -57,6 +61,7 @@ static_observations = {
         "site_id": "d2018f1d-82b1-422a-8ec4-4e8b3fe92a4a",
         "variable": "ghi",
         "value_type": "interval_mean",
-        "interval_label": "beginning"
+        "interval_label": "beginning",
+        "interval_length": 5
     }
 }

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -166,19 +166,19 @@ class ObservationValuesView(MethodView):
           404:
             $ref: '#/components/responses/404-NotFound'
         """
-        errors = []
+        errors = {}
         start = request.args.get('start', None)
         end = request.args.get('end', None)
         if start is not None:
             try:
                 start = pd.Timestamp(start)
             except ValueError:
-                errors.append('Invalid start date format')
+                errors.append({'start': ['Invalid start date format']})
         if end is not None:
             try:
                 end = pd.Timestamp(end)
             except ValueError:
-                errors.append('Invalid end date format')
+                errors.update({'end': ['Invalid end date format']})
         if errors:
             return jsonify({'errors': errors}), 400
         storage = get_storage()
@@ -246,11 +246,11 @@ class ObservationValuesView(MethodView):
             try:
                 raw_values = raw_data['values']
             except (TypeError, KeyError):
-                return 'Supplied JSON does not contain "values" field.', 400
+                return jsonify({'errors': {'error': ['Supplied JSON does not contain "values" field.']}}), 400
             try:
                 observation_df = pd.DataFrame(raw_values)
             except ValueError:
-                return 'Malformed JSON', 400
+                return jsonify({'errors':{'error': ['Malformed JSON']}}), 400
         elif request.content_type == 'text/csv':
             raw_data = StringIO(request.get_data(as_text=True))
             try:
@@ -259,38 +259,38 @@ class ObservationValuesView(MethodView):
                                              keep_default_na=True,
                                              comment='#')
             except pd.errors.EmptyDataError:
-                return 'Malformed CSV', 400
+                return jsonify({'errors':{'error': ['Malformed CSV']}}), 400
             finally:
                 raw_data.close()
         else:
-            return 'Invalid Content-type.', 400
+            return jsonify({'errors':{'error':['Invalid Content-type.']}}), 415
 
         # Verify data format and types are parseable.
         # create list of errors to return meaningful messages to the user.
-        errors = []
+        errors = {}
         try:
             observation_df['value'] = pd.to_numeric(observation_df['value'],
                                                     downcast='float')
         except ValueError:
-            errors.append('Invalid item in "value" field. Ensure that all '
-                          'values are integers, floats, empty, NaN, or NULL')
+            errors.update({'values':['Invalid item in "value" field. Ensure that all '
+                                        'values are integers, floats, empty, NaN, or NULL']})
         except KeyError:
-            errors.append('Missing "value" field.')
+            errors.update({'values': ['Missing "value" field.']})
 
         try:
             observation_df['timestamp'] = pd.to_datetime(
                 observation_df['timestamp'],
                 utc=True)
         except ValueError:
-            errors.append('Invalid item in "timestamp" field. Ensure '
-                          'that timestamps are ISO8601 compliant')
+            errors.update({'timestamp':['Invalid item in "timestamp" field. Ensure '
+                                        'that timestamps are ISO8601 compliant']})
         except KeyError:
-            errors.append('Missing "timestamp" field.')
+            errors.update({'values':['Missing "timestamp" field.']})
 
         if 'quality_flag' not in observation_df.columns:
-            errors.append('Missing "quality_flag" field.')
+            errors.update({'quality_flag':['Missing "quality_flag" field.']})
         elif not observation_df['quality_flag'].isin([0, 1]).all():
-            errors.append('Invalid item in "quality_flag" field.')
+            errors.update({'quality_flag':['Invalid item in "quality_flag" field.']})
 
         if errors:
             return jsonify({'errors': errors}), 400

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -173,7 +173,7 @@ class ObservationValuesView(MethodView):
             try:
                 start = pd.Timestamp(start)
             except ValueError:
-                errors.append({'start': ['Invalid start date format']})
+                errors.update({'start': ['Invalid start date format']})
         if end is not None:
             try:
                 end = pd.Timestamp(end)

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -185,10 +185,15 @@ class ObservationPostSchema(ma.Schema):
                      'instant for instantaneous data'),
         validate=validate.OneOf(['beginning', 'ending', 'instant']),
         required=True)
+    interval_length = ma.String(
+        title='Interval length',
+        description=('The length of time that each data point represents  in'
+                     'HH:MM format, e.g. 00:05 for 5 minutes.'),
+        validate=TimeFormat('%H:%M'),
+        required=True)
     value_type = ma.String(
         title='Value Type',
-        validate=validate.OneOf(VALUE_TYPES)
-    )
+        validate=validate.OneOf(VALUE_TYPES))
     uncertainty = ma.Float(
         title='Uncertainty',
         description='A measure of the uncertainty of the observation values.')

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -278,7 +278,6 @@ class ForecastPostSchema(ma.Schema):
         description=("The difference between the issue time and the start of "
                      "the first forecast interval in minutes, e.g. 60 for one"
                      "hour."),
-        validate=TimeFormat('%H:%M'),
         required=True)
     interval_label = ma.String(
         title='Interval Label',
@@ -290,10 +289,9 @@ class ForecastPostSchema(ma.Schema):
         title='Interval length',
         description=('The length of time that each data point represents in'
                      'minutes, e.g. 5 for 5 minutes.'),
-        validate=TimeFormat('%H:%M'),
         required=True
     )
-    run_length = ma.String(
+    run_length = ma.Integer(
         title='Run Length / Issue Frequency',
         description=('The total length of a single issued forecast run in '
                      'minutes, e.g. 60 for 1 hour. To enforce a continuous,'

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -283,7 +283,7 @@ class ForecastPostSchema(ma.Schema):
     interval_label = ma.String(
         title='Interval Label',
         description=('For data that represents intervals, indicates if a time '
-            'labels the beginning or ending of the interval.'),
+                     'labels the beginning or ending of the interval.'),
         validate=validate.OneOf(['beginning', 'ending', 'instant']),
         required=True)
     interval_length = ma.Integer(

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -10,8 +10,10 @@ VARIABLES = ['ghi', 'dni', 'dhi', 'temp_air', 'wind_speed',
              'poa', 'ac_power', 'dc_power', 'pdf_probability',
              'cdf_value']
 
-VALUE_TYPES = ['interval_mean', 'interval_max', 'interval_min',
-               'interval_media', 'percentile', 'instantaneous']
+OBSERVATION_VALUE_TYPES = ['interval_mean', 'instantaneous']
+
+FORECAST_VALUE_TYPES = ['interval_mean', 'interval_max', 'interval_min',
+                        'interval_median', 'percentile', 'instantaneous']
 
 ALLOWED_TIMEZONES = pytz.country_timezones('US') + list(
     filter(lambda x: 'GMT' in x, pytz.all_timezones))
@@ -193,7 +195,7 @@ class ObservationPostSchema(ma.Schema):
         required=True)
     value_type = ma.String(
         title='Value Type',
-        validate=validate.OneOf(VALUE_TYPES))
+        validate=validate.OneOf(OBSERVATION_VALUE_TYPES))
     uncertainty = ma.Float(
         title='Uncertainty',
         description='A measure of the uncertainty of the observation values.')
@@ -301,7 +303,7 @@ class ForecastPostSchema(ma.Schema):
     )
     value_type = ma.String(
         title='Value Type',
-        validate=validate.OneOf(VALUE_TYPES)
+        validate=validate.OneOf(FORECAST_VALUE_TYPES)
     )
     extra_parameters = EXTRA_PARAMETERS_FIELD
 

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -10,7 +10,8 @@ VARIABLES = ['ghi', 'dni', 'dhi', 'temp_air', 'wind_speed',
              'poa', 'ac_power', 'dc_power', 'pdf_probability',
              'cdf_value']
 
-VALUE_TYPES = ['interval_mean', 'instantaneous']
+VALUE_TYPES = ['interval_mean', 'interval_max', 'interval_min',
+               'interval_media', 'percentile', 'instantaneous']
 
 ALLOWED_TIMEZONES = pytz.country_timezones('US') + list(
     filter(lambda x: 'GMT' in x, pytz.all_timezones))
@@ -185,11 +186,10 @@ class ObservationPostSchema(ma.Schema):
                      'instant for instantaneous data'),
         validate=validate.OneOf(['beginning', 'ending', 'instant']),
         required=True)
-    interval_length = ma.String(
+    interval_length = ma.Integer(
         title='Interval length',
         description=('The length of time that each data point represents  in'
-                     'HH:MM format, e.g. 00:05 for 5 minutes.'),
-        validate=TimeFormat('%H:%M'),
+                     'minutes, e.g. 5 for 5 minutes.'),
         required=True)
     value_type = ma.String(
         title='Value Type',
@@ -273,33 +273,32 @@ class ForecastPostSchema(ma.Schema):
                      'day. Additional issue times are uniquely determined by '
                      'the first issue time and the run length & issue '
                      'frequency attribute.'))
-    lead_time_to_start = ma.String(
+    lead_time_to_start = ma.Integer(
         title='Lead time to start',
         description=("The difference between the issue time and the start of "
-                     "the first forecast interval in HH:MM format, e.g. 01:00 "
-                     "for 1 hour."),
+                     "the first forecast interval in minutes, e.g. 60 for one"
+                     "hour."),
         validate=TimeFormat('%H:%M'),
         required=True)
     interval_label = ma.String(
         title='Interval Label',
         description=('For data that represents intervals, indicates if a time '
-                     'labels the beginning or ending of the interval. N/A for '
-                     'instantaneous data'),
-        validate=validate.OneOf(['beginning', 'ending', 'instant']))
-    interval_length = ma.String(
+            'labels the beginning or ending of the interval.'),
+        validate=validate.OneOf(['beginning', 'ending', 'instant']),
+        required=True)
+    interval_length = ma.Integer(
         title='Interval length',
-        description=('The length of time that each data point represents  in'
-                     'HH:MM format, e.g. 00:05 for 5 minutes.'),
+        description=('The length of time that each data point represents in'
+                     'minutes, e.g. 5 for 5 minutes.'),
         validate=TimeFormat('%H:%M'),
         required=True
     )
     run_length = ma.String(
         title='Run Length / Issue Frequency',
         description=('The total length of a single issued forecast run in '
-                     'HH:MM format,  e.g. 01:00 for 1 hour. To enforce a '
-                     'continuous, non-overlapping sequence, this is equal '
-                     'to the forecast run issue frequency.'),
-        validate=TimeFormat('%H:%M'),
+                     'minutes, e.g. 60 for 1 hour. To enforce a continuous,'
+                     'non-overlapping sequence, this is equal to the forecast'
+                     'run issue frequency.'),
         required=True
     )
     value_type = ma.String(

--- a/sfa_api/test/test_forecast.py
+++ b/sfa_api/test/test_forecast.py
@@ -8,9 +8,9 @@ VALID_FORECAST_JSON = {
     "variable": "ac_power",
     "interval_label": "beginning",
     "issue_time_of_day": "12:00",
-    "lead_time_to_start": "01:00",
-    "interval_length": "00:01",
-    "run_length": "01:00",
+    "lead_time_to_start": 60,
+    "interval_length": 1,
+    "run_length": 86400,
     "value_type": "interval_mean",
 }
 
@@ -37,7 +37,7 @@ INVALID_VALUE_TYPE = copy_update(VALID_FORECAST_JSON,
                                  'value_type', 'invalid')
 
 
-empty_json_response = '{"interval_length":["Missing data for required field."],"issue_time_of_day":["Missing data for required field."],"lead_time_to_start":["Missing data for required field."],"name":["Missing data for required field."],"run_length":["Missing data for required field."],"site_id":["Missing data for required field."],"variable":["Missing data for required field."]}' # NOQA
+empty_json_response = '{"interval_label":["Missing data for required field."],"interval_length":["Missing data for required field."],"issue_time_of_day":["Missing data for required field."],"lead_time_to_start":["Missing data for required field."],"name":["Missing data for required field."],"run_length":["Missing data for required field."],"site_id":["Missing data for required field."],"variable":["Missing data for required field."]}' # NOQA
 
 
 @pytest.mark.parametrize('payload,status_code', [
@@ -55,9 +55,9 @@ def test_forecast_post_success(api, payload, status_code):
     (INVALID_VARIABLE, '{"variable":["Not a valid choice."]}'),
     (INVALID_INTERVAL_LABEL, '{"interval_label":["Not a valid choice."]}'),
     (INVALID_ISSUE_TIME, '{"issue_time_of_day":["Time not in %H:%M format."]}'), # NOQA
-    (INVALID_LEAD_TIME, '{"lead_time_to_start":["Time not in %H:%M format."]}'), # NOQA
-    (INVALID_INTERVAL_LENGTH, '{"interval_length":["Time not in %H:%M format."]}'), # NOQA
-    (INVALID_RUN_LENGTH, '{"run_length":["Time not in %H:%M format."]}'),
+    (INVALID_LEAD_TIME, '{"lead_time_to_start":["Not a valid integer."]}'), # NOQA
+    (INVALID_INTERVAL_LENGTH, '{"interval_length":["Not a valid integer."]}'), # NOQA
+    (INVALID_RUN_LENGTH, '{"run_length":["Not a valid integer."]}'),
     (INVALID_VALUE_TYPE, '{"value_type":["Not a valid choice."]}'),
     ({}, empty_json_response)
 ])

--- a/sfa_api/test/test_forecast.py
+++ b/sfa_api/test/test_forecast.py
@@ -10,7 +10,7 @@ VALID_FORECAST_JSON = {
     "issue_time_of_day": "12:00",
     "lead_time_to_start": 60,
     "interval_length": 1,
-    "run_length": 86400,
+    "run_length": 1440,
     "value_type": "interval_mean",
 }
 

--- a/sfa_api/test/test_observation.py
+++ b/sfa_api/test/test_observation.py
@@ -6,7 +6,8 @@ VALID_OBS_JSON = {
     "name": "Ashland OR, ghi",
     "site_id": "123e4567-e89b-12d3-a456-426655440001",
     "variable": "ghi",
-    "interval_label": "beginning"
+    "interval_label": "beginning",
+    "interval_length": 1,
 }
 
 
@@ -22,7 +23,7 @@ INVALID_INTERVAL_LABEL = copy_update(VALID_OBS_JSON,
                                      'interval_label', 'invalid')
 
 
-empty_json_response = '{"interval_label":["Missing data for required field."],"name":["Missing data for required field."],"site_id":["Missing data for required field."],"variable":["Missing data for required field."]}' # NOQA
+empty_json_response = '{"interval_label":["Missing data for required field."],"interval_length":["Missing data for required field."],"name":["Missing data for required field."],"site_id":["Missing data for required field."],"variable":["Missing data for required field."]}' # NOQA
 
 
 def test_observation_post_success(api):


### PR DESCRIPTION
Supports #38 

1. Adds missing interval_length field to observation schema
2. Correct development storage backend storing keys as UUID objects when nested in other schema.
3. Unifies error formatting. There are some D.R.Y. issues at the moment. I think this should be handled by creating some custom exceptions and flask error handling. This needs a little more thought to continue to provide feedback for _all_ of the errors a user should fix instead of the first one encountered.
4. Change Time delta fields to integers. 