### PR TITLE
Test updates

### DIFF
--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -67,6 +67,48 @@ VALID_CDF_FORECAST_JSON.update({
     "constant_values": [5.0, 20.0, 50.0, 80.0, 95.0]
 })
 
+VALID_OBS_VALUE_JSON = { 
+    'id': '123e4567-e89b-12d3-a456-426655440000',
+    'values': [
+        {'quality_flag': 0,
+         'timestamp': "2019-01-22T17:54:00+00:00",
+         'value': 1.0},
+        {'quality_flag': 0,
+         'timestamp': "2019-01-22T17:55:00+00:00",
+         'value': 32.0},
+        {'quality_flag': 0,
+         'timestamp': "2019-01-22T17:56:00+00:00",
+         'value': 3.0}
+    ]   
+}
+VALID_OBS_VALUE_CSV = (
+    '# observation_id: 123e4567-e89b-12d3-a456-426655440000\n'
+    '# metadata: https://localhost/observations/123e4567-e89b-12d3-a456-426655440000/metadata\n' # NOQA
+    'timestamp,value,quality_flag\n'
+    '20190122T12:04:00+0000,52.0,0\n'
+    '20190122T12:05:00+0000,73.0,0\n'
+    '20190122T12:06:00+0000,42.0,0\n'
+    '20190122T12:07:00+0000,12.0,0\n')
+VALID_FX_VALUE_JSON = { 
+    'id': '123e4567-e89b-12d3-a456-426655440000',
+    'values': [
+        {'timestamp': "2019-01-22T17:54:00+00:00",
+         'value': 1.0},
+        {'timestamp': "2019-01-22T17:55:00+00:00",
+         'value': 32.0},
+        {'timestamp': "2019-01-22T17:56:00+00:00",
+         'value': 3.0}
+    ]   
+}
+VALID_FX_VALUE_CSV = (
+    '# forecast_id: f8dd49fa-23e2-48a0-862b-ba0af6dec276\n'
+    '# metadata: https://localhost/forecasts/single/f8dd49fa-23e2-48a0-862b-ba0af6dec276/metadata\n' # NOQA
+    'timestamp,value\n'
+    '20190122T12:04:00+0000,7.0\n'
+    '20190122T12:05:00+0000,3.0\n'
+    '20190122T12:06:00+0000,13.0\n'
+    '20190122T12:07:00+0000,25.0\n')
+
 
 def copy_update(json, key, value):
     new_json = json.copy()

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -42,11 +42,6 @@ def observation_id():
 
 
 @pytest.fixture()
-def missing_observation_id():
-    return '123e4567-e89b-12d3-a456-426655440007'
-
-
-@pytest.fixture()
 def cdf_forecast_group_id():
     return 'ef51e87c-50b9-11e9-8647-d663bd873d93'
 
@@ -62,11 +57,6 @@ def forecast_id():
 
 
 @pytest.fixture()
-def missing_forecast_id():
-    return 'f8dd49fa-23e2-48a0-862b-ba0afaaaaaa6'
-
-
-@pytest.fixture()
 def site_id():
     return 'd2018f1d-82b1-422a-8ec4-4e8b3fe92a4a'
 
@@ -74,8 +64,3 @@ def site_id():
 @pytest.fixture()
 def site_id_plant():
     return '123e4567-e89b-12d3-a456-426655440002'
-
-
-@pytest.fixture()
-def missing_site_id():
-    return '123e4567-e89b-12d3-a456-000055440002'

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -74,7 +74,7 @@ def copy_update(json, key, value):
     return new_json
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def app():
     if not os.getenv('SFA_API_STATIC_DATA'):
         os.environ['SFA_API_STATIC_DATA'] = 'true'

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -6,6 +6,8 @@ from sfa_api import create_app
 from sfa_api.schema import VARIABLES, INTERVAL_VALUE_TYPES, INTERVAL_LABELS
 
 
+BASE_URL = 'https://localhost'
+
 # Strings of formatted field options for error checking
 # e.g. provides "interval_mean, instantaneous, ..." so
 # f'Must be one of: {interval_value_types}.' can be checked
@@ -13,6 +15,7 @@ from sfa_api.schema import VARIABLES, INTERVAL_VALUE_TYPES, INTERVAL_LABELS
 variables = ', '.join(VARIABLES)
 interval_value_types = ', '.join(INTERVAL_VALUE_TYPES)
 interval_labels = ', '.join(INTERVAL_LABELS)
+
 
 VALID_SITE_JSON = {
     "elevation": 500.0,
@@ -71,7 +74,7 @@ def copy_update(json, key, value):
     return new_json
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def app():
     if not os.getenv('SFA_API_STATIC_DATA'):
         os.environ['SFA_API_STATIC_DATA'] = 'true'

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -116,11 +116,10 @@ VALID_FX_VALUE_CSV = (
     '# forecast_id: f8dd49fa-23e2-48a0-862b-ba0af6dec276\n'
     '# metadata: https://localhost/forecasts/single/f8dd49fa-23e2-48a0-862b-ba0af6dec276/metadata\n' # NOQA
     f'{FORECAST_CSV}')
-VALID_CDF_VALUE_CSV =(
+VALID_CDF_VALUE_CSV = (
     '# forecast_id: 633f9396-50bb-11e9-8647-d663bd873d93\n'
     '# metadata: https://localhost/forecasts/cdf/single/633f9396-50bb-11e9-8647-d663bd873d93\n' # NOQA
     f'{FORECAST_CSV}')
-
 
 
 def copy_update(json, key, value):

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -67,7 +67,7 @@ VALID_CDF_FORECAST_JSON.update({
     "constant_values": [5.0, 20.0, 50.0, 80.0, 95.0]
 })
 
-VALID_OBS_VALUE_JSON = { 
+VALID_OBS_VALUE_JSON = {
     'id': '123e4567-e89b-12d3-a456-426655440000',
     'values': [
         {'quality_flag': 0,
@@ -79,7 +79,7 @@ VALID_OBS_VALUE_JSON = {
         {'quality_flag': 0,
          'timestamp': "2019-01-22T17:56:00+00:00",
          'value': 3.0}
-    ]   
+    ]
 }
 VALID_OBS_VALUE_CSV = (
     '# observation_id: 123e4567-e89b-12d3-a456-426655440000\n'
@@ -89,7 +89,7 @@ VALID_OBS_VALUE_CSV = (
     '20190122T12:05:00+0000,73.0,0\n'
     '20190122T12:06:00+0000,42.0,0\n'
     '20190122T12:07:00+0000,12.0,0\n')
-VALID_FX_VALUE_JSON = { 
+VALID_FX_VALUE_JSON = {
     'id': '123e4567-e89b-12d3-a456-426655440000',
     'values': [
         {'timestamp': "2019-01-22T17:54:00+00:00",
@@ -98,7 +98,7 @@ VALID_FX_VALUE_JSON = {
          'value': 32.0},
         {'timestamp': "2019-01-22T17:56:00+00:00",
          'value': 3.0}
-    ]   
+    ]
 }
 VALID_FX_VALUE_CSV = (
     '# forecast_id: f8dd49fa-23e2-48a0-862b-ba0af6dec276\n'

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -14,8 +14,64 @@ variables = ', '.join(VARIABLES)
 interval_value_types = ', '.join(INTERVAL_VALUE_TYPES)
 interval_labels = ', '.join(INTERVAL_LABELS)
 
+VALID_SITE_JSON = {
+    "elevation": 500.0,
+    "extra_parameters": '{"parameter": "value"}',
+    "latitude": 42.19,
+    "longitude": -122.7,
+    "modeling_parameters": {
+        "ac_capacity": 0.015,
+        "dc_capacity": 0.015,
+        "backtrack": True,
+        "temperature_coefficient": -.002,
+        "ground_coverage_ratio": 0.5,
+        "surface_azimuth": 180,
+        "surface_tilt": 45.0,
+        "tracking_type": "fixed"
+    },
+    "name": "Test Site",
+    "timezone": "Etc/GMT+8",
+}
 
-@pytest.fixture()
+VALID_FORECAST_JSON = {
+    "extra_parameters": '{"instrument": "pyranometer"}',
+    "name": "test forecast",
+    "site_id": "123e4567-e89b-12d3-a456-426655440001",
+    "variable": "ac_power",
+    "interval_label": "beginning",
+    "issue_time_of_day": "12:00",
+    "lead_time_to_start": 60,
+    "interval_length": 1,
+    "run_length": 1440,
+    "interval_value_type": "interval_mean",
+}
+
+
+VALID_OBS_JSON = {
+    "extra_parameters": '{"instrument": "Ascension Technology Rotating Shadowband Pyranometer"}', # NOQA
+    "name": "Ashland OR, ghi",
+    "site_id": "123e4567-e89b-12d3-a456-426655440001",
+    "variable": "ghi",
+    "interval_label": "beginning",
+    "interval_length": 1,
+}
+
+
+VALID_CDF_FORECAST_JSON = VALID_FORECAST_JSON.copy()
+VALID_CDF_FORECAST_JSON.update({
+    "name": 'test cdf forecast',
+    "axis": 'x',
+    "constant_values": [5.0, 20.0, 50.0, 80.0, 95.0]
+})
+
+
+def copy_update(json, key, value):
+    new_json = json.copy()
+    new_json[key] = value
+    return new_json
+
+
+@pytest.fixture(scope="class")
 def app():
     if not os.getenv('SFA_API_STATIC_DATA'):
         os.environ['SFA_API_STATIC_DATA'] = 'true'

--- a/sfa_api/demo/__init__.py
+++ b/sfa_api/demo/__init__.py
@@ -63,7 +63,8 @@ def store_observation_values(observation_id, observation_df):
         index_complement = current_data.index.difference(observation_df.index)
         complement = current_data.loc[index_complement]
         combined = observation_df.combine_first(complement)
-        observation_values[observation_id] = combined.astype(observation_df.dtypes) 
+        observation_values[observation_id] = combined.astype(
+            observation_df.dtypes)
     return observation_id
 
 

--- a/sfa_api/demo/__init__.py
+++ b/sfa_api/demo/__init__.py
@@ -18,6 +18,7 @@ from sfa_api.demo.observations import static_observations
 from sfa_api.demo.sites import static_sites
 from sfa_api.demo.values import (static_observation_values,
                                  static_forecast_values)
+from sfa_api.utils.errors import DeleteRestrictionError
 
 
 # Initialize static data
@@ -316,12 +317,10 @@ def delete_site(site_id):
         site = sites[site_id]
     except KeyError:
         return None
-    forecasts = list_forecasts(site_id)
-    for forecast in forecasts:
-        delete_forecast(forecast['forecast_id'])
-    observations = list_observations(site_id)
-    for observation in observations:
-        delete_observation(observation['observation_id'])
+    if len(list_forecasts(site_id)) > 0:
+        raise DeleteRestrictionError
+    if len(list_observations(site_id)) > 0:
+        raise DeleteRestrictionError
     sites.pop(site_id)
     return site
 

--- a/sfa_api/demo/__init__.py
+++ b/sfa_api/demo/__init__.py
@@ -62,8 +62,8 @@ def store_observation_values(observation_id, observation_df):
         current_data = observation_values[observation_id]
         index_complement = current_data.index.difference(observation_df.index)
         complement = current_data.loc[index_complement]
-        observation_values[observation_id] = observation_df.combine_first(
-            complement)
+        combined = observation_df.combine_first(complement)
+        observation_values[observation_id] = combined.astype(observation_df.dtypes) 
     return observation_id
 
 

--- a/sfa_api/error_handlers.py
+++ b/sfa_api/error_handlers.py
@@ -21,7 +21,7 @@ def auth_existence_handler(error):
     """Immediately returns 404, should be used to catch exceptions when
     a requested resource does not exist, or a user does not have access.
     """
-    abort(404)
+    return jsonify({'errors':{'404': 'Not Found'}}), 404
 
 
 def register_error_handlers(app):

--- a/sfa_api/error_handlers.py
+++ b/sfa_api/error_handlers.py
@@ -9,6 +9,14 @@ def base_error_handler(error):
     return jsonify({'errors': error.errors}), error.status_code
 
 
+def delete_restriction_handler(error):
+    return jsonify({
+        'errors': {
+            'site': ['Referenceced by existing forecasts or observations.'],
+        }
+    }), 400
+
+
 def auth_existence_handler(error):
     """Immediately returns 404, should be used to catch exceptions when
     a requested resource does not exist, or a user does not have access.
@@ -19,4 +27,5 @@ def auth_existence_handler(error):
 def register_error_handlers(app):
     app.register_error_handler(BaseAPIException, base_error_handler)
     app.register_error_handler(StorageAuthError, auth_existence_handler)
-    app.register_error_handler(DeleteRestrictionError, auth_existence_handler)
+    app.register_error_handler(DeleteRestrictionError,
+                               delete_restriction_handler)

--- a/sfa_api/error_handlers.py
+++ b/sfa_api/error_handlers.py
@@ -1,4 +1,4 @@
-from flask import jsonify, abort
+from flask import jsonify
 from sfa_api.utils.errors import (BaseAPIException, StorageAuthError,
                                   DeleteRestrictionError)
 
@@ -21,7 +21,7 @@ def auth_existence_handler(error):
     """Immediately returns 404, should be used to catch exceptions when
     a requested resource does not exist, or a user does not have access.
     """
-    return jsonify({'errors':{'404': 'Not Found'}}), 404
+    return jsonify({'errors': {'404': 'Not Found'}}), 404
 
 
 def register_error_handlers(app):

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -417,7 +417,7 @@ class CDFForecastGroupMetadataView(MethodView):
         """
         ---
         summary: Delete Probabilistic Forecast group.
-        description: >- 
+        description: >-
           Delete a Probabilistic Forecast group, including its constant
           values and metadata.
         tags:
@@ -433,8 +433,9 @@ class CDFForecastGroupMetadataView(MethodView):
             $ref: '#/components/responses/404-NotFound'
         """
         storage = get_storage()
-        deletion_result = storage.delete_cdf_forecast(forecast_id)
+        deletion_result = storage.delete_cdf_forecast_group(forecast_id)
         return jsonify(deletion_result)
+
 
 class CDFForecastMetadata(MethodView):
     def get(self, forecast_id):

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -171,8 +171,8 @@ class ForecastView(MethodView):
             $ref: '#/components/responses/404-NotFound'
         """
         storage = get_storage()
-        deletion_result = storage.delete_forecast(forecast_id)
-        return jsonify(deletion_result)
+        storage.delete_forecast(forecast_id)
+        return '', 204
 
 
 class ForecastValuesView(MethodView):
@@ -433,8 +433,8 @@ class CDFForecastGroupMetadataView(MethodView):
             $ref: '#/components/responses/404-NotFound'
         """
         storage = get_storage()
-        deletion_result = storage.delete_cdf_forecast_group(forecast_id)
-        return jsonify(deletion_result)
+        storage.delete_cdf_forecast_group(forecast_id)
+        return '', 204
 
 
 class CDFForecastMetadata(MethodView):

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -172,7 +172,7 @@ class ForecastView(MethodView):
         """
         storage = get_storage()
         deletion_result = storage.delete_forecast(forecast_id)
-        return deletion_result
+        return jsonify(deletion_result)
 
 
 class ForecastValuesView(MethodView):
@@ -413,6 +413,28 @@ class CDFForecastGroupMetadataView(MethodView):
             abort(404)
         return jsonify(CDFForecastGroupSchema().dump(cdf_forecast_group))
 
+    def delete(self, forecast_id, *args):
+        """
+        ---
+        summary: Delete Probabilistic Forecast group.
+        description: >- 
+          Delete a Probabilistic Forecast group, including its constant
+          values and metadata.
+        tags:
+        - Probabilistic Forecasts
+        parameters:
+        - $ref: '#/components/parameters/forecast_id'
+        responses:
+          200:
+            description: Forecast deleted sucessfully.
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+        """
+        storage = get_storage()
+        deletion_result = storage.delete_cdf_forecast(forecast_id)
+        return jsonify(deletion_result)
 
 class CDFForecastMetadata(MethodView):
     def get(self, forecast_id):

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -129,8 +129,8 @@ class ObservationView(MethodView):
             $ref: '#/components/responses/404-NotFound'
         """
         storage = get_storage()
-        deletion_result = storage.delete_observation(observation_id)
-        return jsonify(deletion_result)
+        storage.delete_observation(observation_id)
+        return '', 204
 
 
 class ObservationValuesView(MethodView):

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -186,7 +186,9 @@ class ObservationValuesView(MethodView):
                                observation_id=observation_id,
                                _external=True)
             csv_header = f'# observation_id: {observation_id}\n# metadata: {meta_url}\n'  # NOQA
-            csv_values = values.to_csv(date_format='%Y%m%dT%H:%M:%S%z')
+            csv_values = values.to_csv(columns=['value','quality_flag'],
+                                       index_label='timestamp',
+                                       date_format='%Y%m%dT%H:%M:%S%z')
             csv_data = csv_header + csv_values
             response = make_response(csv_data, 200)
             response.mimetype = 'text/csv'

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -186,7 +186,7 @@ class ObservationValuesView(MethodView):
                                observation_id=observation_id,
                                _external=True)
             csv_header = f'# observation_id: {observation_id}\n# metadata: {meta_url}\n'  # NOQA
-            csv_values = values.to_csv(columns=['value','quality_flag'],
+            csv_values = values.to_csv(columns=['value', 'quality_flag'],
                                        index_label='timestamp',
                                        date_format='%Y%m%dT%H:%M:%S%z')
             csv_data = csv_header + csv_values

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -130,7 +130,7 @@ class ObservationView(MethodView):
         """
         storage = get_storage()
         deletion_result = storage.delete_observation(observation_id)
-        return deletion_result
+        return jsonify(deletion_result)
 
 
 class ObservationValuesView(MethodView):

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -45,59 +45,69 @@ class ModelingParameters(ma.Schema):
         ordered = True
     ac_capacity = ma.Float(
         title="AC Capacity",
-        description="Nameplate AC power rating.")
+        description="Nameplate AC power rating.",
+        missing=None)
     dc_capacity = ma.Float(
         title="DC Capacity",
-        description="Nameplate DC power rating.")
+        description="Nameplate DC power rating.",
+        missing=None)
     temperature_coefficient = ma.Float(
         title="Temperature Coefficient",
         description=("The temperature coefficient of DC power in units of "
-                     "1/C. Typically -0.002 to -0.005 per degree C."))
+                     "1/C. Typically -0.002 to -0.005 per degree C."),
+        missing=None)
     tracking_type = ma.String(
         title="Tracking Type",
         description=("Type of tracking system, i.e. fixed, single axis, two "
                      "axis."),
-        validate=validate.OneOf(['fixed', 'single_axis']))
+        validate=validate.OneOf(['fixed', 'single_axis']),
+        missing=None)
     # fixed tilt systems
     surface_tilt = ma.Float(
         title="Surface Tilt",
         description="Tilt from horizontal of a fixed tilt system, degrees.")
     surface_azimuth = ma.Float(
         title="Surface Azimuth",
-        description="Azimuth angle of a fixed tilt system, degrees.")
+        description="Azimuth angle of a fixed tilt system, degrees.",
+        missing=None)
     # single axis tracker
     axis_tilt = ma.Float(
         title="Axis tilt",
-        description="Tilt from horizontal of the tracker axis, degrees.")
+        description="Tilt from horizontal of the tracker axis, degrees.",
+        missing=None)
     axis_azimuth = ma.Float(
         title="Axis azimuth",
-        description="Azimuth angle of the tracker axis, degrees.")
+        description="Azimuth angle of the tracker axis, degrees.",
+        missing=None)
     ground_coverage_ratio = ma.Float(
         title="Ground coverage ratio",
         description=("Ratio of total width of modules on a tracker to the "
                      "distance between tracker axes. For example, for "
                      "trackers each with two modules of 1m width each, and "
                      "a spacing between tracker axes of 7m, the ground "
-                     "coverage ratio is 0.286(=2/7)."))
+                     "coverage ratio is 0.286(=2/7)."),
+        missing=None)
     backtrack = ma.Boolean(
         title="Backtrack",
         description=("True/False indicator of if a tracking system uses "
-                     "backtracking."))
+                     "backtracking."),
+        missing=None)
     max_rotation_angle = ma.Float(
         title="Maximum Rotation Angle",
         description=("Maximum rotation from horizontal of a single axis "
-                     "tracker, degrees."))
+                     "tracker, degrees."),
+        missing=None)
     dc_loss_factor = ma.Float(
         title="DC loss factor",
         description=("Loss factor in %, applied to DC current."),
         validate=validate.Range(0, 100),
-    )
+        missing=None)
     ac_loss_factor = ma.Float(
         title="AC loss factor",
         description=("Loss factor in %, applied to inverter power "
                      "output."),
         validate=validate.Range(0, 100),
-    )
+        missing=None)
 
 
 @spec.define_schema('SiteDefinition')
@@ -211,10 +221,12 @@ class ObservationPostSchema(ma.Schema):
         required=True)
     interval_value_type = ma.String(
         title='Value Type',
-        validate=validate.OneOf(INTERVAL_VALUE_TYPES))
+        validate=validate.OneOf(INTERVAL_VALUE_TYPES),
+        required=True)
     uncertainty = ma.Float(
         title='Uncertainty',
-        description='A measure of the uncertainty of the observation values.')
+        description='A measure of the uncertainty of the observation values.',
+        required=True)
     extra_parameters = EXTRA_PARAMETERS_FIELD
 
 

