### PR TITLE
Parametetrize the api fixture to test both demo and sql backends

### DIFF
--- a/sfa_api/config.py
+++ b/sfa_api/config.py
@@ -19,6 +19,7 @@ class Config(object):
     MYSQL_USER = os.getenv('MYSQL_USER', None)
     MYSQL_PASSWORD = os.getenv('MYSQL_PASSWORD', None)
     MYSQL_DATABASE = os.getenv('MYSQL_DATABASE', None)
+    SFA_API_STATIC_DATA = os.getenv('SFA_API_STATIC_DATA', False)
 
 
 class ProductionConfig(Config):

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -194,17 +194,17 @@ def auth_token():
 
 
 @pytest.fixture()
-def app():
+def demo_app():
     app = create_app(config_name='TestingConfig')
     app.config['SFA_API_STATIC_DATA'] = True
     return app
 
 
 @pytest.fixture()
-def api(app, mocker):
+def demo_api(demo_app, mocker):
     verify = mocker.patch('sfa_api.utils.auth.verify_access_token')
     verify.return_value = True
-    api = app.test_client()
+    api = demo_app.test_client()
     return api
 
 
@@ -227,9 +227,9 @@ def invalid_user(sql_app):
 
 
 @pytest.fixture(params=[0, 1])
-def both_apps(request, app, mocker):
+def app(request, demo_app, mocker):
     if request.param:
-        yield app
+        yield demo_app
     else:
         # do this to avoid skipping app when no mysql
         with _make_sql_app() as sql_app:
@@ -238,14 +238,14 @@ def both_apps(request, app, mocker):
 
 
 @pytest.fixture()
-def both_apis(both_apps, mocker):
+def api(app, mocker):
     def add_user():
         _request_ctx_stack.top.user = 'auth0|5be343df7025406237820b85'
         return True
 
     verify = mocker.patch('sfa_api.utils.auth.verify_access_token')
     verify.side_effect = add_user
-    yield both_apps.test_client()
+    yield app.test_client()
 
 
 @pytest.fixture()

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -165,9 +165,8 @@ def auth_token():
 
 @pytest.fixture()
 def app():
-    if not os.getenv('SFA_API_STATIC_DATA'):
-        os.environ['SFA_API_STATIC_DATA'] = 'true'
     app = create_app(config_name='TestingConfig')
+    app.config['SFA_API_STATIC_DATA'] = True
     return app
 
 

--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -104,22 +104,31 @@ def test_post_forecast_values_valid_json(api, cdf_forecast_id):
     assert r.status_code == 201
 
 
-def test_post_json_storage_call(api, cdf_forecast_id, mocker):
-    storage = mocker.patch('sfa_api.demo.store_cdf_forecast_values')
-    storage.return_value = cdf_forecast_id
+@pytest.fixture()
+def patched_store_values(mocker):
+    new = mocker.MagicMock()
+    mocker.patch('sfa_api.utils.storage_interface.store_cdf_forecast_values',
+                 new=new)
+    mocker.patch('sfa_api.demo.store_cdf_forecast_values',
+                 new=new)
+    return new
+
+
+def test_post_json_storage_call(api, cdf_forecast_id, patched_store_values):
+    patched_store_values.return_value = cdf_forecast_id
     api.post(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
              base_url=BASE_URL,
              json=VALID_FX_VALUE_JSON)
-    storage.assert_called()
+    patched_store_values.assert_called()
 
 
-def test_post_values_404(api, missing_id, mocker):
-    storage = mocker.patch('sfa_api.demo.store_forecast_values')
-    storage.return_value = None
+def test_post_values_404(api, missing_id, patched_store_values):
+    patched_store_values.return_value = None
     r = api.post(f'/forecasts/cdf/single/{missing_id}/values',
                  base_url=BASE_URL,
                  json=VALID_FX_VALUE_JSON)
     assert r.status_code == 404
+    patched_store_values.assert_called()
 
 
 @pytest.mark.parametrize('payload', [

--- a/sfa_api/tests/test_observations.py
+++ b/sfa_api/tests/test_observations.py
@@ -100,7 +100,11 @@ def test_post_observation_values_valid_json(api, observation_id):
 
 
 def test_post_json_storage_call(api, observation_id, mocker):
-    storage = mocker.patch('sfa_api.demo.store_observation_values')
+    storage = mocker.MagicMock()
+    mocker.patch('sfa_api.utils.storage_interface.store_observation_values',
+                 new=storage)
+    mocker.patch('sfa_api.demo.store_observation_values',
+                 new=storage)
     storage.return_value = observation_id
     api.post(f'/observations/{observation_id}/values',
              base_url=BASE_URL,

--- a/sfa_api/utils/storage.py
+++ b/sfa_api/utils/storage.py
@@ -1,7 +1,4 @@
-import os
-
-
-from flask import g
+from flask import current_app
 
 
 import sfa_api.demo as demo
@@ -15,9 +12,9 @@ def get_storage():
     A non-persistent, in-memory storage backend can be used
     for development by setting the 'STATIC_DATA' config variable.
     """
-    if 'storage' not in g:
-        if os.getenv('SFA_API_STATIC_DATA'):
-            g.storage = demo
+    if not hasattr(current_app, 'storage'):
+        if current_app.config['SFA_API_STATIC_DATA']:
+            current_app.storage = demo
         else:
-            g.storage = storage
-    return g.storage
+            current_app.storage = storage
+    return current_app.storage

--- a/sfa_api/utils/tests/test_storage_interface.py
+++ b/sfa_api/utils/tests/test_storage_interface.py
@@ -1,4 +1,3 @@
-from functools import partial
 import uuid
 
 
@@ -18,38 +17,6 @@ from sfa_api.utils import storage_interface
 
 
 TESTINDEX = values.generate_randoms()[0].to_series(keep_tz=True)
-
-
-@pytest.fixture()
-def nocommit_cursor(sql_app, mocker):
-    # on release of a Pool connection, any transaction is rolled back
-    # need to keep the transaction open between nocommit tests
-    conn = storage_interface._make_sql_connection_partial()()
-    mocker.patch.object(conn, 'close')
-    mocker.patch('sfa_api.utils.storage_interface.mysql_connection',
-                 return_value=conn)
-    special = partial(storage_interface.get_cursor, commit=False)
-    mocker.patch('sfa_api.utils.storage_interface.get_cursor', special)
-    yield
-    conn.rollback()
-
-
-@pytest.fixture()
-def user(sql_app):
-    ctx = sql_app.test_request_context()
-    ctx.user = 'auth0|5be343df7025406237820b85'
-    ctx.push()
-    yield
-    ctx.pop()
-
-
-@pytest.fixture()
-def invalid_user(sql_app):
-    ctx = sql_app.test_request_context()
-    ctx.user = 'bad'
-    ctx.push()
-    yield
-    ctx.pop()
 
 
 @pytest.fixture(params=[0, 1, 2, 3])


### PR DESCRIPTION
I was running into some unexpected test results when implementing #80 which turn out to be differences between the sql and demo backend. I went with what I think is the easiest route to just test things with api/app fixtures against both backends. 

I added storage to the application instead of g because g is set per request vs per application instance which is I think what we want.