### PR TITLE
remove cdf_value, update air temperature variable name

### DIFF
--- a/datastore/migrations/0020_reference_org.up.sql
+++ b/datastore/migrations/0020_reference_org.up.sql
@@ -63,7 +63,7 @@ INSERT INTO arbiter_data.observations (
 ) VALUES (
     @orgid, @siteid, 'PSEL Reference POA Irradiance', 'poa_global', 'beginning',
     1, 'instantaneous', 0.10, '{"network": "Sandia RTC"}'), (
-    @orgid, @siteid, 'PSEL Reference Air Temperature', 'Air Temperature', 'beginning',
+    @orgid, @siteid, 'PSEL Reference Air Temperature', 'temp_air', 'beginning',
     1, 'instantaneous', 0.10, '{"network": "Sandia RTC"}'), (
     @orgid, @siteid, 'PSEL Reference Sys 1 AC Power', 'ac_power', 'beginning',
     1, 'instantaneous', 0.10, '{"network": "Sandia RTC"}'), (

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -7,7 +7,7 @@ from sfa_api.utils.validators import TimeFormat
 
 
 VARIABLES = ['ghi', 'dni', 'dhi', 'temp_air', 'wind_speed',
-             'poa', 'ac_power', 'dc_power']
+             'poa_global', 'ac_power', 'dc_power']
 
 INTERVAL_LABELS = ['beginning', 'ending', 'instant']
 

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -7,7 +7,7 @@ from sfa_api.utils.validators import TimeFormat
 
 
 VARIABLES = ['ghi', 'dni', 'dhi', 'temp_air', 'wind_speed',
-             'poa', 'ac_power', 'dc_power', 'cdf_value']
+             'poa', 'ac_power', 'dc_power']
 
 INTERVAL_LABELS = ['beginning', 'ending', 'instant']
 


### PR DESCRIPTION
closes #86 
Removes cdf_value from allowed variables in schema.py
The dashboard is throwing a keyError trying to convert 'Air Temperature' so I updated it in the migrations sql to the variable name in the schema. @alorenzo175, would mysql need to be manually rebuilt in openshift for this change to take effect?