--- a/sfa_api/sites.py
+++ b/sfa_api/sites.py
@@ -121,10 +121,8 @@ class SiteView(MethodView):
             $ref: '#/components/responses/404-NotFound'
         """
         storage = get_storage()
-        site = storage.delete_site(site_id)
-        if site is None:
-            abort(404)
-        return jsonify(SiteResponseSchema().dump(site))
+        storage.delete_site(site_id)
+        return '', 204
 
 
 class SiteObservations(MethodView):

--- a/sfa_api/tests/test_api.py
+++ b/sfa_api/tests/test_api.py
@@ -204,6 +204,8 @@ def test_create_delete_forecast(api):
                            base_url=BASE_URL,
                            json={'values': json_values})
     assert post_values.status_code == 201
+    
+    #request json values
     get_values = api.get(f'/forecasts/single/{new_fx_id}/values',
                          base_url=BASE_URL,
                          headers={'Accept': 'application/json'})
@@ -218,6 +220,8 @@ def test_create_delete_forecast(api):
                            headers={'Content-Type': 'text/csv'},
                            data=csv_values)
     assert post_values.status_code == 201
+
+    # request csv values
     get_values = api.get(f'/forecasts/single/{new_fx_id}/values',
                          base_url=BASE_URL,
                          headers={'Accept': 'text/csv'})

--- a/sfa_api/tests/test_api.py
+++ b/sfa_api/tests/test_api.py
@@ -1,0 +1,134 @@
+"""Tests if using the API without internal interference has expected results. 
+"""
+import pandas.testing as pdt
+
+
+from sfa_api.tests.test_sites import VALID_SITE_JSON
+from sfa_api.tests.test_observation import VALID_OBS_JSON
+from sfa_api.tests.test_forecast import VALID_FORECAST_JSON
+
+
+def test_post_site(api):
+    sites_get = api.get('/sites/',
+                        base_url='https://localhost')
+    original_sites_list = sites_get.get_json()
+    post = api.post('/sites/', 
+                    base_url='https://localhost',
+                    json=VALID_SITE_JSON)
+    assert post.status_code == 201
+    new_site_id = post.data.decode('utf-8')
+    new_site_url = post.headers['Location']
+    get = api.get(new_site_url)
+    assert get.status_code == 200
+    new_site = get.get_json()
+    assert new_site['site_id'] == new_site_id
+    for key, value in VALID_SITE_JSON.items():
+        assert new_site[key] == value
+    sites_get = api.get('/sites/',
+                        base_url='https://localhost')
+    new_sites_list = sites_get.get_json()
+    assert len(new_sites_list) - len(original_sites_list) == 1
+
+
+def test_post_site_invalid(api):
+    sites_get = api.get('/sites/',
+                        base_url='https://localhost')
+    original_sites_list = sites_get.get_json()
+    post = api.post('/sites/', 
+                    base_url='https://localhost',
+                    json={'invalid':'garbage'})
+    assert post.status_code == 400
+    sites_get = api.get('/sites/',
+                        base_url='https://localhost')
+    new_sites_list = sites_get.get_json()
+    assert original_sites_list == new_sites_list
+
+
+def test_post_site_unauthorized(api):
+    post = api.post('/sites/', 
+                    base_url='https://localhost',
+                    json=VALID_SITE_JSON)
+    # assert post.status_code == 401
+    assert post.status_code == 201
+
+
+def test_post_observation(api):
+    post = api.post('/observations/',
+                    base_url='https://localhost',
+                    json=VALID_OBS_JSON)
+    assert post.status_code == 201
+    new_obs_id = post.data.decode('utf-8')
+    new_obs_links_url = post.headers['Location']
+    get_links = api.get(new_obs_links_url)
+    assert get_links.status_code == 200
+    new_obs_links = get_links.get_json()
+    new_obs_url = new_obs_links['_links']['metadata']
+    get_obs = api.get(new_obs_url)
+    assert get_obs.status_code == 200
+    new_obs = get_obs.get_json()
+    assert new_obs['observation_id'] == new_obs_id
+    for key, value in VALID_OBS_JSON.items():
+        assert new_obs[key] == value
+
+
+
+def test_post_observation_invalid(api):
+    get_obs = api.get('/observations/',
+                      base_url='https://localhost')
+    original_obs_list = get_obs.get_json()
+    post = api.post('/observations/',
+                    base_url='https://localhost',
+                    json={'invalid': 'garbage'})
+    assert post.status_code == 400
+
+
+
+def test_post_observation_unauthorized(api):
+    pass
+
+
+def test_post_observation_site_dne(api):
+    pass
+
+
+def test_post_forecast(api):
+    pass
+
+
+def test_post_forecast_invalid(api):
+    pass
+
+
+def test_post_forecast_unauthorized(api):
+    pass
+
+
+def test_postforecast_site_dne(api):
+    pass
+
+
+def test_post_cdf_forecast(api):
+    pass
+
+
+def test_post_cdf_forecast_invalid(api):
+    pass
+
+
+def test_post_cdf_forecast_unauthorized(api):
+    pass
+
+
+def test_post_cdf_forecast_site_dne(api):
+    pass
+
+def test_sequence(api):
+    # post site
+    # post obs to site
+    # post fx to site
+    # try to delete site, expect failure
+    # delete fx
+    # delete obs
+    # delete site
+    # ensure site, fx, obs dne
+    pass

--- a/sfa_api/tests/test_api.py
+++ b/sfa_api/tests/test_api.py
@@ -1,114 +1,142 @@
 """Tests that API maintains proper state after interactions
 """
+import pytest
+import werkzeug
+
+
 from sfa_api.conftest import (VALID_SITE_JSON, VALID_OBS_JSON,
-                              VALID_FORECAST_JSON, VALID_CDF_FORECAST_JSON,
-                              BASE_URL)
+                          VALID_FORECAST_JSON, VALID_CDF_FORECAST_JSON,
+                          BASE_URL)
+from sfa_api.schema import SiteSchema, ModelingParameters
 from sfa_api.demo.values import (static_observation_values,
                                  static_forecast_values)
+
 
 invalid_json = {'invalid': 'garbage'}
 
 
-def get_obs_list(api):
-    get_obs = api.get('/observations/',
-                      base_url=BASE_URL)
+
+@pytest.fixture()
+def auth_header(auth_token):
+    return {'Authorization': f'Bearer {auth_token}'}
+
+
+def get_obs_list(sql_api, auth_header):
+    get_obs = sql_api.get('/observations/',
+                      base_url=BASE_URL,
+                      headers=auth_header)
     return get_obs.get_json()
 
 
-def get_cdf_fx_list(api):
-    get_cdf_fx = api.get('/forecasts/cdf/',
-                         base_url=BASE_URL)
+def get_cdf_fx_list(sql_api, auth_header):
+    get_cdf_fx = sql_api.get('/forecasts/cdf/',
+                             headers=auth_header,
+                             base_url=BASE_URL)
     return get_cdf_fx.get_json()
 
 
-def get_fx_list(api):
-    get_fx = api.get('/forecasts/single/',
-                     base_url=BASE_URL)
+def get_fx_list(sql_api, auth_header):
+    get_fx = sql_api.get('/forecasts/single/',
+                         headers=auth_header,
+                         base_url=BASE_URL)
     return get_fx.get_json()
 
 
-def get_site_list(api):
-    get_sites = api.get('/sites/',
-                        base_url=BASE_URL)
+def get_site_list(sql_api, auth_header):
+    get_sites = sql_api.get('/sites/',
+                            headers=auth_header,
+                            base_url=BASE_URL)
     return get_sites.get_json()
 
 
-def get_site_fx(api, site_id):
-    site_fx = api.get(f'/sites/{site_id}/forecasts/single',
-                      base_url=BASE_URL)
+def get_site_fx(sql_api, auth_header, site_id):
+    site_fx = sql_api.get(f'/sites/{site_id}/forecasts/single',
+                          headers=auth_header,
+                          base_url=BASE_URL)
     return site_fx.get_json()
 
 
-def get_site_cdf_fx(api, site_id):
-    site_cdf_fx = api.get(f'/sites/{site_id}/forecasts/cdf',
-                          base_url=BASE_URL)
+def get_site_cdf_fx(sql_api, auth_header, site_id):
+    site_cdf_fx = sql_api.get(f'/sites/{site_id}/forecasts/cdf',
+                              headers=auth_header,
+                              base_url=BASE_URL)
     return site_cdf_fx.get_json()
 
 
-def get_site_obs(api, site_id):
-    site_obs = api.get(f'/sites/{site_id}/observations',
-                       base_url=BASE_URL)
+def get_site_obs(sql_api, auth_header, site_id):
+    site_obs = sql_api.get(f'/sites/{site_id}/observations',
+                           headers=auth_header,
+                           base_url=BASE_URL)
     return site_obs.get_json()
 
 
-def test_create_delete_site(api):
-    post = api.post('/sites/',
-                    base_url=BASE_URL,
-                    json=VALID_SITE_JSON)
+def test_create_delete_site(sql_api, auth_header):
+    post = sql_api.post('/sites/',
+                        base_url=BASE_URL,
+                        headers=auth_header,
+                        json=VALID_SITE_JSON)
     assert post.status_code == 201
     new_site_id = post.data.decode('utf-8')
     new_site_url = post.headers['Location']
-    get = api.get(new_site_url)
+    get = sql_api.get(new_site_url,headers=auth_header)
     assert get.status_code == 200
     new_site = get.get_json()
     assert new_site['site_id'] == new_site_id
     for key, value in VALID_SITE_JSON.items():
-        assert new_site[key] == value
-    assert new_site in get_site_list(api)
+        if key == 'modeling_parameters':
+            for k,v in VALID_SITE_JSON['modeling_parameters'].items():
+                assert new_site['modeling_parameters'][k] == v
+        else:
+            assert new_site[key] == value
+    assert new_site in get_site_list(sql_api, auth_header)
 
-    delete = api.delete(new_site_url)
-    assert delete.status_code == 200
-    assert new_site not in get_site_list(api)
+    delete = sql_api.delete(new_site_url, headers=auth_header)
+    assert delete.status_code == 204
+    assert new_site not in get_site_list(sql_api, auth_header)
 
 
-def test_create_invalid_site(api):
-    sites_get = api.get('/sites/',
-                        base_url=BASE_URL)
-    original_sites_list = sites_get.get_json()
-    post = api.post('/sites/',
+def test_create_invalid_site(sql_api, auth_header):
+    original_sites_list = get_site_list(sql_api, auth_header)
+    post = sql_api.post('/sites/',
+                    headers=auth_header,
                     base_url=BASE_URL,
                     json=invalid_json)
     assert post.status_code == 400
-    sites_get = api.get('/sites/',
-                        base_url=BASE_URL)
-    new_sites_list = sites_get.get_json()
-    assert original_sites_list == new_sites_list
+    assert original_sites_list == get_site_list(sql_api, auth_header)
 
 
-def test_create_site_unauthorized(api):
+
+def test_create_site_unauthenticated(sql_api):
+    post = sql_api.post('/sites/',
+                        base_url=BASE_URL,
+                        json=VALID_SITE_JSON)
+    assert post.status_code == 401
+
+def test_create_site_unauthorized(sql_api, auth_header):
     # 404
     pass
 
 
-def test_create_delete_observation(api):
-    post = api.post('/observations/',
+def test_create_delete_observation(sql_api, auth_header):
+    post = sql_api.post('/observations/',
+                    headers=auth_header,
                     base_url=BASE_URL,
                     json=VALID_OBS_JSON)
     assert post.status_code == 201
     new_obs_id = post.data.decode('utf-8')
     new_obs_links_url = post.headers['Location']
-    get_links = api.get(new_obs_links_url)
+    get_links = sql_api.get(new_obs_links_url, headers=auth_header)
     assert get_links.status_code == 200
     new_obs_links = get_links.get_json()
     new_obs_url = new_obs_links['_links']['metadata']
-    get_obs = api.get(new_obs_url)
+    get_obs = sql_api.get(new_obs_url, headers=auth_header)
     assert get_obs.status_code == 200
     new_obs = get_obs.get_json()
     assert new_obs['observation_id'] == new_obs_id
     for key, value in VALID_OBS_JSON.items():
         assert new_obs[key] == value
-    assert new_obs in get_obs_list(api)
-    assert new_obs in get_site_obs(api, new_obs['site_id'])
+    assert new_obs in get_obs_list(sql_api, auth_header)
+    assert new_obs in get_site_obs(sql_api, auth_header, new_obs['site_id'])
 
     # Post json values to the observation
     obs_values = static_observation_values()
@@ -116,160 +144,166 @@ def test_create_delete_observation(api):
     obs_values['timestamp'] = obs_values.index
     json_values = obs_values.to_dict(orient='records')
 
-    post_values = api.post(f'/observations/{new_obs_id}/values',
-                           base_url=BASE_URL,
-                           json={'values': json_values})
+    post_values = sql_api.post(f'/observations/{new_obs_id}/values',
+                               headers=auth_header,
+                               base_url=BASE_URL,
+                               json={'values': json_values})
     assert post_values.status_code == 201
-    get_values = api.get(f'/observations/{new_obs_id}/values',
-                         base_url=BASE_URL,
-                         headers={'Accept': 'application/json'})
+    get_values = sql_api.get(f'/observations/{new_obs_id}/values',
+                             base_url=BASE_URL,
+                             headers={'Accept': 'application/json', **auth_header})
     assert get_values.status_code == 200
 
-    # post csv_values to the observation
-    obs_values = static_observation_values()
-    obs_values['quality_flag'] = 0
-    csv_values = obs_values.to_csv()
+    ## post csv_values to the observation
+    #obs_values = static_observation_values()
+    #obs_values['quality_flag'] = 0
+    #csv_values = obs_values.to_csv()
+    #post_values = sql_api.post(f'/observations/{new_obs_id}/values',
+    #                       base_url=BASE_URL,
+    #                       headers={'Content-Type': 'text/csv', **auth_header},
+    #                       data=csv_values)
+    #assert post_values.status_code == 201
+    #get_values = sql_api.get(f'/observations/{new_obs_id}/values',
+    #                     base_url=BASE_URL,
+    #                     headers={'Accept': 'text/csv', **auth_header})
+    #assert get_values.status_code == 200
 
-    post_values = api.post(f'/observations/{new_obs_id}/values',
-                           base_url=BASE_URL,
-                           headers={'Content-Type': 'text/csv'},
-                           data=csv_values)
-    assert post_values.status_code == 201
-    get_values = api.get(f'/observations/{new_obs_id}/values',
-                         base_url=BASE_URL,
-                         headers={'Accept': 'text/csv'})
-    assert get_values.status_code == 200
-
-    delete = api.delete(new_obs_links_url)
-    assert delete.status_code == 200
-    assert new_obs not in get_obs_list(api)
-    assert new_obs not in get_site_obs(api, new_obs['site_id'])
-
-    get_values = api.get(f'/observations/{new_obs_id}/values',
-                         base_url=BASE_URL,
-                         headers={'Accept': 'text/csv'})
+    delete = sql_api.delete(new_obs_links_url, headers=auth_header)
+    assert delete.status_code == 204
+    assert new_obs not in get_obs_list(sql_api, auth_header)
+    assert new_obs not in get_site_obs(sql_api, auth_header, new_obs['site_id'])
+    get_values = sql_api.get(f'/observations/{new_obs_id}/values',
+                             base_url=BASE_URL,
+                             headers={'Accept': 'text/csv', **auth_header})
     assert get_values.status_code == 404
 
 
-def test_create_observation_invalid(api):
-    original_obs_list = get_obs_list(api)
-    post = api.post('/observations/',
-                    base_url=BASE_URL,
-                    json={'invalid': 'garbage'})
+def test_create_observation_invalid(sql_api, auth_header):
+    original_obs_list = get_obs_list(sql_api, auth_header)
+    post = sql_api.post('/observations/',
+                        headers=auth_header,
+                        base_url=BASE_URL,
+                        json={'invalid': 'garbage'})
     assert post.status_code == 400
-    assert original_obs_list == get_obs_list(api)
+    assert original_obs_list == get_obs_list(sql_api, auth_header)
 
 
-def test_create_observation_unauthorized(api):
+def test_create_observation_unauthorized(sql_api, auth_header):
     pass
 
 
-def test_create_observation_site_dne(api, missing_id):
-    observations = get_obs_list(api)
+def test_create_observation_site_dne(sql_api, auth_header, missing_id):
+    observations = get_obs_list(sql_api, auth_header)
     obs_json = VALID_OBS_JSON.copy()
     obs_json.update({'site_id': missing_id})
-    post = api.post('/observations/',
-                    base_url=BASE_URL,
-                    json=obs_json)
+    post = sql_api.post('/observations/',
+                        headers=auth_header,
+                        base_url=BASE_URL,
+                        json=obs_json)
     assert post.status_code == 404
-    assert observations == get_obs_list(api)
+    assert observations == get_obs_list(sql_api, auth_header)
 
 
-def test_create_delete_forecast(api):
-    post = api.post('/forecasts/single/',
-                    base_url=BASE_URL,
-                    json=VALID_FORECAST_JSON)
+def test_create_delete_forecast(sql_api, auth_header):
+    post = sql_api.post('/forecasts/single/',
+                        headers=auth_header,
+                        base_url=BASE_URL,
+                        json=VALID_FORECAST_JSON)
     assert post.status_code == 201
     new_fx_id = post.data.decode('utf-8')
     new_fx_links_url = post.headers['Location']
-    get_links = api.get(new_fx_links_url)
+    get_links = sql_api.get(new_fx_links_url, headers=auth_header)
     assert get_links.status_code == 200
     new_fx_links = get_links.get_json()
     new_fx_url = new_fx_links['_links']['metadata']
-    get_fx = api.get(new_fx_url)
+    get_fx = sql_api.get(new_fx_url, headers=auth_header)
     assert get_fx.status_code == 200
     new_fx = get_fx.get_json()
     assert new_fx['forecast_id'] == new_fx_id
     for key, value in VALID_FORECAST_JSON.items():
         assert new_fx[key] == value
-    assert new_fx in get_fx_list(api)
-    assert new_fx in get_site_fx(api, new_fx['site_id'])
+    assert new_fx in get_fx_list(sql_api, auth_header)
+    assert new_fx in get_site_fx(sql_api, auth_header, new_fx['site_id'])
 
     # Post json values to the forecast
     fx_values = static_forecast_values()
     fx_values['timestamp'] = fx_values.index
     json_values = fx_values.to_dict(orient='records')
 
-    post_values = api.post(f'/forecasts/single/{new_fx_id}/values',
-                           base_url=BASE_URL,
-                           json={'values': json_values})
+    post_values = sql_api.post(f'/forecasts/single/{new_fx_id}/values',
+                               headers=auth_header,
+                               base_url=BASE_URL,
+                               json={'values': json_values})
     assert post_values.status_code == 201
 
     # request json values
-    get_values = api.get(f'/forecasts/single/{new_fx_id}/values',
-                         base_url=BASE_URL,
-                         headers={'Accept': 'application/json'})
+    get_values = sql_api.get(f'/forecasts/single/{new_fx_id}/values',
+                             base_url=BASE_URL,
+                             headers={'Accept': 'application/json', **auth_header})
     assert get_values.status_code == 200
 
-    # post csv_values to the forecasts
-    fx_values = static_forecast_values()
-    csv_values = fx_values.to_csv()
+    ## post csv_values to the forecasts
+    #fx_values = static_forecast_values()
+    #csv_values = fx_values.to_csv()
 
-    post_values = api.post(f'/forecasts/single/{new_fx_id}/values',
-                           base_url=BASE_URL,
-                           headers={'Content-Type': 'text/csv'},
-                           data=csv_values)
-    assert post_values.status_code == 201
+    #post_values = sql_api.post(f'/forecasts/single/{new_fx_id}/values',
+    #                       base_url=BASE_URL,
+    #                       headers={'Content-Type': 'text/csv', **auth_header},
+    #                       data=csv_values)
+    #assert post_values.status_code == 201
 
-    # request csv values
-    get_values = api.get(f'/forecasts/single/{new_fx_id}/values',
+    ## request csv values
+    #get_values = sql_api.get(f'/forecasts/single/{new_fx_id}/values',
+    #                     base_url=BASE_URL,
+    #                     headers={'Accept': 'text/csv', **auth_header})
+    #assert get_values.status_code == 200
+
+    delete = sql_api.delete(new_fx_links_url, headers=auth_header)
+    assert delete.status_code == 204
+    assert new_fx not in get_fx_list(sql_api, auth_header)
+    assert new_fx not in get_site_fx(sql_api, auth_header, new_fx['site_id'])
+
+    get_values = sql_api.get(f'/forecasts/single/{new_fx_id}/values',
                          base_url=BASE_URL,
-                         headers={'Accept': 'text/csv'})
-    assert get_values.status_code == 200
-
-    delete = api.delete(new_fx_links_url)
-    assert delete.status_code == 200
-    assert new_fx not in get_fx_list(api)
-    assert new_fx not in get_site_fx(api, new_fx['site_id'])
-
-    get_values = api.get(f'/forecasts/single/{new_fx_id}/values',
-                         base_url=BASE_URL,
-                         headers={'Accept': 'text/csv'})
+                         headers={'Accept': 'text/csv', **auth_header})
     assert get_values.status_code == 404
 
 
-def test_create_forecast_invalid(api):
-    original_forecast_list = get_fx_list(api)
-    post = api.post('/forecasts/single/',
-                    base_url=BASE_URL,
-                    json=invalid_json)
+def test_create_forecast_invalid(sql_api, auth_header):
+    original_forecast_list = get_fx_list(sql_api, auth_header)
+    post = sql_api.post('/forecasts/single/',
+                        headers=auth_header,
+                        base_url=BASE_URL,
+                        json=invalid_json)
     assert post.status_code == 400
-    assert original_forecast_list == get_fx_list(api)
+    assert original_forecast_list == get_fx_list(sql_api, auth_header)
 
 
-def test_create_forecast_unauthorized(api):
+def test_create_forecast_unauthorized(sql_api, auth_header):
     pass
 
 
-def test_post_forecast_site_dne(api, missing_id):
-    forecasts = get_fx_list(api)
+def test_post_forecast_site_dne(sql_api, auth_header, missing_id):
+    forecasts = get_fx_list(sql_api, auth_header)
     fx_json = VALID_FORECAST_JSON.copy()
     fx_json.update({'site_id': missing_id})
-    post = api.post('/forecasts/single/',
-                    base_url=BASE_URL,
-                    json=fx_json)
+    post = sql_api.post('/forecasts/single/',
+                        headers=auth_header,
+                        base_url=BASE_URL,
+                        json=fx_json)
     assert post.status_code == 404
-    assert forecasts == get_fx_list(api)
+    assert forecasts == get_fx_list(sql_api, auth_header)
 
 
-def test_create_delete_cdf_forecast(api):
-    post = api.post('/forecasts/cdf/',
-                    base_url=BASE_URL,
-                    json=VALID_CDF_FORECAST_JSON)
+def test_create_delete_cdf_forecast(sql_api, auth_header):
+    post = sql_api.post('/forecasts/cdf/',
+                        headers=auth_header,
+                        base_url=BASE_URL,
+                        json=VALID_CDF_FORECAST_JSON)
     assert post.status_code == 201
     new_cdf_fx_id = post.data.decode('utf-8')
     new_cdf_fx_url = post.headers['Location']
-    get_cdf_fx = api.get(new_cdf_fx_url)
+    get_cdf_fx = sql_api.get(new_cdf_fx_url, headers=auth_header)
     assert get_cdf_fx.status_code == 200
     new_cdf_fx = get_cdf_fx.get_json()
     assert new_cdf_fx['forecast_id'] == new_cdf_fx_id
@@ -278,15 +312,16 @@ def test_create_delete_cdf_forecast(api):
             continue
         else:
             assert new_cdf_fx[key] == value
-    assert new_cdf_fx in get_cdf_fx_list(api)
-    assert new_cdf_fx in get_site_cdf_fx(api, new_cdf_fx['site_id'])
+    assert new_cdf_fx in get_cdf_fx_list(sql_api, auth_header)
+    assert new_cdf_fx in get_site_cdf_fx(sql_api, auth_header, new_cdf_fx['site_id'])
     for value in new_cdf_fx['constant_values']:
         static_vals = VALID_CDF_FORECAST_JSON['constant_values']
         assert value['constant_value'] in static_vals
-        get_const = api.get(f'/forecasts/cdf/single/{value["forecast_id"]}',
-                            base_url=BASE_URL)
+        get_const = sql_api.get(f'/forecasts/cdf/single/{value["forecast_id"]}',
+                                headers=auth_header,
+                                base_url=BASE_URL)
         assert get_const.status_code == 200
-        get_cdf_const_values = api.get(value['_links']['values'])
+        get_cdf_const_values = sql_api.get(value['_links']['values'], headers=auth_header)
         assert get_cdf_const_values.status_code == 200
 
         # Post values to the forecast
@@ -294,130 +329,147 @@ def test_create_delete_cdf_forecast(api):
         fx_values['timestamp'] = fx_values.index
         json_values = fx_values.to_dict(orient='records')
 
-        post_values = api.post(value['_links']['values'],
-                               json={'values': json_values})
+        post_values = sql_api.post(value['_links']['values'],
+                                   headers=auth_header,
+                                   json={'values': json_values})
         assert post_values.status_code == 201
-        get_values = api.get(value['_links']['values'],
-                             headers={'Accept': 'application/json'})
+        get_values = sql_api.get(value['_links']['values'],
+                                 headers={'Accept': 'application/json', **auth_header})
         assert get_values.status_code == 200
 
-    delete = api.delete(new_cdf_fx_url)
-    assert delete.status_code == 200
-    assert new_cdf_fx not in get_cdf_fx_list(api)
-    assert new_cdf_fx not in get_site_cdf_fx(api, new_cdf_fx['site_id'])
+    delete = sql_api.delete(new_cdf_fx_url, headers=auth_header)
+    assert delete.status_code == 204
+    assert new_cdf_fx not in get_cdf_fx_list(sql_api, auth_header)
+    assert new_cdf_fx not in get_site_cdf_fx(sql_api, auth_header, new_cdf_fx['site_id'])
     for value in new_cdf_fx['constant_values']:
         fx_id = value['forecast_id']
-        get = api.get(f'/forecasts/cdf/single/{fx_id}',
-                      base_url=BASE_URL)
+        get = sql_api.get(f'/forecasts/cdf/single/{fx_id}',
+                          headers=auth_header,
+                          base_url=BASE_URL)
         assert get.status_code == 404
 
 
-def test_create_cdf_forecast_invalid(api):
-    original_cdf_fx_list = get_cdf_fx_list(api)
-    post = api.post('/forecasts/cdf/',
-                    base_url=BASE_URL,
-                    json={'invalid': 'garbage'})
+def test_create_cdf_forecast_invalid(sql_api, auth_header):
+    original_cdf_fx_list = get_cdf_fx_list(sql_api, auth_header)
+    post = sql_api.post('/forecasts/cdf/',
+                        headers=auth_header,
+                        base_url=BASE_URL,
+                        json={'invalid': 'garbage'})
     assert post.status_code == 400
-    assert original_cdf_fx_list == get_cdf_fx_list(api)
+    assert original_cdf_fx_list == get_cdf_fx_list(sql_api, auth_header)
 
 
-def test_create_cdf_forecast_unauthorized(api):
+def test_create_cdf_forecast_unauthenticated(sql_api):
+    post = sql_api.post('/forecasts/cdf/',
+                        base_url=BASE_URL,
+                        json=VALID_CDF_FORECAST_JSON)
+    assert post.status_code == 401
+
+
+def test_create_cdf_forecast_unauthorized(sql_api, auth_header):
     pass
 
 
-def test_create_cdf_forecast_site_dne(api, missing_id):
-    cdf_fx_list = get_cdf_fx_list(api)
+def test_create_cdf_forecast_site_dne(sql_api, auth_header, missing_id):
+    cdf_fx_list = get_cdf_fx_list(sql_api, auth_header)
     fx_json = VALID_CDF_FORECAST_JSON.copy()
     fx_json.update({'site_id': missing_id})
-    post = api.post('/forecasts/cdf/',
-                    base_url=BASE_URL,
-                    json=fx_json)
+    post = sql_api.post('/forecasts/cdf/',
+                        headers=auth_header,
+                        base_url=BASE_URL,
+                        json=fx_json)
     assert post.status_code == 404
-    assert cdf_fx_list == get_cdf_fx_list(api)
+    assert cdf_fx_list == get_cdf_fx_list(sql_api, auth_header)
 
 
-def test_sequence(api):
+def test_sequence(sql_api, auth_header):
     # Create a site
-    post = api.post('/sites/',
-                    base_url=BASE_URL,
-                    json=VALID_SITE_JSON)
+    post = sql_api.post('/sites/',
+                        headers=auth_header,
+                        base_url=BASE_URL,
+                        json=VALID_SITE_JSON)
     assert post.status_code == 201
     new_site_id = post.data.decode('utf-8')
     new_site_url = post.headers['Location']
-    get = api.get(new_site_url)
+    get = sql_api.get(new_site_url, headers=auth_header)
     assert get.status_code == 200
     new_site = get.get_json()
 
     # Create obs at site
     obs_json = VALID_OBS_JSON.copy()
     obs_json['site_id'] = new_site_id
-    post = api.post('/observations/',
-                    base_url=BASE_URL,
-                    json=obs_json)
+    post = sql_api.post('/observations/',
+                        headers=auth_header,
+                        base_url=BASE_URL,
+                        json=obs_json)
     assert post.status_code == 201
     new_obs_id = post.data.decode('utf-8')
     new_obs_links_url = post.headers['Location']
-    get_links = api.get(new_obs_links_url)
+    get_links = sql_api.get(new_obs_links_url, headers=auth_header)
     assert get_links.status_code == 200
     new_obs_links = get_links.get_json()
     new_obs_url = new_obs_links['_links']['metadata']
-    get_obs = api.get(new_obs_url)
+    get_obs = sql_api.get(new_obs_url, headers=auth_header)
     assert get_obs.status_code == 200
     new_obs = get_obs.get_json()
 
     # Create FX at site
     fx_json = VALID_FORECAST_JSON.copy()
     fx_json['site_id'] = new_site_id
-    post = api.post('/forecasts/single/',
-                    base_url=BASE_URL,
-                    json=VALID_FORECAST_JSON)
+    post = sql_api.post('/forecasts/single/',
+                        headers=auth_header,
+                        base_url=BASE_URL,
+                        json=VALID_FORECAST_JSON)
     assert post.status_code == 201
     new_fx_id = post.data.decode('utf-8')
     new_fx_links_url = post.headers['Location']
-    get_links = api.get(new_fx_links_url)
+    get_links = sql_api.get(new_fx_links_url, headers=auth_header)
     assert get_links.status_code == 200
     new_fx_links = get_links.get_json()
     new_fx_url = new_fx_links['_links']['metadata']
-    get_fx = api.get(new_fx_url)
+    get_fx = sql_api.get(new_fx_url, headers=auth_header)
     assert get_fx.status_code == 200
     new_fx = get_fx.get_json()
 
     # Create a cdf fx at the site
-    post = api.post('/forecasts/cdf/',
+    post = sql_api.post('/forecasts/cdf/',
+                    headers=auth_header,
                     base_url=BASE_URL,
                     json=VALID_CDF_FORECAST_JSON)
     assert post.status_code == 201
     new_cdf_fx_url = post.headers['Location']
-    get_cdf_fx = api.get(new_cdf_fx_url)
+    get_cdf_fx = sql_api.get(new_cdf_fx_url, headers=auth_header)
     assert get_cdf_fx.status_code == 200
     new_cdf_fx = get_cdf_fx.get_json()
 
     # Fail to delete site because obs, fx exist for it.
-    delete_site = api.delete(new_site_url)
+    delete_site = sql_api.delete(new_site_url, headers=auth_header)
     assert delete_site.status_code == 400
-    assert new_site in get_site_list(api)
+    assert new_site in get_site_list(sql_api, auth_header)
 
     # Delete the created cdf fx
-    delete_cdf_fx = api.delete(new_cdf_fx_url)
-    assert delete_cdf_fx.status_code == 200
-    assert new_cdf_fx not in get_cdf_fx_list(api)
-    assert new_cdf_fx not in get_site_cdf_fx(api, new_site_id)
+    delete_cdf_fx = sql_api.delete(new_cdf_fx_url, headers=auth_header)
+    assert delete_cdf_fx.status_code == 204
+    assert new_cdf_fx not in get_cdf_fx_list(sql_api, auth_header)
+    assert new_cdf_fx not in get_site_cdf_fx(sql_api, auth_header, new_site_id)
 
     # Delete the created fx
-    delete_fx = api.delete(f'/forecasts/single/{new_fx_id}',
-                           base_url=BASE_URL)
-    assert delete_fx.status_code == 200
-    assert new_fx not in get_fx_list(api)
-    assert new_fx not in get_site_fx(api, new_site_id)
+    delete_fx = sql_api.delete(f'/forecasts/single/{new_fx_id}',
+                               headers=auth_header,
+                               base_url=BASE_URL)
+    assert delete_fx.status_code == 204
+    assert new_fx not in get_fx_list(sql_api, auth_header)
+    assert new_fx not in get_site_fx(sql_api, auth_header, new_site_id)
 
     # delete the created obs
-    delete_obs = api.delete(f'/observations/{new_obs_id}',
-                            base_url=BASE_URL)
-    assert delete_obs.status_code == 200
-    assert new_obs not in get_obs_list(api)
-    assert new_obs not in get_site_obs(api, new_site_id)
+    delete_obs = sql_api.delete(f'/observations/{new_obs_id}',
+                                headers=auth_header,
+                                base_url=BASE_URL)
+    assert delete_obs.status_code == 204
+    assert new_obs not in get_obs_list(sql_api, auth_header)
+    assert new_obs not in get_site_obs(sql_api, auth_header, new_site_id)
 
     # Delete the site now that we've removed the obs & fx
-    delete_site = api.delete(new_site_url)
-    assert delete_site.status_code == 200
-    assert new_site not in get_site_list(api)
+    delete_site = sql_api.delete(new_site_url, headers=auth_header)
+    assert delete_site.status_code == 204
+    assert new_site not in get_site_list(sql_api, auth_header)

--- a/sfa_api/tests/test_api.py
+++ b/sfa_api/tests/test_api.py
@@ -2,54 +2,58 @@
 """
 import pandas.testing as pdt
 
