### PR TITLE
add DB procedures to insert data

### DIFF
--- a/datastore/migrations/0002_permissions_tables.up.sql
+++ b/datastore/migrations/0002_permissions_tables.up.sql
@@ -62,7 +62,7 @@ CREATE TABLE arbiter_data.permissions (
   id BINARY(16) NOT NULL DEFAULT (UUID_TO_BIN(UUID(), 1)),
   description VARCHAR(64) NOT NULL,
   organization_id BINARY(16) NOT NULL,
-  action ENUM('create', 'read', 'update',  'delete') NOT NULL,
+  action ENUM('create', 'read', 'update',  'delete', 'write_values', 'delete_values') NOT NULL,
   object_type ENUM('sites', 'aggregates', 'forecasts', 'observations', 'users', 'roles', 'permissions') NOT NULL,
   applies_to_all BOOLEAN DEFAULT FALSE,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/datastore/migrations/0006_rbac_functions.down.sql
+++ b/datastore/migrations/0006_rbac_functions.down.sql
@@ -1,4 +1,5 @@
-DROP USER IF EXISTS 'select_rbac'@'localhost';
-DROP PROCEDURE IF EXISTS list_objects_user_can_read;
-DROP FUNCTION IF EXISTS can_user_perform_action;
-DROP FUNCTION IF EXISTS user_can_create;
+DROP USER 'select_rbac'@'localhost';
+DROP PROCEDURE list_objects_user_can_read;
+DROP FUNCTION can_user_perform_action;
+DROP FUNCTION user_can_create;
+DROP FUNCTION get_user_organization;

--- a/datastore/migrations/0006_rbac_functions.up.sql
+++ b/datastore/migrations/0006_rbac_functions.up.sql
@@ -71,6 +71,14 @@ BEGIN
 END;
 
 
+-- Function to get organization_id of user
+CREATE DEFINER = 'select_rbac'@'localhost' FUNCTION get_user_organization (auth0id VARCHAR(32))
+RETURNS BINARY(16)
+COMMENT 'Returns the organizaton ID of the user'
+READS SQL DATA SQL SECURITY DEFINER
+RETURN (SELECT organization_id FROM arbiter_data.users WHERE auth0_id = auth0id);
+
+
 -- Grant only required permissions to limited user account to execute rbac functions
 GRANT SELECT ON `arbiter_data`.`permission_object_mapping` TO `select_rbac`@`localhost`;
 GRANT SELECT ON `arbiter_data`.`permissions` TO `select_rbac`@`localhost`;
@@ -81,3 +89,4 @@ GRANT SELECT ON `arbiter_data`.`users` TO `select_rbac`@`localhost`;
 GRANT EXECUTE ON PROCEDURE `arbiter_data`.`list_objects_user_can_read` TO `select_rbac`@`localhost`;
 GRANT EXECUTE ON FUNCTION `arbiter_data`.`can_user_perform_action` TO `select_rbac`@`localhost`;
 GRANT EXECUTE ON FUNCTION `arbiter_data`.`user_can_create` TO `select_rbac`@`localhost`;
+GRANT EXECUTE ON FUNCTION `arbiter_data`.`get_user_organization` TO `select_rbac`@`localhost`;

--- a/datastore/migrations/0008_store_object_procedures.down.sql
+++ b/datastore/migrations/0008_store_object_procedures.down.sql
@@ -2,3 +2,4 @@ DROP USER 'insert_objects'@'localhost';
 DROP PROCEDURE arbiter_data.store_site;
 DROP PROCEDURE arbiter_data.store_observation;
 DROP PROCEDURE arbiter_data.store_forecast;
+DROP PROCEDURE arbiter_data.store_observation_values;

--- a/datastore/migrations/0008_store_object_procedures.down.sql
+++ b/datastore/migrations/0008_store_object_procedures.down.sql
@@ -1,0 +1,4 @@
+DROP USER 'insert_objects'@'localhost';
+DROP PROCEDURE arbiter_data.store_site;
+DROP PROCEDURE arbiter_data.store_observation;
+DROP PROCEDURE arbiter_data.store_forecast;

--- a/datastore/migrations/0008_store_object_procedures.down.sql
+++ b/datastore/migrations/0008_store_object_procedures.down.sql
@@ -3,3 +3,4 @@ DROP PROCEDURE arbiter_data.store_site;
 DROP PROCEDURE arbiter_data.store_observation;
 DROP PROCEDURE arbiter_data.store_forecast;
 DROP PROCEDURE arbiter_data.store_observation_values;
+DROP PROCEDURE arbiter_data.store_forecast_values;

--- a/datastore/migrations/0008_store_object_procedures.up.sql
+++ b/datastore/migrations/0008_store_object_procedures.up.sql
@@ -126,16 +126,36 @@ BEGIN
 END;
 
 
+CREATE DEFINER = 'insert_objects'@'localhost' PROCEDURE store_forecast_values (
+    IN auth0id VARCHAR(32), IN strid CHAR(36), IN timestamp TIMESTAMP, IN value FLOAT)
+COMMENT 'Store a single time, value, quality_flag row into forecast_values'
+MODIFIES SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+    SET binid = (SELECT UUID_TO_BIN(strid, 1));
+    SET allowed = (SELECT can_user_perform_action(auth0id, binid, 'write_values'));
+    IF allowed THEN
+        INSERT INTO arbiter_data.forecasts_values (id, timestamp, value) VALUES (
+            binid, timestamp, value);
+    ELSE
+        SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "write forecast values"',
+        MYSQL_ERRNO = 1142;
+    END IF;
+END;
+
 
 
 GRANT INSERT ON arbiter_data.sites TO 'insert_objects'@'localhost';
 GRANT INSERT ON arbiter_data.observations TO 'insert_objects'@'localhost';
 GRANT INSERT ON arbiter_data.observations_values TO 'insert_objects'@'localhost';
 GRANT INSERT ON arbiter_data.forecasts TO 'insert_objects'@'localhost';
+GRANT INSERT ON arbiter_data.forecasts_values TO 'insert_objects'@'localhost';
 GRANT EXECUTE ON PROCEDURE arbiter_data.store_site to 'insert_objects'@'localhost';
 GRANT EXECUTE ON PROCEDURE arbiter_data.store_observation to 'insert_objects'@'localhost';
 GRANT EXECUTE ON PROCEDURE arbiter_data.store_forecast to 'insert_objects'@'localhost';
 GRANT EXECUTE ON PROCEDURE arbiter_data.store_observation_values TO 'insert_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.store_forecast_values TO 'insert_objects'@'localhost';
 GRANT EXECUTE ON FUNCTION arbiter_data.user_can_create TO 'insert_objects'@'localhost';
 GRANT EXECUTE ON FUNCTION arbiter_data.can_user_perform_action TO 'insert_objects'@'localhost';
 GRANT EXECUTE ON FUNCTION arbiter_data.get_user_organization TO 'insert_objects'@'localhost';

--- a/datastore/migrations/0008_store_object_procedures.up.sql
+++ b/datastore/migrations/0008_store_object_procedures.up.sql
@@ -106,13 +106,36 @@ BEGIN
 END;
 
 
+CREATE DEFINER = 'insert_objects'@'localhost' PROCEDURE store_observation_values (
+    IN auth0id VARCHAR(32), IN strid CHAR(36), IN timestamp TIMESTAMP, IN value FLOAT,
+    IN quality_flag TINYINT UNSIGNED)
+COMMENT 'Store a single time, value, quality_flag row into observation_values'
+MODIFIES SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+    SET binid = (SELECT UUID_TO_BIN(strid, 1));
+    SET allowed = (SELECT can_user_perform_action(auth0id, binid, 'write_values'));
+    IF allowed THEN
+        INSERT INTO arbiter_data.observations_values (id, timestamp, value, quality_flag) VALUES (
+            binid, timestamp, value, quality_flag);
+    ELSE
+        SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "write observation values"',
+        MYSQL_ERRNO = 1142;
+    END IF;
+END;
+
+
+
 
 GRANT INSERT ON arbiter_data.sites TO 'insert_objects'@'localhost';
 GRANT INSERT ON arbiter_data.observations TO 'insert_objects'@'localhost';
+GRANT INSERT ON arbiter_data.observations_values TO 'insert_objects'@'localhost';
 GRANT INSERT ON arbiter_data.forecasts TO 'insert_objects'@'localhost';
 GRANT EXECUTE ON PROCEDURE arbiter_data.store_site to 'insert_objects'@'localhost';
 GRANT EXECUTE ON PROCEDURE arbiter_data.store_observation to 'insert_objects'@'localhost';
 GRANT EXECUTE ON PROCEDURE arbiter_data.store_forecast to 'insert_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.store_observation_values TO 'insert_objects'@'localhost';
 GRANT EXECUTE ON FUNCTION arbiter_data.user_can_create TO 'insert_objects'@'localhost';
 GRANT EXECUTE ON FUNCTION arbiter_data.can_user_perform_action TO 'insert_objects'@'localhost';
 GRANT EXECUTE ON FUNCTION arbiter_data.get_user_organization TO 'insert_objects'@'localhost';

--- a/datastore/migrations/0008_store_object_procedures.up.sql
+++ b/datastore/migrations/0008_store_object_procedures.up.sql
@@ -1,0 +1,117 @@
+CREATE USER 'insert_objects'@'localhost' IDENTIFIED WITH caching_sha2_password as '$A$005$THISISACOMBINATIONOFINVALIDSALTANDPASSWORDTHATMUSTNEVERBRBEUSED' ACCOUNT LOCK;
+
+
+CREATE DEFINER = 'insert_objects'@'localhost' PROCEDURE store_site (
+    IN auth0id VARCHAR(32), IN strid CHAR(36),
+    IN name VARCHAR(64), IN latitude DECIMAL(8, 6), IN longitude DECIMAL(9, 6),
+    IN elevation DECIMAL(7, 2), IN timezone VARCHAR(32), IN extra_parameters TEXT,
+    IN ac_capacity DECIMAL(10, 6), IN dc_capacity DECIMAL(10, 6),
+    IN temperature_coefficient DECIMAL(7, 5), IN tracking_type VARCHAR(32),
+    IN surface_tilt DECIMAL(4, 2), IN surface_azimuth DECIMAL(5, 2),
+    IN axis_tilt DECIMAL(4, 2), IN axis_azimuth DECIMAL(5, 2),
+    IN ground_coverage_ratio DECIMAL(8, 4), IN backtrack BOOLEAN,
+    IN max_rotation_angle DECIMAL(5, 2), IN dc_loss_factor DECIMAL(5, 2),
+    IN ac_loss_factor DECIMAL(5, 2))
+COMMENT 'Store an observation object. User must be able to read site information.'
+MODIFIES SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE orgid BINARY(16);
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+    SET allowed = (SELECT user_can_create(auth0id, 'sites'));
+    IF allowed THEN
+        SELECT organization_id INTO orgid FROM arbiter_data.users WHERE auth0_id = auth0id;
+        INSERT INTO arbiter_data.sites (
+            id, organization_id, name, latitude, longitude, elevation, timezone, extra_parameters,
+            ac_capacity, dc_capacity, temperature_coefficient, tracking_type, surface_tilt,
+            surface_azimuth, axis_tilt, axis_azimuth, ground_coverage_ratio, backtrack,
+            max_rotation_angle, dc_loss_factor, ac_loss_factor
+         ) VALUES (
+             UUID_TO_BIN(strid, 1), orgid, name, latitude, longitude, elevation, timezone, extra_parameters,
+             ac_capacity, dc_capacity, temperature_coefficient, tracking_type, surface_tilt,
+             surface_azimuth, axis_tilt, axis_azimuth, ground_coverage_ratio, backtrack,
+             max_rotation_angle, dc_loss_factor, ac_loss_factor
+         );
+    ELSE
+       SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "create sites"',
+          MYSQL_ERRNO = 1142;
+    END IF;
+END;
+
+
+CREATE DEFINER = 'insert_objects'@'localhost' PROCEDURE store_observation (
+  IN auth0id VARCHAR(32), IN strid CHAR(36), IN variable VARCHAR(32), IN site_id CHAR(36), IN name VARCHAR(64),
+  IN interval_label VARCHAR(32), IN interval_length SMALLINT UNSIGNED, IN value_type VARCHAR(32),
+  IN uncertainty FLOAT, IN extra_parameters TEXT)
+COMMENT 'Store an observation object. User must be able to read site information.'
+MODIFIES SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE orgid BINARY(16);
+    DECLARE binsiteid BINARY(16);
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+    DECLARE canreadsite BOOLEAN DEFAULT FALSE;
+    SET allowed = (SELECT user_can_create(auth0id, 'observations'));
+    SET binsiteid = (SELECT UUID_TO_BIN(site_id, 1));
+    IF allowed THEN
+       SET canreadsite = (SELECT can_user_perform_action(auth0id, binsiteid, 'read'));
+       IF canreadsite THEN
+            SELECT organization_id INTO orgid FROM arbiter_data.users WHERE auth0_id = auth0id;
+            INSERT INTO arbiter_data.observations (
+                id, organization_id, site_id, name, variable, interval_label, interval_length,
+                value_type, uncertainty, extra_parameters
+            ) VALUES (
+                UUID_TO_BIN(strid, 1), orgid, binsiteid, name, variable, interval_label,
+                interval_length, value_type, uncertainty, extra_parameters);
+       ELSE
+           SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'User does not have permission to read site', MYSQL_ERRNO = 1143;
+       END IF;
+    ELSE
+       SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "create observations"',
+       MYSQL_ERRNO = 1142;
+    END IF;
+END;
+
+
+CREATE DEFINER = 'insert_objects'@'localhost' PROCEDURE store_forecast (
+  IN auth0id VARCHAR(32), IN strid CHAR(36), IN site_id CHAR(36), IN name VARCHAR(64), IN variable VARCHAR(32),
+  IN issue_time_of_day TIME, IN lead_time_to_start SMALLINT UNSIGNED, IN interval_label VARCHAR(32),
+  IN interval_length SMALLINT UNSIGNED, IN run_length SMALLINT UNSIGNED, IN value_type VARCHAR(32),
+  IN extra_parameters TEXT)
+COMMENT 'Store an forecast object. User must be able to read site information.'
+MODIFIES SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE orgid BINARY(16);
+    DECLARE binsiteid BINARY(16);
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+    DECLARE canreadsite BOOLEAN DEFAULT FALSE;
+    SET allowed = (SELECT user_can_create(auth0id, 'forecasts'));
+    SET binsiteid = (SELECT UUID_TO_BIN(site_id, 1));
+    IF allowed THEN
+       SET canreadsite = (SELECT can_user_perform_action(auth0id, binsiteid, 'read'));
+       IF canreadsite THEN
+            SELECT organization_id INTO orgid FROM arbiter_data.users WHERE auth0_id = auth0id;
+            INSERT INTO arbiter_data.forecasts (
+                id, organization_id, site_id, name, variable, issue_time_of_day, lead_time_to_start,
+                interval_label, interval_length, run_length, value_type, extra_parameters
+            ) VALUES (
+                UUID_TO_BIN(strid, 1), orgid, binsiteid, name, variable, issue_time_of_day,
+                lead_time_to_start, interval_label, interval_length, run_length, value_type,
+                extra_parameters);
+       ELSE
+           SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'User does not have permission to read site', MYSQL_ERRNO = 1143;
+       END IF;
+    ELSE
+       SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "create forecasts"',
+       MYSQL_ERRNO = 1142;
+    END IF;
+END;
+
+
+GRANT INSERT ON arbiter_data.sites TO 'insert_objects'@'localhost';
+GRANT INSERT ON arbiter_data.observations TO 'insert_objects'@'localhost';
+GRANT INSERT ON arbiter_data.forecasts TO 'insert_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.store_site to 'insert_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.store_observation to 'insert_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.store_forecast to 'insert_objects'@'localhost';
+GRANT EXECUTE ON FUNCTION arbiter_data.user_can_create TO 'insert_objects'@'localhost';
+GRANT EXECUTE ON FUNCTION arbiter_data.can_user_perform_action TO 'insert_objects'@'localhost';
+GRANT SELECT ON arbiter_data.users TO 'insert_objects'@'localhost';

--- a/datastore/tests/test_drops.py
+++ b/datastore/tests/test_drops.py
@@ -27,6 +27,15 @@ def test_drop_org(cursor, valueset_org, test):
     assert check_table_for_org(cursor, oid, test) == 0
 
 
+@pytest.mark.parametrize('test', [
+    'users', 'roles', 'permissions', 'sites',
+    'forecasts', 'permission_object_mapping',
+    'user_role_mapping', 'role_permission_mapping'])
+def test_drop_all_orgs_all_tables(cursor, valueset_org, test):
+    cursor.execute('DELETE FROM organizations')
+    check_table_for_org(cursor, None, test)
+
+
 def test_drop_user(cursor, valueset_user):
     """Check that the user is remove from the user_role_mapping table"""
     user = valueset_user['id']

--- a/datastore/tests/test_inserts.py
+++ b/datastore/tests/test_inserts.py
@@ -145,7 +145,13 @@ def test_store_site(dictcursor, site_callargs, allow_create):
     dictcursor.execute(
         'SELECT * FROM arbiter_data.sites WHERE id = UUID_TO_BIN(%s, 1)',
         (site_callargs['strid'],))
+    keys = list(site_callargs.keys())[2:]
     res = dictcursor.fetchall()[0]
-    del res['created_at']
-    del res['modified_at']
-    assert res == site_callargs
+    for key in keys:
+        assert res[key] == site_callargs[key]
+
+
+def test_store_site_denied_cant_create(dictcursor, site_callargs):
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        dictcursor.callproc('store_site', list(site_callargs.values()))
+        assert e.errcode == 1142

--- a/datastore/tests/test_inserts.py
+++ b/datastore/tests/test_inserts.py
@@ -1,0 +1,151 @@
+from collections import OrderedDict
+import datetime as dt
+import uuid
+
+
+import pytest
+import pymysql
+
+
+from conftest import bin_to_uuid
+
+
+@pytest.fixture()
+def insertuser(cursor, new_permission, valueset, new_user):
+    org = valueset[0][0]
+    user = valueset[1][0]
+    role = valueset[2][0]
+    site = valueset[3][0]
+    fx = valueset[5][0]
+    obs = valueset[6][0]
+    for thing in (user, site, fx, obs):
+        thing['strid'] = str(bin_to_uuid(thing['id']))
+    cursor.execute(
+        'DELETE FROM permissions WHERE action = "create" and '
+        'object_type = "forecasts"')
+    return user, site, fx, obs, org, role
+
+
+@pytest.fixture()
+def allow_read_sites(cursor, new_permission, insertuser):
+    user, site, fx, obs, org, role = insertuser
+    perm = new_permission('read', 'sites', True, org=org)
+    cursor.execute(
+        'INSERT INTO role_permission_mapping (role_id, permission_id) VALUES '
+        '(%s, %s)', (role['id'], perm['id']))
+
+
+@pytest.fixture()
+def allow_create(insertuser, new_permission, cursor):
+    user, site, fx, obs, org, role = insertuser
+    perms = [new_permission('create', obj, True, org=org)
+             for obj in ('sites', 'forecasts', 'observations')]
+    cursor.executemany(
+        'INSERT INTO role_permission_mapping (role_id, permission_id) '
+        'VALUES (%s, %s)',
+        [(role['id'], perm['id']) for perm in perms])
+
+
+@pytest.fixture()
+def obs_callargs(insertuser):
+    auth0id = insertuser[0]['auth0_id']
+    site_id = insertuser[1]['strid']
+    callargs = OrderedDict(
+        auth0id=auth0id, strid=str(uuid.uuid1()), variable='power',
+        site_id=site_id, name='The site', interval_label='beginning',
+        interval_length=5, value_type='interval_mean', uncertainty=0.1,
+        extra_parameters='')
+    return callargs
+
+
+@pytest.fixture()
+def fx_callargs(insertuser):
+    auth0id = insertuser[0]['auth0_id']
+    site_id = insertuser[1]['strid']
+    callargs = OrderedDict(
+        auth0id=auth0id, strid=str(uuid.uuid1()), site_id=site_id,
+        name='The site', variable='power',
+        issue_time_of_day=dt.time(hour=12),
+        lead_time_to_start=60, interval_label='beginning',
+        interval_length=5, run_length=60,
+        value_type='interval_mean', extra_parameters='')
+    return callargs
+
+
+@pytest.fixture()
+def site_callargs(insertuser, new_site):
+    auth0id = insertuser[0]['auth0_id']
+    siteargs = new_site()
+    del siteargs['id']
+    del siteargs['organization_id']
+    callargs = OrderedDict(auth0id=auth0id, strid=str(uuid.uuid1()))
+    callargs.update(siteargs)
+    return callargs
+
+
+def test_store_observation(dictcursor, obs_callargs, allow_read_sites,
+                           allow_create):
+    dictcursor.callproc('store_observation', list(obs_callargs.values()))
+    dictcursor.execute(
+        'SELECT * FROM arbiter_data.observations WHERE id = UUID_TO_BIN(%s, 1)',  # NOQA
+        (obs_callargs['strid'],))
+    res = dictcursor.fetchall()[0]
+    for key in ('variable', 'name', 'interval_label', 'interval_length',
+                'value_type', 'uncertainty', 'extra_parameters'):
+        assert res[key] == obs_callargs[key]
+
+
+def test_store_observation_denied_cant_create(dictcursor, obs_callargs,
+                                              allow_read_sites):
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        dictcursor.callproc('store_observation', list(obs_callargs.values()))
+        assert e.errcode == 1142
+
+
+def test_store_observation_denied_cant_read_sites(dictcursor, obs_callargs,
+                                                  allow_create):
+    """Don't allow a user to create an observation if they can not also read the
+    site metadata"""
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        dictcursor.callproc('store_observation', list(obs_callargs.values()))
+        assert e.errcode == 1143
+
+
+def test_store_forecast(dictcursor, fx_callargs, allow_read_sites,
+                        allow_create):
+    dictcursor.callproc('store_forecast', list(fx_callargs.values()))
+    dictcursor.execute(
+        'SELECT * FROM arbiter_data.forecasts WHERE id = UUID_TO_BIN(%s, 1)',
+        (fx_callargs['strid'],))
+    res = dictcursor.fetchall()[0]
+    for key in ('variable', 'name', 'interval_label', 'interval_length',
+                'value_type', 'issue_time_of_day', 'run_length',
+                'lead_time_to_start', 'extra_parameters'):
+        assert res[key] == fx_callargs[key]
+
+
+def test_store_forecast_denied_cant_create(dictcursor, fx_callargs,
+                                           allow_read_sites):
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        dictcursor.callproc('store_forecast', list(fx_callargs.values()))
+        assert e.errcode == 1142
+
+
+def test_store_forecast_denied_cant_read_sites(dictcursor, fx_callargs,
+                                               allow_create):
+    """Don't allow a user to create an forecast if they can not also read the
+    site metadata"""
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        dictcursor.callproc('store_forecast', list(fx_callargs.values()))
+        assert e.errcode == 1143
+
+
+def test_store_site(dictcursor, site_callargs, allow_create):
+    dictcursor.callproc('store_site', list(site_callargs.values()))
+    dictcursor.execute(
+        'SELECT * FROM arbiter_data.sites WHERE id = UUID_TO_BIN(%s, 1)',
+        (site_callargs['strid'],))
+    res = dictcursor.fetchall()[0]
+    del res['created_at']
+    del res['modified_at']
+    assert res == site_callargs

--- a/datastore/tests/test_uuid_to_bin.py
+++ b/datastore/tests/test_uuid_to_bin.py
@@ -1,6 +1,6 @@
 from uuid import uuid1
 import pytest
-from conftest import uuid_to_bin
+from conftest import uuid_to_bin, bin_to_uuid
 
 
 @pytest.mark.parametrize('uuid', [uuid1() for i in range(5)])
@@ -9,3 +9,12 @@ def test_uuid_to_bin(cursor, uuid):
     assert uuid_to_bin(uuid) == cursor.fetchone()[0]
     cursor.execute('SELECT BIN_TO_UUID(%s, 1)', uuid_to_bin(uuid))
     assert str(uuid) == cursor.fetchone()[0]
+
+
+@pytest.mark.parametrize(
+    'binid', [uuid_to_bin(uuid1()) for i in range(5)])
+def test_bin_to_uuid(cursor, binid):
+    cursor.execute('SELECT BIN_TO_UUID(%s, 1)', binid)
+    assert str(bin_to_uuid(binid)) == cursor.fetchone()[0]
+    cursor.execute('SELECT UUID_TO_BIN(%s, 1)', str(bin_to_uuid(binid)))
+    assert binid == cursor.fetchone()[0]

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -22,6 +22,7 @@ def store_observation_values(obs_id, observation_df):
         The UUID of the associated Observation or None if the it does
         not exist.
     """
+    # PROC: store_observation_values
     raise NotImplementedError
 
 
@@ -61,6 +62,7 @@ def store_observation(observation):
     string
         The UUID of the newly created Observation.
     """
+    # PROC: store_observation
     raise NotImplementedError
 
 
@@ -112,6 +114,7 @@ def list_observations(site=None):
     list
         List of dictionaries of Observation metadata.
     """
+    # PROC: list_observations
     raise NotImplementedError
 
 
@@ -132,6 +135,7 @@ def store_forecast_values(forecast_id, forecast_df):
         The UUID of the associated forecast. Returns
         None if the Forecast does not exist.
     """
+    # PROC: store_forecast_values
     raise NotImplementedError
 
 
@@ -172,6 +176,7 @@ def store_forecast(forecast):
         The UUID of the newly created Forecast.
 
     """
+    # PROC: store_forecast
     raise NotImplementedError
 
 
@@ -223,6 +228,7 @@ def list_forecasts(site=None):
     list
         List of dictionaries of Forecast metadata.
     """
+    # PROC: list_forecasts
     raise NotImplementedError
 
 
@@ -256,6 +262,7 @@ def store_site(site):
     string
         UUID of the newly created site.
     """
+    # PROC: store_site
     raise NotImplementedError
 
 
@@ -284,4 +291,5 @@ def list_sites():
     list
         List of Site metadata as dictionaries.
     """
+    # PROC: list_sites
     raise NotImplementedError


### PR DESCRIPTION
currently can only insert one row at a time. A bulk insert might be necessary, although tougher to secure, based on how slow this implementation is.