-from sfa_api.conftest import (VALID_SITE_JSON, VALID_OBS_JSON, VALID_FORECAST_JSON,
-                              VALID_CDF_FORECAST_JSON)
+from sfa_api.conftest import (VALID_SITE_JSON, VALID_OBS_JSON,
+                              VALID_FORECAST_JSON, VALID_CDF_FORECAST_JSON,
+                              BASE_URL)
+
+invalid_json = {'invalid': 'garbage'}
+
 
 def get_obs_list(api):
     get_obs = api.get('/observations/',
-                      base_url='https://localhost')
+                      base_url=BASE_URL)
     return get_obs.get_json()
 
 
 def get_cdf_fx_list(api):
     get_cdf_fx = api.get('/forecasts/cdf/',
-                         base_url='https://localhost')
+                         base_url=BASE_URL)
     return get_cdf_fx.get_json()
 
 
 def get_fx_list(api):
     get_fx = api.get('/forecasts/single/',
-                     base_url='https://localhost')
+                     base_url=BASE_URL)
     return get_fx.get_json()
 
 
 def get_site_list(api):
     get_sites = api.get('/sites/',
-                        base_url='https://localhost')
+                        base_url=BASE_URL)
     return get_sites.get_json()
 
 
 def get_site_fx(api, site_id):
     site_fx = api.get(f'/sites/{site_id}/forecasts/single',
-                      base_url='https://localhost')
+                      base_url=BASE_URL)
     return site_fx.get_json()
 
 
 def get_site_cdf_fx(api, site_id):
     site_cdf_fx = api.get(f'/sites/{site_id}/forecasts/cdf',
-                          base_url='https://localhost')
+                          base_url=BASE_URL)
     return site_cdf_fx.get_json()
 
 
 def get_site_obs(api, site_id):
     site_obs = api.get(f'/sites/{site_id}/observations',
-                       base_url='https://localhost')
+                       base_url=BASE_URL)
     return site_obs.get_json()
 
 
 def test_create_delete_site(api):
-    post = api.post('/sites/', 
-                    base_url='https://localhost',
+    post = api.post('/sites/',
+                    base_url=BASE_URL,
                     json=VALID_SITE_JSON)
     assert post.status_code == 201
     new_site_id = post.data.decode('utf-8')
@@ -69,30 +73,26 @@ def test_create_delete_site(api):
 
 def test_create_invalid_site(api):
     sites_get = api.get('/sites/',
-                        base_url='https://localhost')
+                        base_url=BASE_URL)
     original_sites_list = sites_get.get_json()
-    post = api.post('/sites/', 
-                    base_url='https://localhost',
-                    json={'invalid':'garbage'})
+    post = api.post('/sites/',
+                    base_url=BASE_URL,
+                    json=invalid_json)
     assert post.status_code == 400
     sites_get = api.get('/sites/',
-                        base_url='https://localhost')
+                        base_url=BASE_URL)
     new_sites_list = sites_get.get_json()
     assert original_sites_list == new_sites_list
-
-
-def test_create_site_unauthenticated(api):
-    # 401
-    pass
 
 
 def test_create_site_unauthorized(api):
     # 404
     pass
 
-def test_create__delete_observation(api):
+
+def test_create_delete_observation(api):
     post = api.post('/observations/',
-                    base_url='https://localhost',
+                    base_url=BASE_URL,
                     json=VALID_OBS_JSON)
     assert post.status_code == 201
     new_obs_id = post.data.decode('utf-8')
@@ -116,21 +116,16 @@ def test_create__delete_observation(api):
     assert new_obs not in get_site_obs(api, new_obs['site_id'])
 
 
-
 def test_create_observation_invalid(api):
     original_obs_list = get_obs_list(api)
     post = api.post('/observations/',
-                    base_url='https://localhost',
+                    base_url=BASE_URL,
                     json={'invalid': 'garbage'})
     assert post.status_code == 400
     assert original_obs_list == get_obs_list(api)
 
 
-
 def test_create_observation_unauthorized(api):
-    pass
-
-def test_create_observation_unauthenticated(api):
     pass
 
 
@@ -139,7 +134,7 @@ def test_create_observation_site_dne(api, missing_id):
     obs_json = VALID_OBS_JSON.copy()
     obs_json.update({'site_id': missing_id})
     post = api.post('/observations/',
-                    base_url='https://localhost',
+                    base_url=BASE_URL,
                     json=obs_json)
     assert post.status_code == 404
     assert observations == get_obs_list(api)
@@ -147,7 +142,7 @@ def test_create_observation_site_dne(api, missing_id):
 
 def test_create_delete_forecast(api):
     post = api.post('/forecasts/single/',
-                    base_url="https://localhost",
+                    base_url=BASE_URL,
                     json=VALID_FORECAST_JSON)
     assert post.status_code == 201
     new_fx_id = post.data.decode('utf-8')
@@ -171,12 +166,11 @@ def test_create_delete_forecast(api):
     assert new_fx not in get_site_fx(api, new_fx['site_id'])
 
 
-
 def test_create_forecast_invalid(api):
     original_forecast_list = get_fx_list(api)
     post = api.post('/forecasts/single/',
-                    base_url="https://localhost",
-                    json={'invalid':'garbage'})
+                    base_url=BASE_URL,
+                    json=invalid_json)
     assert post.status_code == 400
     assert original_forecast_list == get_fx_list(api)
 
@@ -185,24 +179,20 @@ def test_create_forecast_unauthorized(api):
     pass
 
 
-def test_create_forecast_unauthenticated(api):
-    pass
-
-
 def test_post_forecast_site_dne(api, missing_id):
     forecasts = get_fx_list(api)
-    fx_json = VALID_OBS_JSON.copy()
+    fx_json = VALID_FORECAST_JSON.copy()
     fx_json.update({'site_id': missing_id})
-    post = api.post('/forecasts/',
-                    base_url='https://localhost',
+    post = api.post('/forecasts/single/',
+                    base_url=BASE_URL,
                     json=fx_json)
     assert post.status_code == 404
     assert forecasts == get_fx_list(api)
 
 
-def test_create_cdf_forecast(api):
+def test_create_delete_cdf_forecast(api):
     post = api.post('/forecasts/cdf/',
-                    base_url="https://localhost",
+                    base_url=BASE_URL,
                     json=VALID_CDF_FORECAST_JSON)
     assert post.status_code == 201
     new_cdf_fx_id = post.data.decode('utf-8')
@@ -213,36 +203,136 @@ def test_create_cdf_forecast(api):
     assert new_cdf_fx['forecast_id'] == new_cdf_fx_id
     for key, value in VALID_CDF_FORECAST_JSON.items():
         if key == 'constant_values':
-            continue 
+            continue
         else:
             assert new_cdf_fx[key] == value
     assert new_cdf_fx in get_cdf_fx_list(api)
     assert new_cdf_fx in get_site_cdf_fx(api, new_cdf_fx['site_id'])
     for value in new_cdf_fx['constant_values']:
-        assert value['constant_value'] in VALID_CDF_FORECAST_JSON['constant_values']
-        get_cdf_const = api.get(f'/forecasts/cdf/single/{value["forecast_id"]}',
-                                base_url='https://localhost')
-        assert get_cdf_const.status_code == 200
+        static_vals = VALID_CDF_FORECAST_JSON['constant_values']
+        assert value['constant_value'] in static_vals
+        get_const = api.get(f'/forecasts/cdf/single/{value["forecast_id"]}',
+                            base_url=BASE_URL)
+        assert get_const.status_code == 200
+        get_cdf_const_values = api.get(value['_links']['values'])
+        assert get_cdf_const_values.status_code == 200
+    delete = api.delete(new_cdf_fx_url)
+    assert delete.status_code == 200
+    assert new_cdf_fx not in get_cdf_fx_list(api)
+    assert new_cdf_fx not in get_site_cdf_fx(api, new_cdf_fx['site_id'])
+    for value in new_cdf_fx['constant_values']:
+        fx_id = value['forecast_id']
+        get = api.get(f'/forecasts/cdf/single/{fx_id}',
+                      base_url=BASE_URL)
+        assert get.status_code == 404
 
 
 def test_create_cdf_forecast_invalid(api):
-    pass
+    original_cdf_fx_list = get_cdf_fx_list(api)
+    post = api.post('/forecasts/cdf/',
+                    base_url=BASE_URL,
+                    json={'invalid': 'garbage'})
+    assert post.status_code == 400
+    assert original_cdf_fx_list == get_cdf_fx_list(api)
 
 
 def test_create_cdf_forecast_unauthorized(api):
     pass
 
 
-def test_create_cdf_forecast_site_dne(api):
-    pass
+def test_create_cdf_forecast_site_dne(api, missing_id):
+    cdf_fx_list = get_cdf_fx_list(api)
+    fx_json = VALID_CDF_FORECAST_JSON.copy()
+    fx_json.update({'site_id': missing_id})
+    post = api.post('/forecasts/cdf/',
+                    base_url=BASE_URL,
+                    json=fx_json)
+    assert post.status_code == 404
+    assert cdf_fx_list == get_cdf_fx_list(api)
+
 
 def test_sequence(api):
-    # post site
-    # post obs to site
-    # post fx to site
-    # try to delete site, expect failure
-    # delete fx
-    # delete obs
-    # delete site
-    # ensure site, fx, obs dne
-    pass
+    # Create a site
+    post = api.post('/sites/',
+                    base_url=BASE_URL,
+                    json=VALID_SITE_JSON)
+    assert post.status_code == 201
+    new_site_id = post.data.decode('utf-8')
+    new_site_url = post.headers['Location']
+    get = api.get(new_site_url)
+    assert get.status_code == 200
+    new_site = get.get_json()
+
+    # Create obs at site
+    obs_json = VALID_OBS_JSON.copy()
+    obs_json['site_id'] = new_site_id
+    post = api.post('/observations/',
+                    base_url=BASE_URL,
+                    json=obs_json)
+    assert post.status_code == 201
+    new_obs_id = post.data.decode('utf-8')
+    new_obs_links_url = post.headers['Location']
+    get_links = api.get(new_obs_links_url)
+    assert get_links.status_code == 200
+    new_obs_links = get_links.get_json()
+    new_obs_url = new_obs_links['_links']['metadata']
+    get_obs = api.get(new_obs_url)
+    assert get_obs.status_code == 200
+    new_obs = get_obs.get_json()
+
+    # Create FX at site
+    fx_json = VALID_FORECAST_JSON.copy()
+    fx_json['site_id'] = new_site_id
+    post = api.post('/forecasts/single/',
+                    base_url=BASE_URL,
+                    json=VALID_FORECAST_JSON)
+    assert post.status_code == 201
+    new_fx_id = post.data.decode('utf-8')
+    new_fx_links_url = post.headers['Location']
+    get_links = api.get(new_fx_links_url)
+    assert get_links.status_code == 200
+    new_fx_links = get_links.get_json()
+    new_fx_url = new_fx_links['_links']['metadata']
+    get_fx = api.get(new_fx_url)
+    assert get_fx.status_code == 200
+    new_fx = get_fx.get_json()
+
+    # Create a cdf fx at the site
+    post = api.post('/forecasts/cdf/',
+                    base_url=BASE_URL,
+                    json=VALID_CDF_FORECAST_JSON)
+    assert post.status_code == 201
+    new_cdf_fx_url = post.headers['Location']
+    get_cdf_fx = api.get(new_cdf_fx_url)
+    assert get_cdf_fx.status_code == 200
+    new_cdf_fx = get_cdf_fx.get_json()
+
+    # Fail to delete site because obs, fx exist for it.
+    delete_site = api.delete(new_site_url)
+    assert delete_site.status_code == 400
+    assert new_site in get_site_list(api)
+
+    # Delete the created cdf fx
+    delete_cdf_fx = api.delete(new_cdf_fx_url)
+    assert delete_cdf_fx.status_code == 200
+    assert new_cdf_fx not in get_cdf_fx_list(api)
+    assert new_cdf_fx not in get_site_cdf_fx(api, new_site_id)
+
+    # Delete the created fx
+    delete_fx = api.delete(f'/forecasts/single/{new_fx_id}',
+                           base_url=BASE_URL)
+    assert delete_fx.status_code == 200
+    assert new_fx not in get_fx_list(api)
+    assert new_fx not in get_site_fx(api, new_site_id)
+
+    # delete the created obs
+    delete_obs = api.delete(f'/observations/{new_obs_id}',
+                            base_url=BASE_URL)
+    assert delete_obs.status_code == 200
+    assert new_obs not in get_obs_list(api)
+    assert new_obs not in get_site_obs(api, new_site_id)
+
+    # Delete the site now that we've removed the obs & fx
+    delete_site = api.delete(new_site_url)
+    assert delete_site.status_code == 200
+    assert new_site not in get_site_list(api)

--- a/sfa_api/tests/test_api.py
+++ b/sfa_api/tests/test_api.py
@@ -1,17 +1,53 @@
-"""Tests if using the API without internal interference has expected results. 
+"""Tests that API maintains proper state after interactions
 """
 import pandas.testing as pdt
 
+from sfa_api.conftest import (VALID_SITE_JSON, VALID_OBS_JSON, VALID_FORECAST_JSON,
+                              VALID_CDF_FORECAST_JSON)
 
-from sfa_api.tests.test_sites import VALID_SITE_JSON
-from sfa_api.tests.test_observation import VALID_OBS_JSON
-from sfa_api.tests.test_forecast import VALID_FORECAST_JSON
+def get_obs_list(api):
+    get_obs = api.get('/observations/',
+                      base_url='https://localhost')
+    return get_obs.get_json()
 
 
-def test_post_site(api):
-    sites_get = api.get('/sites/',
+def get_cdf_fx_list(api):
+    get_cdf_fx = api.get('/forecasts/cdf/',
+                         base_url='https://localhost')
+    return get_cdf_fx.get_json()
+
+
+def get_fx_list(api):
+    get_fx = api.get('/forecasts/single/',
+                     base_url='https://localhost')
+    return get_fx.get_json()
+
+
+def get_site_list(api):
+    get_sites = api.get('/sites/',
                         base_url='https://localhost')
-    original_sites_list = sites_get.get_json()
+    return get_sites.get_json()
+
+
+def get_site_fx(api, site_id):
+    site_fx = api.get(f'/sites/{site_id}/forecasts/single',
+                      base_url='https://localhost')
+    return site_fx.get_json()
+
+
+def get_site_cdf_fx(api, site_id):
+    site_cdf_fx = api.get(f'/sites/{site_id}/forecasts/cdf',
+                          base_url='https://localhost')
+    return site_cdf_fx.get_json()
+
+
+def get_site_obs(api, site_id):
+    site_obs = api.get(f'/sites/{site_id}/observations',
+                       base_url='https://localhost')
+    return site_obs.get_json()
+
+
+def test_create_delete_site(api):
     post = api.post('/sites/', 
                     base_url='https://localhost',
                     json=VALID_SITE_JSON)
@@ -24,13 +60,14 @@ def test_post_site(api):
     assert new_site['site_id'] == new_site_id
     for key, value in VALID_SITE_JSON.items():
         assert new_site[key] == value
-    sites_get = api.get('/sites/',
-                        base_url='https://localhost')
-    new_sites_list = sites_get.get_json()
-    assert len(new_sites_list) - len(original_sites_list) == 1
+    assert new_site in get_site_list(api)
+
+    delete = api.delete(new_site_url)
+    assert delete.status_code == 200
+    assert new_site not in get_site_list(api)
 
 
-def test_post_site_invalid(api):
+def test_create_invalid_site(api):
     sites_get = api.get('/sites/',
                         base_url='https://localhost')
     original_sites_list = sites_get.get_json()
@@ -44,15 +81,16 @@ def test_post_site_invalid(api):
     assert original_sites_list == new_sites_list
 
 
-def test_post_site_unauthorized(api):
-    post = api.post('/sites/', 
-                    base_url='https://localhost',
-                    json=VALID_SITE_JSON)
-    # assert post.status_code == 401
-    assert post.status_code == 201
+def test_create_site_unauthenticated(api):
+    # 401
+    pass
 
 
-def test_post_observation(api):
+def test_create_site_unauthorized(api):
+    # 404
+    pass
+
+def test_create__delete_observation(api):
     post = api.post('/observations/',
                     base_url='https://localhost',
                     json=VALID_OBS_JSON)
@@ -69,57 +107,133 @@ def test_post_observation(api):
     assert new_obs['observation_id'] == new_obs_id
     for key, value in VALID_OBS_JSON.items():
         assert new_obs[key] == value
+    assert new_obs in get_obs_list(api)
+    assert new_obs in get_site_obs(api, new_obs['site_id'])
+
+    delete = api.delete(new_obs_links_url)
+    assert delete.status_code == 200
+    assert new_obs not in get_obs_list(api)
+    assert new_obs not in get_site_obs(api, new_obs['site_id'])
 
 
 
-def test_post_observation_invalid(api):
-    get_obs = api.get('/observations/',
-                      base_url='https://localhost')
-    original_obs_list = get_obs.get_json()
+def test_create_observation_invalid(api):
+    original_obs_list = get_obs_list(api)
     post = api.post('/observations/',
                     base_url='https://localhost',
                     json={'invalid': 'garbage'})
     assert post.status_code == 400
+    assert original_obs_list == get_obs_list(api)
 
 
 
-def test_post_observation_unauthorized(api):
+def test_create_observation_unauthorized(api):
+    pass
+
+def test_create_observation_unauthenticated(api):
     pass
 
 
-def test_post_observation_site_dne(api):
+def test_create_observation_site_dne(api, missing_id):
+    observations = get_obs_list(api)
+    obs_json = VALID_OBS_JSON.copy()
+    obs_json.update({'site_id': missing_id})
+    post = api.post('/observations/',
+                    base_url='https://localhost',
+                    json=obs_json)
+    assert post.status_code == 404
+    assert observations == get_obs_list(api)
+
+
+def test_create_delete_forecast(api):
+    post = api.post('/forecasts/single/',
+                    base_url="https://localhost",
+                    json=VALID_FORECAST_JSON)
+    assert post.status_code == 201
+    new_fx_id = post.data.decode('utf-8')
+    new_fx_links_url = post.headers['Location']
+    get_links = api.get(new_fx_links_url)
+    assert get_links.status_code == 200
+    new_fx_links = get_links.get_json()
+    new_fx_url = new_fx_links['_links']['metadata']
+    get_fx = api.get(new_fx_url)
+    assert get_fx.status_code == 200
+    new_fx = get_fx.get_json()
+    assert new_fx['forecast_id'] == new_fx_id
+    for key, value in VALID_FORECAST_JSON.items():
+        assert new_fx[key] == value
+    assert new_fx in get_fx_list(api)
+    assert new_fx in get_site_fx(api, new_fx['site_id'])
+
+    delete = api.delete(new_fx_links_url)
+    assert delete.status_code == 200
+    assert new_fx not in get_fx_list(api)
+    assert new_fx not in get_site_fx(api, new_fx['site_id'])
+
+
+
+def test_create_forecast_invalid(api):
+    original_forecast_list = get_fx_list(api)
+    post = api.post('/forecasts/single/',
+                    base_url="https://localhost",
+                    json={'invalid':'garbage'})
+    assert post.status_code == 400
+    assert original_forecast_list == get_fx_list(api)
+
+
+def test_create_forecast_unauthorized(api):
     pass
 
 
-def test_post_forecast(api):
+def test_create_forecast_unauthenticated(api):
     pass
 
 
-def test_post_forecast_invalid(api):
+def test_post_forecast_site_dne(api, missing_id):
+    forecasts = get_fx_list(api)
+    fx_json = VALID_OBS_JSON.copy()
+    fx_json.update({'site_id': missing_id})
+    post = api.post('/forecasts/',
+                    base_url='https://localhost',
+                    json=fx_json)
+    assert post.status_code == 404
+    assert forecasts == get_fx_list(api)
+
+
+def test_create_cdf_forecast(api):
+    post = api.post('/forecasts/cdf/',
+                    base_url="https://localhost",
+                    json=VALID_CDF_FORECAST_JSON)
+    assert post.status_code == 201
+    new_cdf_fx_id = post.data.decode('utf-8')
+    new_cdf_fx_url = post.headers['Location']
+    get_cdf_fx = api.get(new_cdf_fx_url)
+    assert get_cdf_fx.status_code == 200
+    new_cdf_fx = get_cdf_fx.get_json()
+    assert new_cdf_fx['forecast_id'] == new_cdf_fx_id
+    for key, value in VALID_CDF_FORECAST_JSON.items():
+        if key == 'constant_values':
+            continue 
+        else:
+            assert new_cdf_fx[key] == value
+    assert new_cdf_fx in get_cdf_fx_list(api)
+    assert new_cdf_fx in get_site_cdf_fx(api, new_cdf_fx['site_id'])
+    for value in new_cdf_fx['constant_values']:
+        assert value['constant_value'] in VALID_CDF_FORECAST_JSON['constant_values']
+        get_cdf_const = api.get(f'/forecasts/cdf/single/{value["forecast_id"]}',
+                                base_url='https://localhost')
+        assert get_cdf_const.status_code == 200
+
+
+def test_create_cdf_forecast_invalid(api):
     pass
 
 
-def test_post_forecast_unauthorized(api):
+def test_create_cdf_forecast_unauthorized(api):
     pass
 
 
-def test_postforecast_site_dne(api):
-    pass
-
-
-def test_post_cdf_forecast(api):
-    pass
-
-
-def test_post_cdf_forecast_invalid(api):
-    pass
-
-
-def test_post_cdf_forecast_unauthorized(api):
-    pass
-
-
-def test_post_cdf_forecast_site_dne(api):
+def test_create_cdf_forecast_site_dne(api):
     pass
 
 def test_sequence(api):

--- a/sfa_api/tests/test_api.py
+++ b/sfa_api/tests/test_api.py
@@ -1,19 +1,16 @@
 """Tests that API maintains proper state after interactions
 """
 import pytest
-import werkzeug
 
 
 from sfa_api.conftest import (VALID_SITE_JSON, VALID_OBS_JSON,
-                          VALID_FORECAST_JSON, VALID_CDF_FORECAST_JSON,
-                          BASE_URL)
-from sfa_api.schema import SiteSchema, ModelingParameters
+                              VALID_FORECAST_JSON, VALID_CDF_FORECAST_JSON,
+                              BASE_URL)
 from sfa_api.demo.values import (static_observation_values,
                                  static_forecast_values)
 
 
 invalid_json = {'invalid': 'garbage'}
-
 
 
 @pytest.fixture()
@@ -23,8 +20,8 @@ def auth_header(auth_token):
 
 def get_obs_list(sql_api, auth_header):
     get_obs = sql_api.get('/observations/',
-                      base_url=BASE_URL,
-                      headers=auth_header)
+                          base_url=BASE_URL,
+                          headers=auth_header)
     return get_obs.get_json()
 
 
@@ -78,13 +75,13 @@ def test_create_delete_site(sql_api, auth_header):
     assert post.status_code == 201
     new_site_id = post.data.decode('utf-8')
     new_site_url = post.headers['Location']
-    get = sql_api.get(new_site_url,headers=auth_header)
+    get = sql_api.get(new_site_url, headers=auth_header)
     assert get.status_code == 200
     new_site = get.get_json()
     assert new_site['site_id'] == new_site_id
     for key, value in VALID_SITE_JSON.items():
         if key == 'modeling_parameters':
-            for k,v in VALID_SITE_JSON['modeling_parameters'].items():
+            for k, v in VALID_SITE_JSON['modeling_parameters'].items():
                 assert new_site['modeling_parameters'][k] == v
         else:
             assert new_site[key] == value
@@ -98,12 +95,11 @@ def test_create_delete_site(sql_api, auth_header):
 def test_create_invalid_site(sql_api, auth_header):
     original_sites_list = get_site_list(sql_api, auth_header)
     post = sql_api.post('/sites/',
-                    headers=auth_header,
-                    base_url=BASE_URL,
-                    json=invalid_json)
+                        headers=auth_header,
+                        base_url=BASE_URL,
+                        json=invalid_json)
     assert post.status_code == 400
     assert original_sites_list == get_site_list(sql_api, auth_header)
-
 
 
 def test_create_site_unauthenticated(sql_api):
@@ -112,6 +108,7 @@ def test_create_site_unauthenticated(sql_api):
                         json=VALID_SITE_JSON)
     assert post.status_code == 401
 
+
 def test_create_site_unauthorized(sql_api, auth_header):
     # 404
     pass
@@ -119,9 +116,9 @@ def test_create_site_unauthorized(sql_api, auth_header):
 
 def test_create_delete_observation(sql_api, auth_header):
     post = sql_api.post('/observations/',
-                    headers=auth_header,
-                    base_url=BASE_URL,
-                    json=VALID_OBS_JSON)
+                        headers=auth_header,
+                        base_url=BASE_URL,
+                        json=VALID_OBS_JSON)
     assert post.status_code == 201
     new_obs_id = post.data.decode('utf-8')
     new_obs_links_url = post.headers['Location']
@@ -151,27 +148,30 @@ def test_create_delete_observation(sql_api, auth_header):
     assert post_values.status_code == 201
     get_values = sql_api.get(f'/observations/{new_obs_id}/values',
                              base_url=BASE_URL,
-                             headers={'Accept': 'application/json', **auth_header})
+                             headers={'Accept': 'application/json',
+                                      **auth_header})
     assert get_values.status_code == 200
 
-    ## post csv_values to the observation
-    #obs_values = static_observation_values()
-    #obs_values['quality_flag'] = 0
-    #csv_values = obs_values.to_csv()
-    #post_values = sql_api.post(f'/observations/{new_obs_id}/values',
-    #                       base_url=BASE_URL,
-    #                       headers={'Content-Type': 'text/csv', **auth_header},
-    #                       data=csv_values)
-    #assert post_values.status_code == 201
-    #get_values = sql_api.get(f'/observations/{new_obs_id}/values',
-    #                     base_url=BASE_URL,
-    #                     headers={'Accept': 'text/csv', **auth_header})
-    #assert get_values.status_code == 200
+    # # post csv_values to the observation
+    # obs_values = static_observation_values()
+    # obs_values['quality_flag'] = 0
+    # csv_values = obs_values.to_csv()
+    # post_values = sql_api.post(f'/observations/{new_obs_id}/values',
+    #                        base_url=BASE_URL,
+    #                        headers={'Content-Type': 'text/csv',
+    #                                 **auth_header},
+    #                        data=csv_values)
+    # assert post_values.status_code == 201
+    # get_values = sql_api.get(f'/observations/{new_obs_id}/values',
+    #                      base_url=BASE_URL,
+    #                      headers={'Accept': 'text/csv', **auth_header})
+    # assert get_values.status_code == 200
 
     delete = sql_api.delete(new_obs_links_url, headers=auth_header)
     assert delete.status_code == 204
     assert new_obs not in get_obs_list(sql_api, auth_header)
-    assert new_obs not in get_site_obs(sql_api, auth_header, new_obs['site_id'])
+    assert new_obs not in get_site_obs(sql_api, auth_header,
+                                       new_obs['site_id'])
     get_values = sql_api.get(f'/observations/{new_obs_id}/values',
                              base_url=BASE_URL,
                              headers={'Accept': 'text/csv', **auth_header})
@@ -239,33 +239,37 @@ def test_create_delete_forecast(sql_api, auth_header):
     # request json values
     get_values = sql_api.get(f'/forecasts/single/{new_fx_id}/values',
                              base_url=BASE_URL,
-                             headers={'Accept': 'application/json', **auth_header})
+                             headers={'Accept': 'application/json',
+                                      **auth_header})
     assert get_values.status_code == 200
 
-    ## post csv_values to the forecasts
-    #fx_values = static_forecast_values()
-    #csv_values = fx_values.to_csv()
+    # # post csv_values to the forecasts
+    # fx_values = static_forecast_values()
+    # csv_values = fx_values.to_csv()
 
-    #post_values = sql_api.post(f'/forecasts/single/{new_fx_id}/values',
-    #                       base_url=BASE_URL,
-    #                       headers={'Content-Type': 'text/csv', **auth_header},
-    #                       data=csv_values)
-    #assert post_values.status_code == 201
+    # post_values = sql_api.post(f'/forecasts/single/{new_fx_id}/values',
+    #                            base_url=BASE_URL,
+    #                            headers={'Content-Type': 'text/csv',
+    #                            **auth_header},
+    #                            data=csv_values)
+    # assert post_values.status_code == 201
 
-    ## request csv values
-    #get_values = sql_api.get(f'/forecasts/single/{new_fx_id}/values',
-    #                     base_url=BASE_URL,
-    #                     headers={'Accept': 'text/csv', **auth_header})
-    #assert get_values.status_code == 200
+    # # request csv values
+    # get_values = sql_api.get(f'/forecasts/single/{new_fx_id}/values',
+    #                      base_url=BASE_URL,
+    #                      headers={'Accept': 'text/csv', **auth_header})
+    # assert get_values.status_code == 200
 
     delete = sql_api.delete(new_fx_links_url, headers=auth_header)
     assert delete.status_code == 204
     assert new_fx not in get_fx_list(sql_api, auth_header)
-    assert new_fx not in get_site_fx(sql_api, auth_header, new_fx['site_id'])
+    assert new_fx not in get_site_fx(sql_api, auth_header,
+                                     new_fx['site_id'])
 
-    get_values = sql_api.get(f'/forecasts/single/{new_fx_id}/values',
-                         base_url=BASE_URL,
-                         headers={'Accept': 'text/csv', **auth_header})
+    get_values = sql_api.get(
+        f'/forecasts/single/{new_fx_id}/values',
+        base_url=BASE_URL,
+        headers={'Accept': 'text/csv', **auth_header})
     assert get_values.status_code == 404
 
 
@@ -313,15 +317,18 @@ def test_create_delete_cdf_forecast(sql_api, auth_header):
         else:
             assert new_cdf_fx[key] == value
     assert new_cdf_fx in get_cdf_fx_list(sql_api, auth_header)
-    assert new_cdf_fx in get_site_cdf_fx(sql_api, auth_header, new_cdf_fx['site_id'])
+    assert new_cdf_fx in get_site_cdf_fx(sql_api, auth_header,
+                                         new_cdf_fx['site_id'])
     for value in new_cdf_fx['constant_values']:
         static_vals = VALID_CDF_FORECAST_JSON['constant_values']
         assert value['constant_value'] in static_vals
-        get_const = sql_api.get(f'/forecasts/cdf/single/{value["forecast_id"]}',
-                                headers=auth_header,
-                                base_url=BASE_URL)
+        get_const = sql_api.get(
+            f'/forecasts/cdf/single/{value["forecast_id"]}',
+            headers=auth_header,
+            base_url=BASE_URL)
         assert get_const.status_code == 200
-        get_cdf_const_values = sql_api.get(value['_links']['values'], headers=auth_header)
+        get_cdf_const_values = sql_api.get(value['_links']['values'],
+                                           headers=auth_header)
         assert get_cdf_const_values.status_code == 200
 
         # Post values to the forecast
@@ -334,13 +341,15 @@ def test_create_delete_cdf_forecast(sql_api, auth_header):
                                    json={'values': json_values})
         assert post_values.status_code == 201
         get_values = sql_api.get(value['_links']['values'],
-                                 headers={'Accept': 'application/json', **auth_header})
+                                 headers={'Accept': 'application/json',
+                                          **auth_header})
         assert get_values.status_code == 200
 
     delete = sql_api.delete(new_cdf_fx_url, headers=auth_header)
     assert delete.status_code == 204
     assert new_cdf_fx not in get_cdf_fx_list(sql_api, auth_header)
-    assert new_cdf_fx not in get_site_cdf_fx(sql_api, auth_header, new_cdf_fx['site_id'])
+    assert new_cdf_fx not in get_site_cdf_fx(sql_api, auth_header,
+                                             new_cdf_fx['site_id'])
     for value in new_cdf_fx['constant_values']:
         fx_id = value['forecast_id']
         get = sql_api.get(f'/forecasts/cdf/single/{fx_id}',
@@ -433,9 +442,9 @@ def test_sequence(sql_api, auth_header):
 
     # Create a cdf fx at the site
     post = sql_api.post('/forecasts/cdf/',
-                    headers=auth_header,
-                    base_url=BASE_URL,
-                    json=VALID_CDF_FORECAST_JSON)
+                        headers=auth_header,
+                        base_url=BASE_URL,
+                        json=VALID_CDF_FORECAST_JSON)
     assert post.status_code == 201
     new_cdf_fx_url = post.headers['Location']
     get_cdf_fx = sql_api.get(new_cdf_fx_url, headers=auth_header)

--- a/sfa_api/tests/test_api.py
+++ b/sfa_api/tests/test_api.py
@@ -204,8 +204,8 @@ def test_create_delete_forecast(api):
                            base_url=BASE_URL,
                            json={'values': json_values})
     assert post_values.status_code == 201
-    
-    #request json values
+
+    # request json values
     get_values = api.get(f'/forecasts/single/{new_fx_id}/values',
                          base_url=BASE_URL,
                          headers={'Accept': 'application/json'})

--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -95,8 +95,8 @@ def test_get_cdf_forecast_group_metadata(api, cdf_forecast_group_id):
     assert 'site_id' in response
 
 
-def test_get_forecast_metadata_404(api, missing_forecast_id):
-    r = api.get(f'/forecasts/cdf{missing_forecast_id}/metadata',
+def test_get_forecast_metadata_404(api, missing_id):
+    r = api.get(f'/forecasts/cdf/{missing_id}/metadata',
                 base_url='https://localhost')
     assert r.status_code == 404
 

--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -81,17 +81,6 @@ def test_get_forecast_metadata_404(api, missing_id):
     assert r.status_code == 404
 
 
-VALID_FX_VALUE_JSON = {
-    'id': '123e4567-e89b-12d3-a456-426655440000',
-    'values': [
-        {'timestamp': "2019-01-22T17:54:00+00:00",
-         'value': 1.0},
-        {'timestamp': "2019-01-22T17:55:00+00:00",
-         'value': 32.0},
-        {'timestamp': "2019-01-22T17:56:00+00:00",
-         'value': 3.0}
-    ]
-}
 WRONG_DATE_FORMAT_VALUE_JSON = {
     'values': [
         {'timestamp': '20-2-3T11111F',
@@ -104,13 +93,6 @@ NON_NUMERICAL_VALUE_JSON = {
          'value': 'four'},
     ]
 }
-VALID_FX_VALUE_CSV = ('# forecast_id: 633f9396-50bb-11e9-8647-d663bd873d93\n'
-             '# metadata: https://localhost/forecasts/cdf/single/633f9396-50bb-11e9-8647-d663bd873d93\n' # NOQA
-             'timestamp,value\n'
-             '20190122T12:04:00+0000,5.0\n'
-             '20190122T12:05:00+0000,1.0\n'
-             '20190122T12:06:00+0000,32.0\n'
-             '20190122T12:07:00+0000,3.0\n')
 WRONG_DATE_FORMAT_CSV = "timestamp,value\nksdfjgn,32.93"
 NON_NUMERICAL_VALUE_CSV = "timestamp,value\n2018-10-29T12:04:23Z,fgh" # NOQA
 

--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -211,7 +211,7 @@ def test_post_and_get_values_json(api, cdf_forecast_id):
     r = api.post(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
                  base_url=BASE_URL,
                  json=VALID_VALUE_JSON)
-    assert r.status_code == 201 
+    assert r.status_code == 201
     start = '2019-01-22T17:54:00+00:00'
     end = '2019-01-22T17:56:00+00:00'
     r = api.get(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
@@ -227,7 +227,7 @@ def test_post_and_get_values_csv(api, cdf_forecast_id):
                  base_url=BASE_URL,
                  headers={'Content-Type': 'text/csv'},
                  data=VALID_CSV)
-    assert r.status_code == 201 
+    assert r.status_code == 201
     start = '2019-01-22T12:04:00+00:00'
     end = '2019-01-22T12:07:00+00:00'
     r = api.get(f'/forecasts/cdf/single/{cdf_forecast_id}/values',

--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -1,48 +1,27 @@
 import pytest
 
 
-from sfa_api.conftest import variables, interval_value_types, interval_labels
+from sfa_api.conftest import (variables, interval_value_types, interval_labels,
+                              VALID_CDF_FORECAST_JSON, copy_update)
 
 
-VALID_FORECAST_JSON = {
-    "extra_parameters": '{"instrument": "pyranometer"}',
-    "name": "test forecast",
-    "site_id": "123e4567-e89b-12d3-a456-426655440001",
-    "variable": "ac_power",
-    "interval_label": "beginning",
-    "issue_time_of_day": "12:00",
-    "lead_time_to_start": 60,
-    "interval_length": 1,
-    "run_length": 1440,
-    "interval_value_type": "interval_mean",
-    "axis": 'x',
-    "constant_values": [5.0, 20.0, 50.0, 80.0, 95.0]
-}
-
-
-def copy_update(json, key, value):
-    new_json = json.copy()
-    new_json[key] = value
-    return new_json
-
-
-INVALID_VARIABLE = copy_update(VALID_FORECAST_JSON,
+INVALID_VARIABLE = copy_update(VALID_CDF_FORECAST_JSON,
                                'variable', 'invalid')
-INVALID_INTERVAL_LABEL = copy_update(VALID_FORECAST_JSON,
+INVALID_INTERVAL_LABEL = copy_update(VALID_CDF_FORECAST_JSON,
                                      'interval_label', 'invalid')
-INVALID_ISSUE_TIME = copy_update(VALID_FORECAST_JSON,
+INVALID_ISSUE_TIME = copy_update(VALID_CDF_FORECAST_JSON,
                                  'issue_time_of_day', 'invalid')
-INVALID_LEAD_TIME = copy_update(VALID_FORECAST_JSON,
+INVALID_LEAD_TIME = copy_update(VALID_CDF_FORECAST_JSON,
                                 'lead_time_to_start', 'invalid')
-INVALID_INTERVAL_LENGTH = copy_update(VALID_FORECAST_JSON,
+INVALID_INTERVAL_LENGTH = copy_update(VALID_CDF_FORECAST_JSON,
                                       'interval_length', 'invalid')
-INVALID_RUN_LENGTH = copy_update(VALID_FORECAST_JSON,
+INVALID_RUN_LENGTH = copy_update(VALID_CDF_FORECAST_JSON,
                                  'run_length', 'invalid')
-INVALID_VALUE_TYPE = copy_update(VALID_FORECAST_JSON,
+INVALID_VALUE_TYPE = copy_update(VALID_CDF_FORECAST_JSON,
                                  'interval_value_type', 'invalid')
-INVALID_AXIS = copy_update(VALID_FORECAST_JSON,
+INVALID_AXIS = copy_update(VALID_CDF_FORECAST_JSON,
                            'interval_value_type', 'invalid')
-INVALID_CONSTANT_VALUES = copy_update(VALID_FORECAST_JSON,
+INVALID_CONSTANT_VALUES = copy_update(VALID_CDF_FORECAST_JSON,
                                       'interval_value_type',
                                       'invalid')
 
@@ -51,7 +30,7 @@ empty_json_response = '{"axis":["Missing data for required field."],"constant_va
 
 
 @pytest.mark.parametrize('payload,status_code', [
-    (VALID_FORECAST_JSON, 201),
+    (VALID_CDF_FORECAST_JSON, 201),
 ])
 def test_cdf_forecast_group_post_success(api, payload, status_code):
     r = api.post('/forecasts/cdf/',

--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -2,7 +2,7 @@ import pytest
 
 
 from sfa_api.conftest import (variables, interval_value_types, interval_labels,
-                              VALID_CDF_FORECAST_JSON, copy_update)
+                              BASE_URL, VALID_CDF_FORECAST_JSON, copy_update)
 
 
 INVALID_VARIABLE = copy_update(VALID_CDF_FORECAST_JSON,
@@ -34,7 +34,7 @@ empty_json_response = '{"axis":["Missing data for required field."],"constant_va
 ])
 def test_cdf_forecast_group_post_success(api, payload, status_code):
     r = api.post('/forecasts/cdf/',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  json=payload)
     assert r.status_code == status_code
     assert 'Location' in r.headers
@@ -52,7 +52,7 @@ def test_cdf_forecast_group_post_success(api, payload, status_code):
 ])
 def test_cdf_forecast_group_post_bad_request(api, payload, message):
     r = api.post('/forecasts/cdf/',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  json=payload)
     assert r.status_code == 400
     assert r.get_data(as_text=True) == f'{{"errors":{message}}}\n'
@@ -60,13 +60,13 @@ def test_cdf_forecast_group_post_bad_request(api, payload, message):
 
 def test_get_cdf_forecast_group_404(api, missing_id):
     r = api.get(f'/forecasts/cdf/{missing_id}',
-                base_url='https://localhost')
+                base_url=BASE_URL)
     assert r.status_code == 404
 
 
 def test_get_cdf_forecast_group_metadata(api, cdf_forecast_group_id):
     r = api.get(f'/forecasts/cdf/{cdf_forecast_group_id}',
-                base_url='https://localhost')
+                base_url=BASE_URL)
     response = r.get_json()
     assert 'forecast_id' in response
     assert 'variable' in response
@@ -76,7 +76,7 @@ def test_get_cdf_forecast_group_metadata(api, cdf_forecast_group_id):
 
 def test_get_forecast_metadata_404(api, missing_id):
     r = api.get(f'/forecasts/cdf/{missing_id}/metadata',
-                base_url='https://localhost')
+                base_url=BASE_URL)
     assert r.status_code == 404
 
 
@@ -110,7 +110,7 @@ NON_NUMERICAL_VALUE_CSV = "timestamp,value\n2018-10-29T12:04:23Z,fgh" # NOQA
 
 def test_post_forecast_values_valid_json(api, cdf_forecast_id):
     r = api.post(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  json=VALID_VALUE_JSON)
     assert r.status_code == 201
 
@@ -119,7 +119,7 @@ def test_post_json_storage_call(api, cdf_forecast_id, mocker):
     storage = mocker.patch('sfa_api.demo.store_cdf_forecast_values')
     storage.return_value = cdf_forecast_id
     api.post(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
-             base_url='https://localhost',
+             base_url=BASE_URL,
              json=VALID_VALUE_JSON)
     storage.assert_called()
 
@@ -128,7 +128,7 @@ def test_post_values_404(api, missing_id, mocker):
     storage = mocker.patch('sfa_api.demo.store_forecast_values')
     storage.return_value = None
     r = api.post(f'/forecasts/cdf/single/{missing_id}/values',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  json=VALID_VALUE_JSON)
     assert r.status_code == 404
 
@@ -141,7 +141,7 @@ def test_post_values_404(api, missing_id, mocker):
 ])
 def test_post_forecast_values_invalid_json(api, payload, cdf_forecast_id):
     r = api.post(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  json=payload)
     assert r.status_code == 400
 
@@ -154,7 +154,7 @@ def test_post_forecast_values_invalid_json(api, payload, cdf_forecast_id):
 ])
 def test_post_forecast_values_invalid_csv(api, payload, cdf_forecast_id):
     r = api.post(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  headers={'Content-Type': 'text/csv'},
                  data=payload)
     assert r.status_code == 400
@@ -162,7 +162,7 @@ def test_post_forecast_values_invalid_csv(api, payload, cdf_forecast_id):
 
 def test_post_forecast_values_valid_csv(api, cdf_forecast_id):
     r = api.post(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  headers={'Content-Type': 'text/csv'},
                  data=VALID_CSV)
     assert r.status_code == 201
@@ -170,7 +170,7 @@ def test_post_forecast_values_valid_csv(api, cdf_forecast_id):
 
 def test_get_forecast_values_404(api, missing_id):
     r = api.get(f'/forecasts/cdf/single/{missing_id}/values',
-                base_url='https://localhost')
+                base_url=BASE_URL)
     assert r.status_code == 404
 
 
@@ -180,7 +180,7 @@ def test_get_forecast_values_404(api, missing_id):
 ])
 def test_get_forecast_values_400(api, start, end, mimetype, cdf_forecast_id):
     r = api.get(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
-                base_url='https://localhost',
+                base_url=BASE_URL,
                 headers={'Accept': mimetype},
                 query_string={'start': start, 'end': end})
     assert r.status_code == 400
@@ -194,7 +194,7 @@ def test_get_forecast_values_400(api, start, end, mimetype, cdf_forecast_id):
 def test_get_cdf_forecast_values_200(api, start, end, mimetype,
                                      cdf_forecast_id):
     r = api.get(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
-                base_url='https://localhost',
+                base_url=BASE_URL,
                 headers={'Accept': mimetype},
                 query_string={'start': start, 'end': end})
     assert r.status_code == 200

--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -3,7 +3,7 @@ import pytest
 
 from sfa_api.conftest import (variables, interval_value_types, interval_labels,
                               BASE_URL, VALID_CDF_FORECAST_JSON, copy_update,
-                              VALID_FX_VALUE_JSON, VALID_FX_VALUE_CSV)
+                              VALID_FX_VALUE_JSON, VALID_CDF_VALUE_CSV)
 
 
 INVALID_VARIABLE = copy_update(VALID_CDF_FORECAST_JSON,
@@ -153,7 +153,7 @@ def test_post_forecast_values_valid_csv(api, cdf_forecast_id):
     r = api.post(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
                  base_url=BASE_URL,
                  headers={'Content-Type': 'text/csv'},
-                 data=VALID_FX_VALUE_CSV)
+                 data=VALID_CDF_VALUE_CSV)
     assert r.status_code == 201
 
 
@@ -209,7 +209,7 @@ def test_post_and_get_values_csv(api, cdf_forecast_id):
     r = api.post(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
                  base_url=BASE_URL,
                  headers={'Content-Type': 'text/csv'},
-                 data=VALID_FX_VALUE_CSV)
+                 data=VALID_CDF_VALUE_CSV)
     assert r.status_code == 201
     start = '2019-01-22T12:04:00+00:00'
     end = '2019-01-22T12:07:00+00:00'
@@ -218,4 +218,4 @@ def test_post_and_get_values_csv(api, cdf_forecast_id):
                 headers={'Accept': 'text/csv'},
                 query_string={'start': start, 'end': end})
     posted_data = r.data
-    assert VALID_FX_VALUE_CSV == posted_data.decode('utf-8')
+    assert VALID_CDF_VALUE_CSV == posted_data.decode('utf-8')

--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -83,12 +83,12 @@ def test_get_forecast_metadata_404(api, missing_id):
 VALID_VALUE_JSON = {
     'id': '123e4567-e89b-12d3-a456-426655440000',
     'values': [
-        {'timestamp': "2019-01-22T17:54:36Z",
-         'value': 1},
-        {'timestamp': "2019-01-22T17:55:36Z",
-         'value': '32.96'},
-        {'timestamp': "2019-01-22T17:56:36Z",
-         'value': 3}
+        {'timestamp': "2019-01-22T17:54:00+00:00",
+         'value': 1.0},
+        {'timestamp': "2019-01-22T17:55:00+00:00",
+         'value': 32.0},
+        {'timestamp': "2019-01-22T17:56:00+00:00",
+         'value': 3.0}
     ]
 }
 WRONG_DATE_FORMAT_VALUE_JSON = {
@@ -103,7 +103,13 @@ NON_NUMERICAL_VALUE_JSON = {
          'value': 'four'},
     ]
 }
-VALID_CSV = "#I am a header comment, I am going to be ignored\ntimestamp,value\n2018-10-29T12:04:23Z,32.93\n2018-10-29T12:05:23Z,32.93\n2018-10-29T12:06:23Z,32.93\n2018-10-29T12:07:23Z,32.93\n" # NOQA
+VALID_CSV = ('# forecast_id: 633f9396-50bb-11e9-8647-d663bd873d93\n'
+             '# metadata: https://localhost/forecasts/cdf/single/633f9396-50bb-11e9-8647-d663bd873d93\n' # NOQA
+             'timestamp,value\n'
+             '20190122T12:04:00+0000,5.0\n'
+             '20190122T12:05:00+0000,1.0\n'
+             '20190122T12:06:00+0000,32.0\n'
+             '20190122T12:07:00+0000,3.0\n')
 WRONG_DATE_FORMAT_CSV = "timestamp,value\nksdfjgn,32.93"
 NON_NUMERICAL_VALUE_CSV = "timestamp,value\n2018-10-29T12:04:23Z,fgh" # NOQA
 
@@ -199,3 +205,34 @@ def test_get_cdf_forecast_values_200(api, start, end, mimetype,
                 query_string={'start': start, 'end': end})
     assert r.status_code == 200
     assert r.mimetype == mimetype
+
+
+def test_post_and_get_values_json(api, cdf_forecast_id):
+    r = api.post(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
+                 base_url=BASE_URL,
+                 json=VALID_VALUE_JSON)
+    assert r.status_code == 201 
+    start = '2019-01-22T17:54:00+00:00'
+    end = '2019-01-22T17:56:00+00:00'
+    r = api.get(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
+                base_url=BASE_URL,
+                headers={'Accept': 'application/json'},
+                query_string={'start': start, 'end': end})
+    posted_data = r.get_json()
+    assert VALID_VALUE_JSON['values'] == posted_data['values']
+
+
+def test_post_and_get_values_csv(api, cdf_forecast_id):
+    r = api.post(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
+                 base_url=BASE_URL,
+                 headers={'Content-Type': 'text/csv'},
+                 data=VALID_CSV)
+    assert r.status_code == 201 
+    start = '2019-01-22T12:04:00+00:00'
+    end = '2019-01-22T12:07:00+00:00'
+    r = api.get(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
+                base_url=BASE_URL,
+                headers={'Accept': 'text/csv'},
+                query_string={'start': start, 'end': end})
+    posted_data = r.data
+    assert VALID_CSV == posted_data.decode('utf-8')

--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -2,7 +2,8 @@ import pytest
 
 
 from sfa_api.conftest import (variables, interval_value_types, interval_labels,
-                              BASE_URL, VALID_CDF_FORECAST_JSON, copy_update)
+                              BASE_URL, VALID_CDF_FORECAST_JSON, copy_update,
+                              VALID_FX_VALUE_JSON, VALID_FX_VALUE_CSV)
 
 
 INVALID_VARIABLE = copy_update(VALID_CDF_FORECAST_JSON,
@@ -80,7 +81,7 @@ def test_get_forecast_metadata_404(api, missing_id):
     assert r.status_code == 404
 
 
-VALID_VALUE_JSON = {
+VALID_FX_VALUE_JSON = {
     'id': '123e4567-e89b-12d3-a456-426655440000',
     'values': [
         {'timestamp': "2019-01-22T17:54:00+00:00",
@@ -103,7 +104,7 @@ NON_NUMERICAL_VALUE_JSON = {
          'value': 'four'},
     ]
 }
-VALID_CSV = ('# forecast_id: 633f9396-50bb-11e9-8647-d663bd873d93\n'
+VALID_FX_VALUE_CSV = ('# forecast_id: 633f9396-50bb-11e9-8647-d663bd873d93\n'
              '# metadata: https://localhost/forecasts/cdf/single/633f9396-50bb-11e9-8647-d663bd873d93\n' # NOQA
              'timestamp,value\n'
              '20190122T12:04:00+0000,5.0\n'
@@ -117,7 +118,7 @@ NON_NUMERICAL_VALUE_CSV = "timestamp,value\n2018-10-29T12:04:23Z,fgh" # NOQA
 def test_post_forecast_values_valid_json(api, cdf_forecast_id):
     r = api.post(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
                  base_url=BASE_URL,
-                 json=VALID_VALUE_JSON)
+                 json=VALID_FX_VALUE_JSON)
     assert r.status_code == 201
 
 
@@ -126,7 +127,7 @@ def test_post_json_storage_call(api, cdf_forecast_id, mocker):
     storage.return_value = cdf_forecast_id
     api.post(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
              base_url=BASE_URL,
-             json=VALID_VALUE_JSON)
+             json=VALID_FX_VALUE_JSON)
     storage.assert_called()
 
 
@@ -135,7 +136,7 @@ def test_post_values_404(api, missing_id, mocker):
     storage.return_value = None
     r = api.post(f'/forecasts/cdf/single/{missing_id}/values',
                  base_url=BASE_URL,
-                 json=VALID_VALUE_JSON)
+                 json=VALID_FX_VALUE_JSON)
     assert r.status_code == 404
 
 
@@ -170,7 +171,7 @@ def test_post_forecast_values_valid_csv(api, cdf_forecast_id):
     r = api.post(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
                  base_url=BASE_URL,
                  headers={'Content-Type': 'text/csv'},
-                 data=VALID_CSV)
+                 data=VALID_FX_VALUE_CSV)
     assert r.status_code == 201
 
 
@@ -210,7 +211,7 @@ def test_get_cdf_forecast_values_200(api, start, end, mimetype,
 def test_post_and_get_values_json(api, cdf_forecast_id):
     r = api.post(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
                  base_url=BASE_URL,
-                 json=VALID_VALUE_JSON)
+                 json=VALID_FX_VALUE_JSON)
     assert r.status_code == 201
     start = '2019-01-22T17:54:00+00:00'
     end = '2019-01-22T17:56:00+00:00'
@@ -219,14 +220,14 @@ def test_post_and_get_values_json(api, cdf_forecast_id):
                 headers={'Accept': 'application/json'},
                 query_string={'start': start, 'end': end})
     posted_data = r.get_json()
-    assert VALID_VALUE_JSON['values'] == posted_data['values']
+    assert VALID_FX_VALUE_JSON['values'] == posted_data['values']
 
 
 def test_post_and_get_values_csv(api, cdf_forecast_id):
     r = api.post(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
                  base_url=BASE_URL,
                  headers={'Content-Type': 'text/csv'},
-                 data=VALID_CSV)
+                 data=VALID_FX_VALUE_CSV)
     assert r.status_code == 201
     start = '2019-01-22T12:04:00+00:00'
     end = '2019-01-22T12:07:00+00:00'
@@ -235,4 +236,4 @@ def test_post_and_get_values_csv(api, cdf_forecast_id):
                 headers={'Accept': 'text/csv'},
                 query_string={'start': start, 'end': end})
     posted_data = r.data
-    assert VALID_CSV == posted_data.decode('utf-8')
+    assert VALID_FX_VALUE_CSV == posted_data.decode('utf-8')

--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -80,8 +80,8 @@ def test_get_forecast_links(api, forecast_id):
     assert '_links' in response
 
 
-def test_get_forecast_404(api, missing_forecast_id):
-    r = api.get(f'/forecasts/single/{missing_forecast_id}',
+def test_get_forecast_404(api, missing_id):
+    r = api.get(f'/forecasts/single/{missing_id}',
                 base_url='https://localhost')
     assert r.status_code == 404
 
@@ -96,8 +96,8 @@ def test_get_forecast_metadata(api, forecast_id):
     assert 'site_id' in response
 
 
-def test_get_forecast_metadata_404(api, missing_forecast_id):
-    r = api.get(f'/forecasts/single{missing_forecast_id}/metadata',
+def test_get_forecast_metadata_404(api, missing_id):
+    r = api.get(f'/forecasts/single{missing_id}/metadata',
                 base_url='https://localhost')
     assert r.status_code == 404
 
@@ -146,10 +146,10 @@ def test_post_json_storage_call(api, forecast_id, mocker):
     storage.assert_called()
 
 
-def test_post_values_404(api, missing_forecast_id, mocker):
+def test_post_values_404(api, missing_id, mocker):
     storage = mocker.patch('sfa_api.demo.store_forecast_values')
     storage.return_value = None
-    r = api.post(f'/forecasts/single/{missing_forecast_id}/values',
+    r = api.post(f'/forecasts/single/{missing_id}/values',
                  base_url='https://localhost',
                  json=VALID_VALUE_JSON)
     assert r.status_code == 404
@@ -190,8 +190,8 @@ def test_post_forecast_values_valid_csv(api, forecast_id):
     assert r.status_code == 201
 
 
-def test_get_forecast_values_404(api, missing_forecast_id):
-    r = api.get(f'/forecasts/single/{missing_forecast_id}/values',
+def test_get_forecast_values_404(api, missing_id):
+    r = api.get(f'/forecasts/single/{missing_id}/values',
                 base_url='https://localhost')
     assert r.status_code == 404
 

--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -2,7 +2,7 @@ import pytest
 
 
 from sfa_api.conftest import (variables, interval_value_types, interval_labels,
-                              VALID_FORECAST_JSON, copy_update)
+                              BASE_URL, VALID_FORECAST_JSON, copy_update)
 
 
 INVALID_VARIABLE = copy_update(VALID_FORECAST_JSON,
@@ -29,7 +29,7 @@ empty_json_response = '{"interval_label":["Missing data for required field."],"i
 ])
 def test_forecast_post_success(api, payload, status_code):
     r = api.post('/forecasts/single/',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  json=payload)
     assert r.status_code == status_code
     assert 'Location' in r.headers
@@ -47,7 +47,7 @@ def test_forecast_post_success(api, payload, status_code):
 ])
 def test_forecast_post_bad_request(api, payload, message):
     r = api.post('/forecasts/single/',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  json=payload)
     assert r.status_code == 400
     assert r.get_data(as_text=True) == f'{{"errors":{message}}}\n'
@@ -55,7 +55,7 @@ def test_forecast_post_bad_request(api, payload, message):
 
 def test_get_forecast_links(api, forecast_id):
     r = api.get(f'/forecasts/single/{forecast_id}',
-                base_url='https://localhost')
+                base_url=BASE_URL)
     response = r.get_json()
     assert 'forecast_id' in response
     assert '_links' in response
@@ -63,13 +63,13 @@ def test_get_forecast_links(api, forecast_id):
 
 def test_get_forecast_404(api, missing_id):
     r = api.get(f'/forecasts/single/{missing_id}',
-                base_url='https://localhost')
+                base_url=BASE_URL)
     assert r.status_code == 404
 
 
 def test_get_forecast_metadata(api, forecast_id):
     r = api.get(f'/forecasts/single/{forecast_id}/metadata',
-                base_url='https://localhost')
+                base_url=BASE_URL)
     response = r.get_json()
     assert 'forecast_id' in response
     assert 'variable' in response
@@ -79,7 +79,7 @@ def test_get_forecast_metadata(api, forecast_id):
 
 def test_get_forecast_metadata_404(api, missing_id):
     r = api.get(f'/forecasts/single{missing_id}/metadata',
-                base_url='https://localhost')
+                base_url=BASE_URL)
     assert r.status_code == 404
 
 
@@ -113,7 +113,7 @@ NON_NUMERICAL_VALUE_CSV = "timestamp,value\n2018-10-29T12:04:23Z,fgh" # NOQA
 
 def test_post_forecast_values_valid_json(api, forecast_id):
     r = api.post(f'/forecasts/single/{forecast_id}/values',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  json=VALID_VALUE_JSON)
     assert r.status_code == 201
 
@@ -122,7 +122,7 @@ def test_post_json_storage_call(api, forecast_id, mocker):
     storage = mocker.patch('sfa_api.demo.store_forecast_values')
     storage.return_value = forecast_id
     api.post(f'/forecasts/single/{forecast_id}/values',
-             base_url='https://localhost',
+             base_url=BASE_URL,
              json=VALID_VALUE_JSON)
     storage.assert_called()
 
@@ -131,7 +131,7 @@ def test_post_values_404(api, missing_id, mocker):
     storage = mocker.patch('sfa_api.demo.store_forecast_values')
     storage.return_value = None
     r = api.post(f'/forecasts/single/{missing_id}/values',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  json=VALID_VALUE_JSON)
     assert r.status_code == 404
 
@@ -144,7 +144,7 @@ def test_post_values_404(api, missing_id, mocker):
 ])
 def test_post_forecast_values_invalid_json(api, payload, forecast_id):
     r = api.post(f'/forecasts/single/{forecast_id}/values',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  json=payload)
     assert r.status_code == 400
 
@@ -157,7 +157,7 @@ def test_post_forecast_values_invalid_json(api, payload, forecast_id):
 ])
 def test_post_forecast_values_invalid_csv(api, payload, forecast_id):
     r = api.post(f'/forecasts/single/{forecast_id}/values',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  headers={'Content-Type': 'text/csv'},
                  data=payload)
     assert r.status_code == 400
@@ -165,7 +165,7 @@ def test_post_forecast_values_invalid_csv(api, payload, forecast_id):
 
 def test_post_forecast_values_valid_csv(api, forecast_id):
     r = api.post(f'/forecasts/single/{forecast_id}/values',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  headers={'Content-Type': 'text/csv'},
                  data=VALID_CSV)
     assert r.status_code == 201
@@ -173,7 +173,7 @@ def test_post_forecast_values_valid_csv(api, forecast_id):
 
 def test_get_forecast_values_404(api, missing_id):
     r = api.get(f'/forecasts/single/{missing_id}/values',
-                base_url='https://localhost')
+                base_url=BASE_URL)
     assert r.status_code == 404
 
 
@@ -183,7 +183,7 @@ def test_get_forecast_values_404(api, missing_id):
 ])
 def test_get_forecast_values_400(api, start, end, mimetype, forecast_id):
     r = api.get(f'/forecasts/single/{forecast_id}/values',
-                base_url='https://localhost',
+                base_url=BASE_URL,
                 headers={'Accept': mimetype},
                 query_string={'start': start, 'end': end})
     assert r.status_code == 400
@@ -196,7 +196,7 @@ def test_get_forecast_values_400(api, start, end, mimetype, forecast_id):
 ])
 def test_get_forecast_values_200(api, start, end, mimetype, forecast_id):
     r = api.get(f'/forecasts/single/{forecast_id}/values',
-                base_url='https://localhost',
+                base_url=BASE_URL,
                 headers={'Accept': mimetype},
                 query_string={'start': start, 'end': end})
     assert r.status_code == 200

--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -1,9 +1,6 @@
 import pytest
 
 
-import pandas.testing as pdt
-
-
 from sfa_api.conftest import (variables, interval_value_types, interval_labels,
                               BASE_URL, VALID_FORECAST_JSON, copy_update)
 
@@ -110,7 +107,7 @@ NON_NUMERICAL_VALUE_JSON = {
     ]
 }
 VALID_CSV = ('# forecast_id: f8dd49fa-23e2-48a0-862b-ba0af6dec276\n'
-             '# metadata: https://localhost/forecasts/single/f8dd49fa-23e2-48a0-862b-ba0af6dec276/metadata\n' #NOQA
+             '# metadata: https://localhost/forecasts/single/f8dd49fa-23e2-48a0-862b-ba0af6dec276/metadata\n' # NOQA
              'timestamp,value\n'
              '20190122T12:04:00+0000,7.0\n'
              '20190122T12:05:00+0000,3.0\n'

--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -2,7 +2,8 @@ import pytest
 
 
 from sfa_api.conftest import (variables, interval_value_types, interval_labels,
-                              BASE_URL, VALID_FORECAST_JSON, copy_update)
+                              BASE_URL, VALID_FORECAST_JSON, copy_update,
+                              VALID_FX_VALUE_JSON, VALID_FX_VALUE_CSV)
 
 
 INVALID_VARIABLE = copy_update(VALID_FORECAST_JSON,
@@ -83,17 +84,7 @@ def test_get_forecast_metadata_404(api, missing_id):
     assert r.status_code == 404
 
 
-VALID_VALUE_JSON = {
-    'id': '123e4567-e89b-12d3-a456-426655440000',
-    'values': [
-        {'timestamp': "2019-01-22T17:54:00+00:00",
-         'value': 1.0},
-        {'timestamp': "2019-01-22T17:55:00+00:00",
-         'value': 32.0},
-        {'timestamp': "2019-01-22T17:56:00+00:00",
-         'value': 3.0}
-    ]
-}
+
 WRONG_DATE_FORMAT_VALUE_JSON = {
     'values': [
         {'timestamp': '20-2-3T11111F',
@@ -106,13 +97,6 @@ NON_NUMERICAL_VALUE_JSON = {
          'value': 'four'},
     ]
 }
-VALID_CSV = ('# forecast_id: f8dd49fa-23e2-48a0-862b-ba0af6dec276\n'
-             '# metadata: https://localhost/forecasts/single/f8dd49fa-23e2-48a0-862b-ba0af6dec276/metadata\n' # NOQA
-             'timestamp,value\n'
-             '20190122T12:04:00+0000,7.0\n'
-             '20190122T12:05:00+0000,3.0\n'
-             '20190122T12:06:00+0000,13.0\n'
-             '20190122T12:07:00+0000,25.0\n')
 WRONG_DATE_FORMAT_CSV = "timestamp,value\nksdfjgn,32.93"
 NON_NUMERICAL_VALUE_CSV = "timestamp,value\n2018-10-29T12:04:00:00+00,fgh" # NOQA
 
@@ -120,7 +104,7 @@ NON_NUMERICAL_VALUE_CSV = "timestamp,value\n2018-10-29T12:04:00:00+00,fgh" # NOQ
 def test_post_forecast_values_valid_json(api, forecast_id):
     r = api.post(f'/forecasts/single/{forecast_id}/values',
                  base_url=BASE_URL,
-                 json=VALID_VALUE_JSON)
+                 json=VALID_FX_VALUE_JSON)
     assert r.status_code == 201
 
 
@@ -129,7 +113,7 @@ def test_post_json_storage_call(api, forecast_id, mocker):
     storage.return_value = forecast_id
     api.post(f'/forecasts/single/{forecast_id}/values',
              base_url=BASE_URL,
-             json=VALID_VALUE_JSON)
+             json=VALID_FX_VALUE_JSON)
     storage.assert_called()
 
 
@@ -138,7 +122,7 @@ def test_post_values_404(api, missing_id, mocker):
     storage.return_value = None
     r = api.post(f'/forecasts/single/{missing_id}/values',
                  base_url=BASE_URL,
-                 json=VALID_VALUE_JSON)
+                 json=VALID_FX_VALUE_JSON)
     assert r.status_code == 404
 
 
@@ -173,7 +157,7 @@ def test_post_forecast_values_valid_csv(api, forecast_id):
     r = api.post(f'/forecasts/single/{forecast_id}/values',
                  base_url=BASE_URL,
                  headers={'Content-Type': 'text/csv'},
-                 data=VALID_CSV)
+                 data=VALID_FX_VALUE_CSV)
     assert r.status_code == 201
 
 
@@ -212,7 +196,7 @@ def test_get_forecast_values_200(api, start, end, mimetype, forecast_id):
 def test_post_and_get_values_json(api, forecast_id):
     r = api.post(f'/forecasts/single/{forecast_id}/values',
                  base_url=BASE_URL,
-                 json=VALID_VALUE_JSON)
+                 json=VALID_FX_VALUE_JSON)
     assert r.status_code == 201
     start = '2019-01-22T17:54:00+00:00'
     end = '2019-01-22T17:56:00+00:00'
@@ -221,14 +205,14 @@ def test_post_and_get_values_json(api, forecast_id):
                 headers={'Accept': 'application/json'},
                 query_string={'start': start, 'end': end})
     posted_data = r.get_json()
-    assert VALID_VALUE_JSON['values'] == posted_data['values']
+    assert VALID_FX_VALUE_JSON['values'] == posted_data['values']
 
 
 def test_post_and_get_values_csv(api, forecast_id):
     r = api.post(f'/forecasts/single/{forecast_id}/values',
                  base_url=BASE_URL,
                  headers={'Content-Type': 'text/csv'},
-                 data=VALID_CSV)
+                 data=VALID_FX_VALUE_CSV)
     assert r.status_code == 201
     start = '2019-01-22T12:04:00+00:00'
     end = '2019-01-22T12:07:00+00:00'
@@ -237,4 +221,4 @@ def test_post_and_get_values_csv(api, forecast_id):
                 headers={'Accept': 'text/csv'},
                 query_string={'start': start, 'end': end})
     posted_data = r.data
-    assert VALID_CSV == posted_data.decode('utf-8')
+    assert VALID_FX_VALUE_CSV == posted_data.decode('utf-8')

--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -1,27 +1,8 @@
 import pytest
 
 
-from sfa_api.conftest import variables, interval_value_types, interval_labels
-
-
-VALID_FORECAST_JSON = {
-    "extra_parameters": '{"instrument": "pyranometer"}',
-    "name": "test forecast",
-    "site_id": "123e4567-e89b-12d3-a456-426655440001",
-    "variable": "ac_power",
-    "interval_label": "beginning",
-    "issue_time_of_day": "12:00",
-    "lead_time_to_start": 60,
-    "interval_length": 1,
-    "run_length": 1440,
-    "interval_value_type": "interval_mean",
-}
-
-
-def copy_update(json, key, value):
-    new_json = json.copy()
-    new_json[key] = value
-    return new_json
+from sfa_api.conftest import (variables, interval_value_types, interval_labels,
+                              VALID_FORECAST_JSON, copy_update)
 
 
 INVALID_VARIABLE = copy_update(VALID_FORECAST_JSON,

--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -84,7 +84,6 @@ def test_get_forecast_metadata_404(api, missing_id):
     assert r.status_code == 404
 
 
-
 WRONG_DATE_FORMAT_VALUE_JSON = {
     'values': [
         {'timestamp': '20-2-3T11111F',

--- a/sfa_api/tests/test_observation.py
+++ b/sfa_api/tests/test_observation.py
@@ -58,8 +58,8 @@ def test_get_observation_links(api, observation_id):
     assert '_links' in response
 
 
-def test_get_observation_links_404(api, missing_observation_id):
-    r = api.get(f'/observations/{missing_observation_id}',
+def test_get_observation_links_404(api, missing_id):
+    r = api.get(f'/observations/{missing_id}',
                 base_url='https://localhost')
     assert r.status_code == 404
 
@@ -74,8 +74,8 @@ def test_get_observation_metadata(api, observation_id):
     assert 'site_id' in response
 
 
-def test_get_observation_metadata_404(api, missing_observation_id):
-    r = api.get(f'/observations/{missing_observation_id}/metadata',
+def test_get_observation_metadata_404(api, missing_id):
+    r = api.get(f'/observations/{missing_id}/metadata',
                 base_url='https://localhost')
     assert r.status_code == 404
 
@@ -174,8 +174,8 @@ def test_post_observation_values_valid_csv(api, observation_id):
     assert r.status_code == 201
 
 
-def test_get_observation_values_404(api, missing_observation_id):
-    r = api.get(f'/observations/{missing_observation_id}/values',
+def test_get_observation_values_404(api, missing_id):
+    r = api.get(f'/observations/{missing_id}/values',
                 base_url='https://localhost')
     assert r.status_code == 404
 

--- a/sfa_api/tests/test_observations.py
+++ b/sfa_api/tests/test_observations.py
@@ -2,6 +2,7 @@ import pytest
 
 
 from sfa_api.conftest import (variables, interval_labels, BASE_URL,
+                              VALID_OBS_VALUE_JSON, VALID_OBS_VALUE_CSV,
                               VALID_OBS_JSON, copy_update)
 
 
@@ -65,20 +66,6 @@ def test_get_observation_metadata_404(api, missing_id):
     assert r.status_code == 404
 
 
-VALID_JSON = {
-    'id': '123e4567-e89b-12d3-a456-426655440000',
-    'values': [
-        {'quality_flag': 0,
-         'timestamp': "2019-01-22T17:54:00+00:00",
-         'value': 1.0},
-        {'quality_flag': 0,
-         'timestamp': "2019-01-22T17:55:00+00:00",
-         'value': 32.0},
-        {'quality_flag': 0,
-         'timestamp': "2019-01-22T17:56:00+00:00",
-         'value': 3.0}
-    ]
-}
 WRONG_DATE_FORMAT_JSON = {
     'values': [
         {'quality_flag': 0,
@@ -100,13 +87,6 @@ NON_BINARY_FLAG_JSON = {
          'value': 3},
     ]
 }
-VALID_CSV = ('# observation_id: 123e4567-e89b-12d3-a456-426655440000\n'
-             '# metadata: https://localhost/observations/123e4567-e89b-12d3-a456-426655440000/metadata\n' # NOQA
-             'timestamp,value,quality_flag\n'
-             '20190122T12:04:00+0000,52.0,0\n'
-             '20190122T12:05:00+0000,73.0,0\n'
-             '20190122T12:06:00+0000,42.0,0\n'
-             '20190122T12:07:00+0000,12.0,0\n')
 WRONG_DATE_FORMAT_CSV = "timestamp,value,quality_flag\nksdfjgn,32.93,0"
 NON_NUMERICAL_VALUE_CSV = "timestamp,value,quality_flag\n2018-10-29T12:04:23Z,fgh,0" # NOQA
 NON_BINARY_FLAG_CSV = "timestamp,value,quality_flag\n2018-10-29T12:04:23Z,32.93,B" # NOQA
@@ -115,7 +95,7 @@ NON_BINARY_FLAG_CSV = "timestamp,value,quality_flag\n2018-10-29T12:04:23Z,32.93,
 def test_post_observation_values_valid_json(api, observation_id):
     r = api.post(f'/observations/{observation_id}/values',
                  base_url=BASE_URL,
-                 json=VALID_JSON)
+                 json=VALID_OBS_VALUE_JSON)
     assert r.status_code == 201
 
 
@@ -124,7 +104,7 @@ def test_post_json_storage_call(api, observation_id, mocker):
     storage.return_value = observation_id
     api.post(f'/observations/{observation_id}/values',
              base_url=BASE_URL,
-             json=VALID_JSON)
+             json=VALID_OBS_VALUE_JSON)
     storage.assert_called()
 
 
@@ -161,7 +141,7 @@ def test_post_observation_values_valid_csv(api, observation_id):
     r = api.post(f'/observations/{observation_id}/values',
                  base_url=BASE_URL,
                  headers={'Content-Type': 'text/csv'},
-                 data=VALID_CSV)
+                 data=VALID_OBS_VALUE_CSV)
     assert r.status_code == 201
 
 
@@ -200,7 +180,7 @@ def test_get_observation_values_200(api, start, end, mimetype, observation_id):
 def test_post_and_get_values_json(api, observation_id):
     r = api.post(f'/observations/{observation_id}/values',
                  base_url=BASE_URL,
-                 json=VALID_JSON)
+                 json=VALID_OBS_VALUE_JSON)
     assert r.status_code == 201
     start = '2019-01-22T17:54:00+00:00'
     end = '2019-01-22T17:56:00+00:00'
@@ -209,14 +189,14 @@ def test_post_and_get_values_json(api, observation_id):
                 headers={'Accept': 'application/json'},
                 query_string={'start': start, 'end': end})
     posted_data = r.get_json()
-    assert VALID_JSON['values'] == posted_data['values']
+    assert VALID_OBS_VALUE_JSON['values'] == posted_data['values']
 
 
 def test_post_and_get_values_csv(api, observation_id):
     r = api.post(f'/observations/{observation_id}/values',
                  base_url=BASE_URL,
                  headers={'Content-Type': 'text/csv'},
-                 data=VALID_CSV)
+                 data=VALID_OBS_VALUE_CSV)
     assert r.status_code == 201
     start = '2019-01-22T12:04:00+00:00'
     end = '2019-01-22T12:07:00+00:00'
@@ -225,4 +205,4 @@ def test_post_and_get_values_csv(api, observation_id):
                 headers={'Accept': 'text/csv'},
                 query_string={'start': start, 'end': end})
     posted_data = r.data
-    assert VALID_CSV == posted_data.decode('utf-8')
+    assert VALID_OBS_VALUE_CSV == posted_data.decode('utf-8')

--- a/sfa_api/tests/test_observations.py
+++ b/sfa_api/tests/test_observations.py
@@ -101,7 +101,7 @@ NON_BINARY_FLAG_JSON = {
     ]
 }
 VALID_CSV = ('# observation_id: 123e4567-e89b-12d3-a456-426655440000\n'
-             '# metadata: https://localhost/observations/123e4567-e89b-12d3-a456-426655440000/metadata\n' #NOQA
+             '# metadata: https://localhost/observations/123e4567-e89b-12d3-a456-426655440000/metadata\n' # NOQA
              'timestamp,quality_flag,value\n'
              '20190122T12:04:00+0000,0.0,52.0\n'
              '20190122T12:05:00+0000,0.0,73.0\n'

--- a/sfa_api/tests/test_observations.py
+++ b/sfa_api/tests/test_observations.py
@@ -12,7 +12,7 @@ INVALID_INTERVAL_LABEL = copy_update(VALID_OBS_JSON,
                                      'interval_label', 'invalid')
 
 
-empty_json_response = '{"interval_label":["Missing data for required field."],"interval_length":["Missing data for required field."],"name":["Missing data for required field."],"site_id":["Missing data for required field."],"variable":["Missing data for required field."]}' # NOQA
+empty_json_response = '{"interval_label":["Missing data for required field."],"interval_length":["Missing data for required field."],"interval_value_type":["Missing data for required field."],"name":["Missing data for required field."],"site_id":["Missing data for required field."],"uncertainty":["Missing data for required field."],"variable":["Missing data for required field."]}' # NOQA
 
 
 def test_observation_post_success(api):

--- a/sfa_api/tests/test_observations.py
+++ b/sfa_api/tests/test_observations.py
@@ -1,23 +1,8 @@
 import pytest
 
 
-from sfa_api.conftest import variables, interval_labels
-
-
-VALID_OBS_JSON = {
-    "extra_parameters": '{"instrument": "Ascension Technology Rotating Shadowband Pyranometer"}', # NOQA
-    "name": "Ashland OR, ghi",
-    "site_id": "123e4567-e89b-12d3-a456-426655440001",
-    "variable": "ghi",
-    "interval_label": "beginning",
-    "interval_length": 1,
-}
-
-
-def copy_update(json, key, value):
-    new_json = json.copy()
-    new_json[key] = value
-    return new_json
+from sfa_api.conftest import (variables, interval_labels,
+                              VALID_OBS_JSON, copy_update)
 
 
 INVALID_VARIABLE = copy_update(VALID_OBS_JSON,

--- a/sfa_api/tests/test_observations.py
+++ b/sfa_api/tests/test_observations.py
@@ -102,11 +102,11 @@ NON_BINARY_FLAG_JSON = {
 }
 VALID_CSV = ('# observation_id: 123e4567-e89b-12d3-a456-426655440000\n'
              '# metadata: https://localhost/observations/123e4567-e89b-12d3-a456-426655440000/metadata\n' # NOQA
-             'timestamp,quality_flag,value\n'
-             '20190122T12:04:00+0000,0.0,52.0\n'
-             '20190122T12:05:00+0000,0.0,73.0\n'
-             '20190122T12:06:00+0000,0.0,42.0\n'
-             '20190122T12:07:00+0000,0.0,12.0\n')
+             'timestamp,value,quality_flag\n'
+             '20190122T12:04:00+0000,52.0,0\n'
+             '20190122T12:05:00+0000,73.0,0\n'
+             '20190122T12:06:00+0000,42.0,0\n'
+             '20190122T12:07:00+0000,12.0,0\n')
 WRONG_DATE_FORMAT_CSV = "timestamp,value,quality_flag\nksdfjgn,32.93,0"
 NON_NUMERICAL_VALUE_CSV = "timestamp,value,quality_flag\n2018-10-29T12:04:23Z,fgh,0" # NOQA
 NON_BINARY_FLAG_CSV = "timestamp,value,quality_flag\n2018-10-29T12:04:23Z,32.93,B" # NOQA

--- a/sfa_api/tests/test_observations.py
+++ b/sfa_api/tests/test_observations.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-from sfa_api.conftest import (variables, interval_labels,
+from sfa_api.conftest import (variables, interval_labels, BASE_URL,
                               VALID_OBS_JSON, copy_update)
 
 
@@ -16,7 +16,7 @@ empty_json_response = '{"interval_label":["Missing data for required field."],"i
 
 def test_observation_post_success(api):
     r = api.post('/observations/',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  json=VALID_OBS_JSON)
     assert r.status_code == 201
     assert 'Location' in r.headers
@@ -29,7 +29,7 @@ def test_observation_post_success(api):
 ])
 def test_observation_post_bad_request(api, payload, message):
     r = api.post('/observations/',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  json=payload)
     assert r.status_code == 400
     assert r.get_data(as_text=True) == f'{{"errors":{message}}}\n'
@@ -37,7 +37,7 @@ def test_observation_post_bad_request(api, payload, message):
 
 def test_get_observation_links(api, observation_id):
     r = api.get(f'/observations/{observation_id}',
-                base_url='https://localhost')
+                base_url=BASE_URL)
     response = r.get_json()
     assert 'observation_id' in response
     assert '_links' in response
@@ -45,13 +45,13 @@ def test_get_observation_links(api, observation_id):
 
 def test_get_observation_links_404(api, missing_id):
     r = api.get(f'/observations/{missing_id}',
-                base_url='https://localhost')
+                base_url=BASE_URL)
     assert r.status_code == 404
 
 
 def test_get_observation_metadata(api, observation_id):
     r = api.get(f'/observations/{observation_id}/metadata',
-                base_url='https://localhost')
+                base_url=BASE_URL)
     response = r.get_json()
     assert 'observation_id' in response
     assert 'variable' in response
@@ -61,7 +61,7 @@ def test_get_observation_metadata(api, observation_id):
 
 def test_get_observation_metadata_404(api, missing_id):
     r = api.get(f'/observations/{missing_id}/metadata',
-                base_url='https://localhost')
+                base_url=BASE_URL)
     assert r.status_code == 404
 
 
@@ -108,7 +108,7 @@ NON_BINARY_FLAG_CSV = "timestamp,value,quality_flag\n2018-10-29T12:04:23Z,32.93,
 
 def test_post_observation_values_valid_json(api, observation_id):
     r = api.post(f'/observations/{observation_id}/values',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  json=VALID_JSON)
     assert r.status_code == 201
 
@@ -117,7 +117,7 @@ def test_post_json_storage_call(api, observation_id, mocker):
     storage = mocker.patch('sfa_api.demo.store_observation_values')
     storage.return_value = observation_id
     api.post(f'/observations/{observation_id}/values',
-             base_url='https://localhost',
+             base_url=BASE_URL,
              json=VALID_JSON)
     storage.assert_called()
 
@@ -131,7 +131,7 @@ def test_post_json_storage_call(api, observation_id, mocker):
 ])
 def test_post_observation_values_invalid_json(api, payload, observation_id):
     r = api.post(f'/observations/{observation_id}/values',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  json=payload)
     assert r.status_code == 400
 
@@ -145,7 +145,7 @@ def test_post_observation_values_invalid_json(api, payload, observation_id):
 ])
 def test_post_observation_values_invalid_csv(api, payload, observation_id):
     r = api.post(f'/observations/{observation_id}/values',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  headers={'Content-Type': 'text/csv'},
                  data=payload)
     assert r.status_code == 400
@@ -153,7 +153,7 @@ def test_post_observation_values_invalid_csv(api, payload, observation_id):
 
 def test_post_observation_values_valid_csv(api, observation_id):
     r = api.post(f'/observations/{observation_id}/values',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  headers={'Content-Type': 'text/csv'},
                  data=VALID_CSV)
     assert r.status_code == 201
@@ -161,7 +161,7 @@ def test_post_observation_values_valid_csv(api, observation_id):
 
 def test_get_observation_values_404(api, missing_id):
     r = api.get(f'/observations/{missing_id}/values',
-                base_url='https://localhost')
+                base_url=BASE_URL)
     assert r.status_code == 404
 
 
@@ -171,7 +171,7 @@ def test_get_observation_values_404(api, missing_id):
 ])
 def test_get_observation_values_400(api, start, end, mimetype, observation_id):
     r = api.get(f'/observations/{observation_id}/values',
-                base_url='https://localhost',
+                base_url=BASE_URL,
                 headers={'Accept': mimetype},
                 query_string={'start': start, 'end': end})
     assert r.status_code == 400
@@ -184,7 +184,7 @@ def test_get_observation_values_400(api, start, end, mimetype, observation_id):
 ])
 def test_get_observation_values_200(api, start, end, mimetype, observation_id):
     r = api.get(f'/observations/{observation_id}/values',
-                base_url='https://localhost',
+                base_url=BASE_URL,
                 headers={'Accept': mimetype},
                 query_string={'start': start, 'end': end})
     assert r.status_code == 200

--- a/sfa_api/tests/test_sites.py
+++ b/sfa_api/tests/test_sites.py
@@ -99,7 +99,7 @@ def test_site_forecasts_404(api, missing_id):
     assert r.status_code == 404
 
 
-def test_site_delete_200(api, site_id):
+def test_site_delete_204(api, site_id):
     r = api.post('/sites/',
                  base_url=BASE_URL,
                  json=VALID_SITE_JSON)
@@ -108,10 +108,4 @@ def test_site_delete_200(api, site_id):
     new_site_id = r.data.decode('utf-8')
     r = api.delete(f'/sites/{new_site_id}',
                    base_url=BASE_URL)
-    assert r.status_code == 200
-
-
-def test_site_delete_404(api, missing_id):
-    r = api.delete(f'/sites/{missing_id}',
-                   base_url=BASE_URL)
-    assert r.status_code == 404
+    assert r.status_code == 204

--- a/sfa_api/tests/test_sites.py
+++ b/sfa_api/tests/test_sites.py
@@ -1,5 +1,7 @@
 import pytest
 
+from sfa_api.conftest import VALID_SITE_JSON
+
 
 def invalidate(json, key):
     new_json = json.copy()
@@ -7,24 +9,6 @@ def invalidate(json, key):
     return new_json
 
 
-VALID_SITE_JSON = {
-    "elevation": 500.0,
-    "extra_parameters": '{"parameter": "value"}',
-    "latitude": 42.19,
-    "longitude": -122.7,
-    "modeling_parameters": {
-        "ac_capacity": 0.015,
-        "dc_capacity": 0.015,
-        "backtrack": True,
-        "temperature_coefficient": -.002,
-        "ground_coverage_ratio": 0.5,
-        "surface_azimuth": 180,
-        "surface_tilt": 45.0,
-        "tracking_type": "fixed"
-    },
-    "name": "Test Site",
-    "timezone": "Etc/GMT+8",
-}
 INVALID_ELEVATION = invalidate(VALID_SITE_JSON, 'elevation')
 INVALID_LATITUDE = invalidate(VALID_SITE_JSON, 'latitude')
 INVALID_LONGITUDE = invalidate(VALID_SITE_JSON, 'longitude')

--- a/sfa_api/tests/test_sites.py
+++ b/sfa_api/tests/test_sites.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sfa_api.conftest import VALID_SITE_JSON
+from sfa_api.conftest import VALID_SITE_JSON, BASE_URL
 
 
 def invalidate(json, key):
@@ -33,7 +33,7 @@ OUTSIDE_LONGITUDE['longitude'] = 181
 ])
 def test_site_post_201(api, payload):
     r = api.post('/sites/',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  json=payload)
     assert r.status_code == 201
     assert 'Location' in r.headers
@@ -49,7 +49,7 @@ def test_site_post_201(api, payload):
 ])
 def test_site_post_400(api, payload, message):
     r = api.post('/sites/',
-                 base_url='https://localhost',
+                 base_url=BASE_URL,
                  json=payload)
     assert r.status_code == 400
     assert r.get_data(as_text=True) == f'{{"errors":{message}}}\n'
@@ -57,55 +57,61 @@ def test_site_post_400(api, payload, message):
 
 def test_all_sites_get_200(api):
     r = api.get('/sites/',
-                base_url='https://localhost')
+                base_url=BASE_URL)
     assert r.status_code == 200
 
 
 def test_site_get_200(api, site_id):
     r = api.get(f'/sites/{site_id}',
-                base_url='https://localhost')
+                base_url=BASE_URL)
     assert r.status_code == 200
 
 
 def test_site_get_404(api, missing_id):
     r = api.get(f'/sites/{missing_id}',
-                base_url='https://localhost')
+                base_url=BASE_URL)
     assert r.status_code == 404
 
 
 def test_site_observations_200(api, site_id):
     r = api.get(f'/sites/{site_id}/observations',
-                base_url='https://localhost')
+                base_url=BASE_URL)
     assert r.status_code == 200
     assert isinstance(r.get_json(), list)
 
 
 def test_site_observations_404(api, missing_id):
     r = api.get(f'/sites/{missing_id}/observations',
-                base_url='https://localhost')
+                base_url=BASE_URL)
     assert r.status_code == 404
 
 
 def test_site_forecasts_200(api, site_id_plant):
     r = api.get(f'/sites/{site_id_plant}/forecasts/single',
-                base_url='https://localhost')
+                base_url=BASE_URL)
     assert r.status_code == 200
     assert isinstance(r.get_json(), list)
 
 
 def test_site_forecasts_404(api, missing_id):
     r = api.get(f'/sites/{missing_id}/forecasts/single',
-                base_url='https://localhost')
+                base_url=BASE_URL)
     assert r.status_code == 404
 
 
 def test_site_delete_200(api, site_id):
-    r = api.delete(f'/sites/{site_id}',
-                   base_url='https://localhost')
+    r = api.post('/sites/',
+                 base_url=BASE_URL,
+                 json=VALID_SITE_JSON)
+    assert r.status_code == 201
+    assert 'Location' in r.headers
+    new_site_id = r.data.decode('utf-8')
+    r = api.delete(f'/sites/{new_site_id}',
+                   base_url=BASE_URL)
     assert r.status_code == 200
 
 
 def test_site_delete_404(api, missing_id):
     r = api.delete(f'/sites/{missing_id}',
-                   base_url='https://localhost')
+                   base_url=BASE_URL)
     assert r.status_code == 404

--- a/sfa_api/tests/test_sites.py
+++ b/sfa_api/tests/test_sites.py
@@ -83,8 +83,8 @@ def test_site_get_200(api, site_id):
     assert r.status_code == 200
 
 
-def test_site_get_404(api, missing_site_id):
-    r = api.get(f'/sites/{missing_site_id}',
+def test_site_get_404(api, missing_id):
+    r = api.get(f'/sites/{missing_id}',
                 base_url='https://localhost')
     assert r.status_code == 404
 
@@ -96,8 +96,8 @@ def test_site_observations_200(api, site_id):
     assert isinstance(r.get_json(), list)
 
 
-def test_site_observations_404(api, missing_site_id):
-    r = api.get(f'/sites/{missing_site_id}/observations',
+def test_site_observations_404(api, missing_id):
+    r = api.get(f'/sites/{missing_id}/observations',
                 base_url='https://localhost')
     assert r.status_code == 404
 
@@ -109,8 +109,8 @@ def test_site_forecasts_200(api, site_id_plant):
     assert isinstance(r.get_json(), list)
 
 
-def test_site_forecasts_404(api, missing_site_id):
-    r = api.get(f'/sites/{missing_site_id}/forecasts/single',
+def test_site_forecasts_404(api, missing_id):
+    r = api.get(f'/sites/{missing_id}/forecasts/single',
                 base_url='https://localhost')
     assert r.status_code == 404
 
@@ -121,7 +121,7 @@ def test_site_delete_200(api, site_id):
     assert r.status_code == 200
 
 
-def test_site_delete_404(api, missing_site_id):
-    r = api.delete(f'/sites/{missing_site_id}',
+def test_site_delete_404(api, missing_id):
+    r = api.delete(f'/sites/{missing_id}',
                    base_url='https://localhost')
     assert r.status_code == 404

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -77,7 +77,6 @@ def get_cursor(cursor_type, commit=True):
     finally:
         cursor.close()
 
-
 def try_query(query_cmd):
     try:
         query_cmd()
@@ -218,7 +217,7 @@ def store_observation(observation):
     # the procedure expects arguments in a certain order
     _call_procedure(
         'store_observation', observation_id,
-        observation['variable'], observation['site_id'],
+        observation['variable'], str(observation['site_id']),
         observation['name'], observation['interval_label'],
         observation['interval_length'], observation['interval_value_type'],
         observation['uncertainty'], observation['extra_parameters'])
@@ -376,7 +375,7 @@ def store_forecast(forecast):
     forecast_id = generate_uuid()
     # the procedure expects arguments in a certain order
     _call_procedure(
-        'store_forecast', forecast_id, forecast['site_id'], forecast['name'],
+        'store_forecast', forecast_id, str(forecast['site_id']), forecast['name'],
         forecast['variable'], forecast['issue_time_of_day'],
         forecast['lead_time_to_start'], forecast['interval_label'],
         forecast['interval_length'], forecast['run_length'],
@@ -688,7 +687,7 @@ def store_cdf_forecast_group(cdf_forecast_group):
     # the procedure expects arguments in a certain order
     _call_procedure('store_cdf_forecasts_group',
                     forecast_id,
-                    cdf_forecast_group['site_id'],
+                    str(cdf_forecast_group['site_id']),
                     cdf_forecast_group['name'],
                     cdf_forecast_group['variable'],
                     cdf_forecast_group['issue_time_of_day'],

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -77,6 +77,7 @@ def get_cursor(cursor_type, commit=True):
     finally:
         cursor.close()
 
+
 def try_query(query_cmd):
     try:
         query_cmd()
@@ -375,8 +376,8 @@ def store_forecast(forecast):
     forecast_id = generate_uuid()
     # the procedure expects arguments in a certain order
     _call_procedure(
-        'store_forecast', forecast_id, str(forecast['site_id']), forecast['name'],
-        forecast['variable'], forecast['issue_time_of_day'],
+        'store_forecast', forecast_id, str(forecast['site_id']),
+        forecast['name'], forecast['variable'], forecast['issue_time_of_day'],
         forecast['lead_time_to_start'], forecast['interval_label'],
         forecast['interval_length'], forecast['run_length'],
         forecast['interval_value_type'], forecast['extra_parameters'])

--- a/sfa_api/utils/tests/test_auth.py
+++ b/sfa_api/utils/tests/test_auth.py
@@ -1,5 +1,4 @@
 import pytest
-import requests
 
 
 from sfa_api.utils import auth

--- a/sfa_api/utils/tests/test_auth.py
+++ b/sfa_api/utils/tests/test_auth.py
@@ -5,23 +5,6 @@ import requests
 from sfa_api.utils import auth
 
 
-@pytest.fixture(scope='session')
-def auth_token():
-    token_req = requests.post(
-        'https://solarforecastarbiter.auth0.com/oauth/token',
-        headers={'content-type': 'application/json'},
-        data=('{"grant_type": "password", '
-              '"username": "testing@solarforecastarbiter.org",'
-              '"password": "Thepassword123!", '
-              '"audience": "https://api.solarforecastarbiter.org", '
-              '"client_id": "c16EJo48lbTCQEhqSztGGlmxxxmZ4zX7"}'))
-    if token_req.status_code != 200:
-        pytest.skip('Cannot retrieve valid Auth0 token')
-    else:
-        token = token_req.json()['access_token']
-        return token
-
-
 @pytest.fixture()
 def valid_auth(app, auth_token):
     with app.test_request_context(

--- a/sfa_api/utils/tests/test_storage_interface.py
+++ b/sfa_api/utils/tests/test_storage_interface.py
@@ -184,7 +184,8 @@ def test_store_observation(sql_app, user, observation, nocommit_cursor):
     assert observation == new_observation
 
 
-def test_store_observation_invalid_user(sql_app, invalid_user, nocommit_cursor):
+def test_store_observation_invalid_user(
+        sql_app, invalid_user, nocommit_cursor):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.store_observation(
             list(demo_observations.values())[0])
@@ -201,7 +202,8 @@ def test_store_observation_values(sql_app, user, nocommit_cursor,
     pdt.assert_frame_equal(stored, obs_vals)
 
 
-def test_store_observation_values_no_observation(sql_app, user, nocommit_cursor):
+def test_store_observation_values_no_observation(
+        sql_app, user, nocommit_cursor):
     new_id = str(uuid.uuid1())
     obs_vals = values.static_observation_values()
     with pytest.raises(storage_interface.StorageAuthError):
@@ -224,7 +226,8 @@ def test_delete_observation(sql_app, user, nocommit_cursor, observation_id):
     assert observation_id not in observation_list
 
 
-def test_delete_observation_invalid_user(sql_app, invalid_user, nocommit_cursor):
+def test_delete_observation_invalid_user(
+        sql_app, invalid_user, nocommit_cursor):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.delete_observation(list(demo_observations.keys())[0])
 
@@ -442,7 +445,8 @@ def test_read_cdf_forecast_values_invalid_forecast(sql_app, user, startend):
             str(uuid.uuid1()), start, end)
 
 
-def test_read_cdf_forecast_values_invalid_user(sql_app, invalid_user, startend):
+def test_read_cdf_forecast_values_invalid_user(
+        sql_app, invalid_user, startend):
     start, end = startend
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_cdf_forecast_values(
@@ -607,7 +611,8 @@ def test_list_cdf_forecasts_invalid_parent(sql_app, user):
 
 
 @pytest.mark.parametrize('forecast_id', demo_single_cdf.keys())
-def test_delete_cdf_forecast_single(sql_app, user, nocommit_cursor, forecast_id):
+def test_delete_cdf_forecast_single(
+        sql_app, user, nocommit_cursor, forecast_id):
     storage_interface.delete_cdf_forecast(forecast_id)
     forecast_list = [k['forecast_id']
                      for k in storage_interface.list_cdf_forecasts()]
@@ -620,7 +625,8 @@ def test_delete_cdf_forecast_single_invalid_user(
         storage_interface.delete_cdf_forecast(list(demo_single_cdf.keys())[0])
 
 
-def test_delete_cdf_forecast_single_does_not_exist(sql_app, user, nocommit_cursor):
+def test_delete_cdf_forecast_single_does_not_exist(
+        sql_app, user, nocommit_cursor):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.delete_cdf_forecast(str(uuid.uuid1()))
 
@@ -660,7 +666,8 @@ def test_list_cdf_forecast_groups_invalid_site(sql_app, user):
 
 
 @pytest.mark.parametrize('forecast_id', demo_group_cdf.keys())
-def test_delete_cdf_forecast_group(sql_app, user, nocommit_cursor, forecast_id):
+def test_delete_cdf_forecast_group(
+        sql_app, user, nocommit_cursor, forecast_id):
     storage_interface.delete_cdf_forecast_group(forecast_id)
     forecast_list = [k['forecast_id']
                      for k in storage_interface.list_cdf_forecast_groups()]
@@ -674,6 +681,7 @@ def test_delete_cdf_forecast_group_invalid_user(
             list(demo_group_cdf.keys())[0])
 
 
-def test_delete_cdf_forecast_group_does_not_exist(sql_app, user, nocommit_cursor):
+def test_delete_cdf_forecast_group_does_not_exist(
+        sql_app, user, nocommit_cursor):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.delete_cdf_forecast_group(str(uuid.uuid1()))

--- a/sfa_api/utils/tests/test_storage_interface.py
+++ b/sfa_api/utils/tests/test_storage_interface.py
@@ -8,7 +8,6 @@ import pytest
 import pymysql
 
 
-from sfa_api import create_app
 from sfa_api.demo.sites import static_sites as demo_sites
 from sfa_api.demo.observations import static_observations as demo_observations
 from sfa_api.demo.forecasts import static_forecasts as demo_forecasts
@@ -21,20 +20,8 @@ from sfa_api.utils import storage_interface
 TESTINDEX = values.generate_randoms()[0].to_series(keep_tz=True)
 
 
-@pytest.fixture(scope='module')
-def app():
-    app = create_app('TestingConfig')
-    with app.app_context():
-        try:
-            storage_interface.mysql_connection()
-        except pymysql.err.OperationalError:
-            pytest.skip('No connection to test database')
-        else:
-            yield app
-
-
 @pytest.fixture()
-def nocommit_cursor(app, mocker):
+def nocommit_cursor(sql_app, mocker):
     conn = storage_interface.mysql_connection()
     special = partial(storage_interface.get_cursor, commit=False)
     mocker.patch('sfa_api.utils.storage_interface.get_cursor', special)
@@ -43,8 +30,8 @@ def nocommit_cursor(app, mocker):
 
 
 @pytest.fixture()
-def user(app):
-    ctx = app.test_request_context()
+def user(sql_app):
+    ctx = sql_app.test_request_context()
     ctx.user = 'auth0|5be343df7025406237820b85'
     ctx.push()
     yield
@@ -52,8 +39,8 @@ def user(app):
 
 
 @pytest.fixture()
-def invalid_user(app):
-    ctx = app.test_request_context()
+def invalid_user(sql_app):
+    ctx = sql_app.test_request_context()
     ctx.user = 'bad'
     ctx.push()
     yield
@@ -84,19 +71,19 @@ def test_try_query_raises():
         storage_interface.try_query(f)
 
 
-def test_get_cursor_and_timezone(app):
+def test_get_cursor_and_timezone(sql_app):
     with storage_interface.get_cursor('standard') as cursor:
         cursor.execute('SELECT @@session.time_zone')
         res = cursor.fetchone()[0]
     assert res == '+00:00'
 
 
-def test_get_cursor_invalid_type(app):
+def test_get_cursor_invalid_type(sql_app):
     with pytest.raises(AttributeError):
         with storage_interface.get_cursor('oither'): pass  # NOQA
 
 
-def test_cursor_rollback(app, user):
+def test_cursor_rollback(sql_app, user):
     obs_id = list(demo_observations.keys())[0]
     with pytest.raises(ValueError):
         with storage_interface.get_cursor('standard') as cursor:
@@ -107,12 +94,12 @@ def test_cursor_rollback(app, user):
     assert res == demo_observations[obs_id]
 
 
-def test_cursor_rollback_internal_err(app):
+def test_cursor_rollback_internal_err(sql_app):
     obs_id = list(demo_observations.keys())[0]
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.delete_observation(obs_id)
 
-    ctx = app.test_request_context()
+    ctx = sql_app.test_request_context()
     ctx.user = 'auth0|5be343df7025406237820b85'
     ctx.push()
     res = storage_interface.read_observation(obs_id)
@@ -120,7 +107,7 @@ def test_cursor_rollback_internal_err(app):
     ctx.pop()
 
 
-def test_cursor_commit(app, user):
+def test_cursor_commit(sql_app, user):
     demo = list(demo_observations.values())[0].copy()
     demo['name'] = 'demo'
     new_id = storage_interface.store_observation(demo)
@@ -129,40 +116,40 @@ def test_cursor_commit(app, user):
         storage_interface.read_observation(new_id)
 
 
-def test_list_observations(app, user):
+def test_list_observations(sql_app, user):
     observations = storage_interface.list_observations()
     for obs in observations:
         assert obs == demo_observations[obs['observation_id']]
 
 
-def test_list_observations_invalid_user(app, invalid_user):
+def test_list_observations_invalid_user(sql_app, invalid_user):
     observations = storage_interface.list_observations()
     assert len(observations) == 0
 
 
-def test_list_observations_invalid_site(app, user):
+def test_list_observations_invalid_site(sql_app, user):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.list_observations(str(uuid.uuid1()))
 
 
 @pytest.mark.parametrize('observation_id', demo_observations.keys())
-def test_read_observation(app, user, observation_id):
+def test_read_observation(sql_app, user, observation_id):
     observation = storage_interface.read_observation(observation_id)
     assert observation == demo_observations[observation_id]
 
 
-def test_read_observation_invalid_observation(app, user):
+def test_read_observation_invalid_observation(sql_app, user):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_observation(str(uuid.uuid1()))
 
 
-def test_read_observation_invalid_user(app, invalid_user):
+def test_read_observation_invalid_user(sql_app, invalid_user):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_observation(list(demo_observations.keys())[0])
 
 
 @pytest.mark.parametrize('observation_id', demo_observations.keys())
-def test_read_observation_values(app, user, observation_id, startend):
+def test_read_observation_values(sql_app, user, observation_id, startend):
     start, end = startend
     observation_values = storage_interface.read_observation_values(
         observation_id, start, end)
@@ -170,14 +157,14 @@ def test_read_observation_values(app, user, observation_id, startend):
     assert (observation_values.columns == ['value', 'quality_flag']).all()
 
 
-def test_read_observation_values_invalid_observation(app, user, startend):
+def test_read_observation_values_invalid_observation(sql_app, user, startend):
     start, end = startend
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_observation_values(
             str(uuid.uuid1()), start, end)
 
 
-def test_read_observation_values_invalid_user(app, invalid_user, startend):
+def test_read_observation_values_invalid_user(sql_app, invalid_user, startend):
     start, end = startend
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_observation_values(
@@ -185,7 +172,7 @@ def test_read_observation_values_invalid_user(app, invalid_user, startend):
 
 
 @pytest.mark.parametrize('observation', demo_observations.values())
-def test_store_observation(app, user, observation, nocommit_cursor):
+def test_store_observation(sql_app, user, observation, nocommit_cursor):
     observation = observation.copy()
     observation['name'] = 'new_observation'
     new_id = storage_interface.store_observation(observation)
@@ -197,14 +184,14 @@ def test_store_observation(app, user, observation, nocommit_cursor):
     assert observation == new_observation
 
 
-def test_store_observation_invalid_user(app, invalid_user, nocommit_cursor):
+def test_store_observation_invalid_user(sql_app, invalid_user, nocommit_cursor):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.store_observation(
             list(demo_observations.values())[0])
 
 
 @pytest.mark.parametrize('observation', demo_observations.values())
-def test_store_observation_values(app, user, nocommit_cursor,
+def test_store_observation_values(sql_app, user, nocommit_cursor,
                                   observation):
     observation['name'] = 'new_observation'
     new_id = storage_interface.store_observation(observation)
@@ -214,14 +201,14 @@ def test_store_observation_values(app, user, nocommit_cursor,
     pdt.assert_frame_equal(stored, obs_vals)
 
 
-def test_store_observation_values_no_observation(app, user, nocommit_cursor):
+def test_store_observation_values_no_observation(sql_app, user, nocommit_cursor):
     new_id = str(uuid.uuid1())
     obs_vals = values.static_observation_values()
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.store_observation_values(new_id, obs_vals)
 
 
-def test_store_observation_values_invalid_user(app, invalid_user,
+def test_store_observation_values_invalid_user(sql_app, invalid_user,
                                                nocommit_cursor):
     obs_id = list(demo_observations.keys())[0]
     obs_vals = values.static_observation_values()
@@ -230,57 +217,57 @@ def test_store_observation_values_invalid_user(app, invalid_user,
 
 
 @pytest.mark.parametrize('observation_id', demo_observations.keys())
-def test_delete_observation(app, user, nocommit_cursor, observation_id):
+def test_delete_observation(sql_app, user, nocommit_cursor, observation_id):
     storage_interface.delete_observation(observation_id)
     observation_list = [
         k['observation_id'] for k in storage_interface.list_observations()]
     assert observation_id not in observation_list
 
 
-def test_delete_observation_invalid_user(app, invalid_user, nocommit_cursor):
+def test_delete_observation_invalid_user(sql_app, invalid_user, nocommit_cursor):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.delete_observation(list(demo_observations.keys())[0])
 
 
-def test_delete_observation_does_not_exist(app, user, nocommit_cursor):
+def test_delete_observation_does_not_exist(sql_app, user, nocommit_cursor):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.delete_observation(str(uuid.uuid1()))
 
 
-def test_list_forecasts(app, user):
+def test_list_forecasts(sql_app, user):
     forecasts = storage_interface.list_forecasts()
     for fx in forecasts:
         assert fx == demo_forecasts[fx['forecast_id']]
 
 
-def test_list_forecasts_invalid_user(app, invalid_user):
+def test_list_forecasts_invalid_user(sql_app, invalid_user):
     forecasts = storage_interface.list_forecasts()
     assert len(forecasts) == 0
 
 
-def test_list_forecasts_invalid_site(app, user):
+def test_list_forecasts_invalid_site(sql_app, user):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.list_forecasts(str(uuid.uuid1()))
 
 
 @pytest.mark.parametrize('forecast_id', demo_forecasts.keys())
-def test_read_forecast(app, user, forecast_id):
+def test_read_forecast(sql_app, user, forecast_id):
     forecast = storage_interface.read_forecast(forecast_id)
     assert forecast == demo_forecasts[forecast_id]
 
 
-def test_read_forecast_invalid_forecast(app, user):
+def test_read_forecast_invalid_forecast(sql_app, user):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_forecast(str(uuid.uuid1()))
 
 
-def test_read_forecast_invalid_user(app, invalid_user):
+def test_read_forecast_invalid_user(sql_app, invalid_user):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_forecast(list(demo_forecasts.keys())[0])
 
 
 @pytest.mark.parametrize('forecast_id', demo_forecasts.keys())
-def test_read_forecast_values(app, user, forecast_id, startend):
+def test_read_forecast_values(sql_app, user, forecast_id, startend):
     start, end = startend
     forecast_values = storage_interface.read_forecast_values(
         forecast_id, start, end)
@@ -288,14 +275,14 @@ def test_read_forecast_values(app, user, forecast_id, startend):
     assert (forecast_values.columns == ['value']).all()
 
 
-def test_read_forecast_values_invalid_forecast(app, user, startend):
+def test_read_forecast_values_invalid_forecast(sql_app, user, startend):
     start, end = startend
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_forecast_values(
             str(uuid.uuid1()), start, end)
 
 
-def test_read_forecast_values_invalid_user(app, invalid_user, startend):
+def test_read_forecast_values_invalid_user(sql_app, invalid_user, startend):
     start, end = startend
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_forecast_values(
@@ -303,7 +290,7 @@ def test_read_forecast_values_invalid_user(app, invalid_user, startend):
 
 
 @pytest.mark.parametrize('forecast', demo_forecasts.values())
-def test_store_forecast(app, user, forecast, nocommit_cursor):
+def test_store_forecast(sql_app, user, forecast, nocommit_cursor):
     forecast = forecast.copy()
     forecast['name'] = 'new_forecast'
     new_id = storage_interface.store_forecast(forecast)
@@ -315,13 +302,13 @@ def test_store_forecast(app, user, forecast, nocommit_cursor):
     assert forecast == new_forecast
 
 
-def test_store_forecast_invalid_user(app, invalid_user, nocommit_cursor):
+def test_store_forecast_invalid_user(sql_app, invalid_user, nocommit_cursor):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.store_forecast(list(demo_forecasts.values())[0])
 
 
 @pytest.mark.parametrize('forecast', demo_forecasts.values())
-def test_store_forecast_values(app, user, nocommit_cursor,
+def test_store_forecast_values(sql_app, user, nocommit_cursor,
                                forecast):
     forecast['name'] = 'new_forecast'
     new_id = storage_interface.store_forecast(forecast)
@@ -331,14 +318,14 @@ def test_store_forecast_values(app, user, nocommit_cursor,
     pdt.assert_frame_equal(stored, fx_vals)
 
 
-def test_store_forecast_values_no_forecast(app, user, nocommit_cursor):
+def test_store_forecast_values_no_forecast(sql_app, user, nocommit_cursor):
     new_id = str(uuid.uuid1())
     fx_vals = values.static_forecast_values()
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.store_forecast_values(new_id, fx_vals)
 
 
-def test_store_forecast_values_invalid_user(app, invalid_user,
+def test_store_forecast_values_invalid_user(sql_app, invalid_user,
                                             nocommit_cursor):
     fx_id = list(demo_forecasts.keys())[0]
     fx_vals = values.static_forecast_values()
@@ -347,52 +334,52 @@ def test_store_forecast_values_invalid_user(app, invalid_user,
 
 
 @pytest.mark.parametrize('forecast_id', demo_forecasts.keys())
-def test_delete_forecast(app, user, nocommit_cursor, forecast_id):
+def test_delete_forecast(sql_app, user, nocommit_cursor, forecast_id):
     storage_interface.delete_forecast(forecast_id)
     forecast_list = [k['forecast_id']
                      for k in storage_interface.list_forecasts()]
     assert forecast_id not in forecast_list
 
 
-def test_delete_forecast_invalid_user(app, invalid_user, nocommit_cursor):
+def test_delete_forecast_invalid_user(sql_app, invalid_user, nocommit_cursor):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.delete_forecast(list(demo_forecasts.keys())[0])
 
 
-def test_delete_forecast_does_not_exist(app, user, nocommit_cursor):
+def test_delete_forecast_does_not_exist(sql_app, user, nocommit_cursor):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.delete_forecast(str(uuid.uuid1()))
 
 
 @pytest.mark.parametrize('site_id', demo_sites.keys())
-def test_read_site(app, user, site_id):
+def test_read_site(sql_app, user, site_id):
     site = storage_interface.read_site(site_id)
     assert site == demo_sites[site_id]
 
 
-def test_read_site_invalid_site(app, user):
+def test_read_site_invalid_site(sql_app, user):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_site(str(uuid.uuid1()))
 
 
-def test_read_site_invalid_user(app, invalid_user):
+def test_read_site_invalid_user(sql_app, invalid_user):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_site(list(demo_sites.keys())[0])
 
 
-def test_list_sites(app, user):
+def test_list_sites(sql_app, user):
     sites = storage_interface.list_sites()
     for site in sites:
         assert site == demo_sites[site['site_id']]
 
 
-def test_list_sites_invalid_user(app, invalid_user):
+def test_list_sites_invalid_user(sql_app, invalid_user):
     sites = storage_interface.list_sites()
     assert len(sites) == 0
 
 
 @pytest.mark.parametrize('site', demo_sites.values())
-def test_store_site(app, user, site, nocommit_cursor):
+def test_store_site(sql_app, user, site, nocommit_cursor):
     site = site.copy()
     site['name'] = 'new_site'
     new_id = storage_interface.store_site(site)
@@ -405,13 +392,13 @@ def test_store_site(app, user, site, nocommit_cursor):
     assert site == new_site
 
 
-def test_store_site_invalid_user(app, invalid_user, nocommit_cursor):
+def test_store_site_invalid_user(sql_app, invalid_user, nocommit_cursor):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.store_site(list(demo_sites.values())[0])
 
 
 @pytest.mark.parametrize('site', demo_sites.values())
-def test_delete_site(app, user, nocommit_cursor, site):
+def test_delete_site(sql_app, user, nocommit_cursor, site):
     # create a new site to delete since it can be restrict by obs/fx
     site = site.copy()
     site['name'] = 'new_site'
@@ -423,24 +410,24 @@ def test_delete_site(app, user, nocommit_cursor, site):
     assert new_id not in site_list
 
 
-def test_delete_site_forecast_restricts(app, user, nocommit_cursor):
+def test_delete_site_forecast_restricts(sql_app, user, nocommit_cursor):
     with pytest.raises(storage_interface.DeleteRestrictionError):
         storage_interface.delete_site(list(demo_sites.keys())[0])
 
 
-def test_delete_site_invalid_user(app, invalid_user, nocommit_cursor):
+def test_delete_site_invalid_user(sql_app, invalid_user, nocommit_cursor):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.delete_site(list(demo_sites.keys())[0])
 
 
-def test_delete_site_does_not_exist(app, user, nocommit_cursor):
+def test_delete_site_does_not_exist(sql_app, user, nocommit_cursor):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.delete_site(str(uuid.uuid1()))
 
 
 # CDF
 @pytest.mark.parametrize('forecast_id', demo_single_cdf.keys())
-def test_read_cdf_forecast_values(app, user, forecast_id, startend):
+def test_read_cdf_forecast_values(sql_app, user, forecast_id, startend):
     start, end = startend
     forecast_values = storage_interface.read_cdf_forecast_values(
         forecast_id, start, end)
@@ -448,14 +435,14 @@ def test_read_cdf_forecast_values(app, user, forecast_id, startend):
     assert (forecast_values.columns == ['value']).all()
 
 
-def test_read_cdf_forecast_values_invalid_forecast(app, user, startend):
+def test_read_cdf_forecast_values_invalid_forecast(sql_app, user, startend):
     start, end = startend
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_cdf_forecast_values(
             str(uuid.uuid1()), start, end)
 
 
-def test_read_cdf_forecast_values_invalid_user(app, invalid_user, startend):
+def test_read_cdf_forecast_values_invalid_user(sql_app, invalid_user, startend):
     start, end = startend
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_cdf_forecast_values(
@@ -463,7 +450,7 @@ def test_read_cdf_forecast_values_invalid_user(app, invalid_user, startend):
 
 
 @pytest.mark.parametrize('cdf_forecast_id', demo_single_cdf.keys())
-def test_store_cdf_forecast_values(app, user, nocommit_cursor,
+def test_store_cdf_forecast_values(sql_app, user, nocommit_cursor,
                                    cdf_forecast_id):
     fx_vals = values.static_forecast_values().shift(freq='30d')
     storage_interface.store_cdf_forecast_values(cdf_forecast_id, fx_vals)
@@ -472,14 +459,14 @@ def test_store_cdf_forecast_values(app, user, nocommit_cursor,
     pdt.assert_frame_equal(stored, fx_vals)
 
 
-def test_store_cdf_forecast_values_no_forecast(app, user, nocommit_cursor):
+def test_store_cdf_forecast_values_no_forecast(sql_app, user, nocommit_cursor):
     new_id = str(uuid.uuid1())
     fx_vals = values.static_forecast_values()
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.store_cdf_forecast_values(new_id, fx_vals)
 
 
-def test_store_cdf_forecast_values_invalid_user(app, invalid_user,
+def test_store_cdf_forecast_values_invalid_user(sql_app, invalid_user,
                                                 nocommit_cursor):
     fx_id = list(demo_single_cdf.keys())[0]
     fx_vals = values.static_forecast_values()
@@ -488,7 +475,7 @@ def test_store_cdf_forecast_values_invalid_user(app, invalid_user,
 
 
 @pytest.mark.parametrize('forecast_id', demo_single_cdf.keys())
-def test_read_cdf_forecast_single(app, user, forecast_id):
+def test_read_cdf_forecast_single(sql_app, user, forecast_id):
     single = demo_single_cdf[forecast_id]
     forecast = storage_interface.read_cdf_forecast(forecast_id)
     parent = demo_group_cdf[single['parent']].copy()
@@ -499,17 +486,17 @@ def test_read_cdf_forecast_single(app, user, forecast_id):
     assert forecast == parent
 
 
-def test_read_cdf_forecast_single_invalid_forecast(app, user):
+def test_read_cdf_forecast_single_invalid_forecast(sql_app, user):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_cdf_forecast(str(uuid.uuid1()))
 
 
-def test_read_cdf_forecast_single_invalid_user(app, invalid_user):
+def test_read_cdf_forecast_single_invalid_user(sql_app, invalid_user):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_cdf_forecast(list(demo_single_cdf.keys())[0])
 
 
-def test_store_cdf_forecast_single(app, user, nocommit_cursor):
+def test_store_cdf_forecast_single(sql_app, user, nocommit_cursor):
     cdf_forecast = {'parent': list(demo_group_cdf.keys())[0],
                     'constant_value': 100.0}
     new_id = storage_interface.store_cdf_forecast(cdf_forecast)
@@ -525,7 +512,7 @@ def test_store_cdf_forecast_single(app, user, nocommit_cursor):
     assert new_cdf_forecast == parent
 
 
-def test_store_cdf_forecast_single_invalid_user(app, invalid_user,
+def test_store_cdf_forecast_single_invalid_user(sql_app, invalid_user,
                                                 nocommit_cursor):
     cdf_forecast = {'parent': list(demo_group_cdf.keys())[0],
                     'constant_value': 100.0}
@@ -533,7 +520,7 @@ def test_store_cdf_forecast_single_invalid_user(app, invalid_user,
         storage_interface.store_cdf_forecast(cdf_forecast)
 
 
-def test_store_cdf_forecast_single_same_parent_value(app, invalid_user,
+def test_store_cdf_forecast_single_same_parent_value(sql_app, invalid_user,
                                                      nocommit_cursor):
     cdf_forecast = {'parent': list(demo_group_cdf.keys())[0],
                     'constant_value': 5.0}
@@ -542,7 +529,7 @@ def test_store_cdf_forecast_single_same_parent_value(app, invalid_user,
 
 
 @pytest.mark.parametrize('forecast_id', demo_group_cdf.keys())
-def test_read_cdf_forecast_group(app, user, forecast_id):
+def test_read_cdf_forecast_group(sql_app, user, forecast_id):
     group = demo_group_cdf[forecast_id].copy()
     forecast = storage_interface.read_cdf_forecast_group(forecast_id)
     group['constant_values'] = {thing['forecast_id']: thing
@@ -552,19 +539,19 @@ def test_read_cdf_forecast_group(app, user, forecast_id):
     assert forecast == group
 
 
-def test_read_cdf_forecast_group_invalid_forecast(app, user):
+def test_read_cdf_forecast_group_invalid_forecast(sql_app, user):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_cdf_forecast_group(str(uuid.uuid1()))
 
 
-def test_read_cdf_forecast_group_invalid_user(app, invalid_user):
+def test_read_cdf_forecast_group_invalid_user(sql_app, invalid_user):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_cdf_forecast_group(
             list(demo_group_cdf.keys())[0])
 
 
 @pytest.mark.parametrize('cdf_forecast', demo_group_cdf.values())
-def test_store_cdf_forecast_group(app, user, nocommit_cursor,
+def test_store_cdf_forecast_group(sql_app, user, nocommit_cursor,
                                   cdf_forecast):
     cdf_forecast = cdf_forecast.copy()
     cdf_forecast['constant_values'] = [
@@ -581,14 +568,14 @@ def test_store_cdf_forecast_group(app, user, nocommit_cursor,
     assert new_cdf_forecast == cdf_forecast
 
 
-def test_store_cdf_forecast_group_invalid_user(app, invalid_user,
+def test_store_cdf_forecast_group_invalid_user(sql_app, invalid_user,
                                                nocommit_cursor):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.store_cdf_forecast_group(
             list(demo_group_cdf.values())[0])
 
 
-def test_list_cdf_forecasts(app, user):
+def test_list_cdf_forecasts(sql_app, user):
     forecasts = storage_interface.list_cdf_forecasts()
     for fx in forecasts:
         single = demo_single_cdf[fx['forecast_id']]
@@ -600,7 +587,7 @@ def test_list_cdf_forecasts(app, user):
         assert fx == parent
 
 
-def test_list_cdf_forecasts_one_parent(app, user):
+def test_list_cdf_forecasts_one_parent(sql_app, user):
     parent = list(demo_group_cdf.values())[0].copy()
     forecasts = storage_interface.list_cdf_forecasts(parent['forecast_id'])
     cv = [p['forecast_id'] for p in parent['constant_values']]
@@ -609,18 +596,18 @@ def test_list_cdf_forecasts_one_parent(app, user):
         assert fx['parent'] == parent['forecast_id']
 
 
-def test_list_cdf_forecasts_invalid_user(app, invalid_user):
+def test_list_cdf_forecasts_invalid_user(sql_app, invalid_user):
     forecasts = storage_interface.list_cdf_forecasts()
     assert len(forecasts) == 0
 
 
-def test_list_cdf_forecasts_invalid_parent(app, user):
+def test_list_cdf_forecasts_invalid_parent(sql_app, user):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.list_cdf_forecasts(str(uuid.uuid1()))
 
 
 @pytest.mark.parametrize('forecast_id', demo_single_cdf.keys())
-def test_delete_cdf_forecast_single(app, user, nocommit_cursor, forecast_id):
+def test_delete_cdf_forecast_single(sql_app, user, nocommit_cursor, forecast_id):
     storage_interface.delete_cdf_forecast(forecast_id)
     forecast_list = [k['forecast_id']
                      for k in storage_interface.list_cdf_forecasts()]
@@ -628,17 +615,17 @@ def test_delete_cdf_forecast_single(app, user, nocommit_cursor, forecast_id):
 
 
 def test_delete_cdf_forecast_single_invalid_user(
-        app, invalid_user, nocommit_cursor):
+        sql_app, invalid_user, nocommit_cursor):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.delete_cdf_forecast(list(demo_single_cdf.keys())[0])
 
 
-def test_delete_cdf_forecast_single_does_not_exist(app, user, nocommit_cursor):
+def test_delete_cdf_forecast_single_does_not_exist(sql_app, user, nocommit_cursor):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.delete_cdf_forecast(str(uuid.uuid1()))
 
 
-def test_list_cdf_forecast_groups(app, user):
+def test_list_cdf_forecast_groups(sql_app, user):
     forecasts = storage_interface.list_cdf_forecast_groups()
     for fx in forecasts:
         group = demo_group_cdf[fx['forecast_id']].copy()
@@ -649,7 +636,7 @@ def test_list_cdf_forecast_groups(app, user):
         assert fx == group
 
 
-def test_list_cdf_forecast_groups_site(app, user):
+def test_list_cdf_forecast_groups_site(sql_app, user):
     site = list(demo_sites.keys())[0]
     forecasts = storage_interface.list_cdf_forecast_groups(site)
     for fx in forecasts:
@@ -662,18 +649,18 @@ def test_list_cdf_forecast_groups_site(app, user):
         assert fx['site_id'] == site
 
 
-def test_list_cdf_forecast_groups_invalid_user(app, invalid_user):
+def test_list_cdf_forecast_groups_invalid_user(sql_app, invalid_user):
     forecasts = storage_interface.list_cdf_forecast_groups()
     assert len(forecasts) == 0
 
 
-def test_list_cdf_forecast_groups_invalid_site(app, user):
+def test_list_cdf_forecast_groups_invalid_site(sql_app, user):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.list_cdf_forecast_groups(str(uuid.uuid1()))
 
 
 @pytest.mark.parametrize('forecast_id', demo_group_cdf.keys())
-def test_delete_cdf_forecast_group(app, user, nocommit_cursor, forecast_id):
+def test_delete_cdf_forecast_group(sql_app, user, nocommit_cursor, forecast_id):
     storage_interface.delete_cdf_forecast_group(forecast_id)
     forecast_list = [k['forecast_id']
                      for k in storage_interface.list_cdf_forecast_groups()]
@@ -681,12 +668,12 @@ def test_delete_cdf_forecast_group(app, user, nocommit_cursor, forecast_id):
 
 
 def test_delete_cdf_forecast_group_invalid_user(
-        app, invalid_user, nocommit_cursor):
+        sql_app, invalid_user, nocommit_cursor):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.delete_cdf_forecast_group(
             list(demo_group_cdf.keys())[0])
 
 
-def test_delete_cdf_forecast_group_does_not_exist(app, user, nocommit_cursor):
+def test_delete_cdf_forecast_group_does_not_exist(sql_app, user, nocommit_cursor):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.delete_cdf_forecast_group(str(uuid.uuid1()))


### PR DESCRIPTION
Major changes:
- Added test_api.py to do high level testing of the API and ensure resources exist in all the expected places after creation and are removed everywhere on deletion.
- Fixed demo data site deletion logic
- Fixed observation/forecast deletion return values. I'm not sure how the tests were passing before, because the flask app was crashing on delete calls due to lack of jsonify() call.

Minor changes:
- Moved shared variables to conftest/removed hardcoding of 'https://localhost' as base_url in all test files.
Further updates needed before review:
- [x] rebase on #76
- [x] incorporate /values endpoints into `test_api.py`(tested individually in test_forecast.py etc.)