### PR TITLE
more schema validation

### DIFF
--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -32,9 +32,9 @@ VALID_SITE_JSON = {
     "modeling_parameters": {
         "ac_capacity": 0.015,
         "dc_capacity": 0.015,
-        "backtrack": True,
+        "ac_loss_factor": 0,
+        "dc_loss_factor": 0,
         "temperature_coefficient": -.002,
-        "ground_coverage_ratio": 0.5,
         "surface_azimuth": 180.0,
         "surface_tilt": 45.0,
         "tracking_type": "fixed"

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -66,7 +66,8 @@ class ModelingParameters(ma.Schema):
     # fixed tilt systems
     surface_tilt = ma.Float(
         title="Surface Tilt",
-        description="Tilt from horizontal of a fixed tilt system, degrees.")
+        description="Tilt from horizontal of a fixed tilt system, degrees.",
+        missing=None)
     surface_azimuth = ma.Float(
         title="Surface Azimuth",
         description="Azimuth angle of a fixed tilt system, degrees.",
@@ -138,7 +139,8 @@ class SiteSchema(ma.Schema):
         title="Timezone",
         description="IANA Timezone",
         required=True)
-    modeling_parameters = ma.Nested(ModelingParameters)
+    modeling_parameters = ma.Nested(ModelingParameters,
+                                    missing=ModelingParameters().load({}))
     extra_parameters = EXTRA_PARAMETERS_FIELD
 
     @validates('timezone')

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -3,7 +3,7 @@ from marshmallow.exceptions import ValidationError
 import pytz
 
 from sfa_api import spec, ma
-from sfa_api.utils.validators import TimeFormat
+from sfa_api.utils.validators import TimeFormat, UserstringValidator
 
 
 VARIABLES = ['ghi', 'dni', 'dhi', 'temp_air', 'wind_speed',
@@ -158,7 +158,8 @@ class SiteSchema(ma.Schema):
     name = ma.String(
         title='Name',
         description="Name of the Site",
-        required=True)
+        required=True,
+        validate=UserstringValidator())
     latitude = ma.Float(
         title='Latitude',
         description="Latitude in degrees North",
@@ -247,7 +248,8 @@ class ObservationPostSchema(ma.Schema):
     name = ma.String(
         title='Name',
         description='Human friendly name for the observation',
-        required=True)
+        required=True,
+        validate=UserstringValidator())
     interval_label = ma.String(
         title='Interval Label',
         description=('For data that represents intervals, indicates if a time '
@@ -367,7 +369,8 @@ class ForecastPostSchema(ma.Schema):
     name = ma.String(
         title='Name',
         description="Human friendly name for forecast",
-        required=True)
+        required=True,
+        validate=UserstringValidator())
     variable = VARIABLE_FIELD
     issue_time_of_day = ma.String(
         title='Issue Time of Day',

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -19,7 +19,8 @@ ALLOWED_TIMEZONES = pytz.country_timezones('US') + list(
 
 EXTRA_PARAMETERS_FIELD = ma.String(
     title='Extra Parameters',
-    description='Additional user specified parameters.')
+    description='Additional user specified parameters.',
+    missing='')
 
 VARIABLE_FIELD = ma.String(
     title='Variable',

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -148,8 +148,6 @@ class ModelingParameters(ma.Schema):
                 if data[key] is None})
             if errors:
                 raise ValidationError(errors)
-        else:
-            raise ValidationError({'tracking_type': ['Invalid tracking type']})
 
 
 @spec.define_schema('SiteDefinition')

--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -6,6 +6,7 @@ from sfa_api.conftest import (variables, interval_value_types, interval_labels,
                               VALID_FX_VALUE_JSON, VALID_CDF_VALUE_CSV)
 
 
+INVALID_NAME = copy_update(VALID_CDF_FORECAST_JSON, 'name', '@drain')
 INVALID_VARIABLE = copy_update(VALID_CDF_FORECAST_JSON,
                                'variable', 'invalid')
 INVALID_INTERVAL_LABEL = copy_update(VALID_CDF_FORECAST_JSON,
@@ -49,7 +50,8 @@ def test_cdf_forecast_group_post_success(api, payload, status_code):
     (INVALID_INTERVAL_LENGTH, '{"interval_length":["Not a valid integer."]}'), # NOQA
     (INVALID_RUN_LENGTH, '{"run_length":["Not a valid integer."]}'),
     (INVALID_VALUE_TYPE, f'{{"interval_value_type":["Must be one of: {interval_value_types}."]}}'), # NOQA
-    ({}, empty_json_response)
+    ({}, empty_json_response),
+    (INVALID_NAME, '{"name":["Invalid characters in string."]}')
 ])
 def test_cdf_forecast_group_post_bad_request(api, payload, message):
     r = api.post('/forecasts/cdf/',

--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -6,6 +6,7 @@ from sfa_api.conftest import (variables, interval_value_types, interval_labels,
                               VALID_FX_VALUE_JSON, VALID_FX_VALUE_CSV)
 
 
+INVALID_NAME = copy_update(VALID_FORECAST_JSON, 'name', 'Bad semicolon;')
 INVALID_VARIABLE = copy_update(VALID_FORECAST_JSON,
                                'variable', 'invalid')
 INVALID_INTERVAL_LABEL = copy_update(VALID_FORECAST_JSON,
@@ -44,7 +45,8 @@ def test_forecast_post_success(api, payload, status_code):
     (INVALID_INTERVAL_LENGTH, '{"interval_length":["Not a valid integer."]}'), # NOQA
     (INVALID_RUN_LENGTH, '{"run_length":["Not a valid integer."]}'),
     (INVALID_VALUE_TYPE, f'{{"interval_value_type":["Must be one of: {interval_value_types}."]}}'), # NOQA
-    ({}, empty_json_response)
+    ({}, empty_json_response),
+    (INVALID_NAME, '{"name":["Invalid characters in string."]}')
 ])
 def test_forecast_post_bad_request(api, payload, message):
     r = api.post('/forecasts/single/',

--- a/sfa_api/tests/test_observations.py
+++ b/sfa_api/tests/test_observations.py
@@ -6,6 +6,7 @@ from sfa_api.conftest import (variables, interval_labels, BASE_URL,
                               VALID_OBS_JSON, copy_update)
 
 
+INVALID_NAME = copy_update(VALID_OBS_JSON, 'name', '#Nope')
 INVALID_VARIABLE = copy_update(VALID_OBS_JSON,
                                'variable', 'invalid')
 INVALID_INTERVAL_LABEL = copy_update(VALID_OBS_JSON,
@@ -26,7 +27,8 @@ def test_observation_post_success(api):
 @pytest.mark.parametrize('payload,message', [
     (INVALID_VARIABLE, f'{{"variable":["Must be one of: {variables}."]}}'),
     (INVALID_INTERVAL_LABEL, f'{{"interval_label":["Must be one of: {interval_labels}."]}}'),  # NOQA
-    ({}, empty_json_response)
+    ({}, empty_json_response),
+    (INVALID_NAME, '{"name":["Invalid characters in string."]}')
 ])
 def test_observation_post_bad_request(api, payload, message):
     r = api.post('/observations/',

--- a/sfa_api/tests/test_sites.py
+++ b/sfa_api/tests/test_sites.py
@@ -154,6 +154,7 @@ def test_site_post_extra_modeling_params(api, tracking_type, params, extras):
     (INVALID_LONGITUDE, '{"longitude":["Not a valid number."]}'),
     (OUTSIDE_LONGITUDE, '{"longitude":["Must be between -180 and 180."]}'),
     (INVALID_TIMEZONE, '{"timezone":["Invalid timezone."]}'),
+    (INVALID_TRACKING_TYPE, '{"tracking_type":["Unknown field."]}')
 ])
 def test_site_post_400(api, payload, message):
     r = api.post('/sites/',

--- a/sfa_api/tests/test_sites.py
+++ b/sfa_api/tests/test_sites.py
@@ -9,6 +9,12 @@ def invalidate(json, key):
     return new_json
 
 
+def removekey(json, key):
+    new_json = json.copy()
+    del new_json[key]
+    return new_json
+
+
 INVALID_ELEVATION = invalidate(VALID_SITE_JSON, 'elevation')
 INVALID_LATITUDE = invalidate(VALID_SITE_JSON, 'latitude')
 INVALID_LONGITUDE = invalidate(VALID_SITE_JSON, 'longitude')
@@ -29,7 +35,11 @@ OUTSIDE_LONGITUDE['longitude'] = 181
 
 
 @pytest.mark.parametrize('payload', [
-    (VALID_SITE_JSON)
+    VALID_SITE_JSON,
+    removekey(VALID_SITE_JSON, 'extra_parameters'),
+    removekey(VALID_SITE_JSON, 'modeling_parameters'),
+    removekey(removekey(VALID_SITE_JSON, 'modeling_parameters'),
+              'extra_parameters')
 ])
 def test_site_post_201(api, payload):
     r = api.post('/sites/',

--- a/sfa_api/tests/test_sites.py
+++ b/sfa_api/tests/test_sites.py
@@ -4,12 +4,12 @@ from itertools import combinations
 import pytest
 
 
-from sfa_api.conftest import VALID_SITE_JSON, BASE_URL
+from sfa_api.conftest import VALID_SITE_JSON, BASE_URL, copy_update
 
 
-def altervalue(json, key, new='invalid'):
+def invalidate(json, key):
     new_json = json.copy()
-    new_json[key] = new
+    new_json[key] = 'invalid'
     return new_json
 
 
@@ -19,18 +19,19 @@ def removekey(json, key):
     return new_json
 
 
-INVALID_ELEVATION = altervalue(VALID_SITE_JSON, 'elevation')
-INVALID_LATITUDE = altervalue(VALID_SITE_JSON, 'latitude')
-INVALID_LONGITUDE = altervalue(VALID_SITE_JSON, 'longitude')
-INVALID_TIMEZONE = altervalue(VALID_SITE_JSON, 'timezone')
-INVALID_AC_CAPACITY = altervalue(VALID_SITE_JSON, 'ac_capacity')
-INVALID_DC_CAPACITY = altervalue(VALID_SITE_JSON, 'dc_capacity')
-INVALID_BACKTRACK = altervalue(VALID_SITE_JSON, 'backtrack')
-INVALID_T_COEFF = altervalue(VALID_SITE_JSON, 'temperature_coefficient')
-INVALID_COVERAGE = altervalue(VALID_SITE_JSON, 'ground_coverage_ratio')
-INVALID_SURFACE_AZIMUTH = altervalue(VALID_SITE_JSON, 'surface_azimuth')
-INVALID_SURFACE_TILT = altervalue(VALID_SITE_JSON, 'surface_tilt')
-INVALID_TRACKING_TYPE = altervalue(VALID_SITE_JSON, 'tracking_type')
+INVALID_NAME = copy_update(VALID_SITE_JSON, 'name', '<script>kiddies</script>')
+INVALID_ELEVATION = invalidate(VALID_SITE_JSON, 'elevation')
+INVALID_LATITUDE = invalidate(VALID_SITE_JSON, 'latitude')
+INVALID_LONGITUDE = invalidate(VALID_SITE_JSON, 'longitude')
+INVALID_TIMEZONE = invalidate(VALID_SITE_JSON, 'timezone')
+INVALID_AC_CAPACITY = invalidate(VALID_SITE_JSON, 'ac_capacity')
+INVALID_DC_CAPACITY = invalidate(VALID_SITE_JSON, 'dc_capacity')
+INVALID_BACKTRACK = invalidate(VALID_SITE_JSON, 'backtrack')
+INVALID_T_COEFF = invalidate(VALID_SITE_JSON, 'temperature_coefficient')
+INVALID_COVERAGE = invalidate(VALID_SITE_JSON, 'ground_coverage_ratio')
+INVALID_SURFACE_AZIMUTH = invalidate(VALID_SITE_JSON, 'surface_azimuth')
+INVALID_SURFACE_TILT = invalidate(VALID_SITE_JSON, 'surface_tilt')
+INVALID_TRACKING_TYPE = invalidate(VALID_SITE_JSON, 'tracking_type')
 
 OUTSIDE_LATITUDE = VALID_SITE_JSON.copy()
 OUTSIDE_LATITUDE['latitude'] = 91
@@ -42,7 +43,7 @@ OUTSIDE_LONGITUDE['longitude'] = 181
     VALID_SITE_JSON,
     removekey(VALID_SITE_JSON, 'extra_parameters'),
     removekey(VALID_SITE_JSON, 'modeling_parameters'),
-    altervalue(VALID_SITE_JSON, 'modeling_parameters', {}),
+    copy_update(VALID_SITE_JSON, 'modeling_parameters', {}),
     removekey(removekey(VALID_SITE_JSON, 'modeling_parameters'),
               'extra_parameters')
 ])
@@ -154,7 +155,8 @@ def test_site_post_extra_modeling_params(api, tracking_type, params, extras):
     (INVALID_LONGITUDE, '{"longitude":["Not a valid number."]}'),
     (OUTSIDE_LONGITUDE, '{"longitude":["Must be between -180 and 180."]}'),
     (INVALID_TIMEZONE, '{"timezone":["Invalid timezone."]}'),
-    (INVALID_TRACKING_TYPE, '{"tracking_type":["Unknown field."]}')
+    (INVALID_TRACKING_TYPE, '{"tracking_type":["Unknown field."]}'),
+    (INVALID_NAME, '{"name":["Invalid characters in string."]}')
 ])
 def test_site_post_400(api, payload, message):
     r = api.post('/sites/',

--- a/sfa_api/utils/tests/test_validators.py
+++ b/sfa_api/utils/tests/test_validators.py
@@ -1,0 +1,39 @@
+from marshmallow.exceptions import ValidationError
+import pytest
+
+
+from sfa_api.utils import validators
+
+
+@pytest.mark.parametrize('thetime', [
+    '09:00', '9:00', '00:00'
+])
+def test_time_format(thetime):
+    assert validators.TimeFormat('%H:%M')(thetime) == thetime
+
+
+@pytest.mark.parametrize('bad', [
+    '25:00', '00:00:00', 'ab:cd', '10:88'
+])
+def test_time_format_fail(bad):
+    with pytest.raises(ValidationError):
+        validators.TimeFormat('%H:%M')(bad)
+
+
+@pytest.mark.parametrize('thestring', [
+    'mysite', 'Site 1', 'A really long but otherwise OK site',
+    "apostrophe '", 'site_99'
+])
+def test_userstring(thestring):
+    assert validators.UserstringValidator()(
+        thestring) == thestring
+
+
+@pytest.mark.parametrize('thestring', [
+    '<script>bac</script>', '<', ';delete',
+    'site:a:b', 'site+1', 'site\\G',
+    'site\n', '', ' ', "'", "'   ", '_'
+])
+def test_invalid_userstring(thestring):
+    with pytest.raises(ValidationError):
+        validators.UserstringValidator()(thestring)

--- a/sfa_api/utils/tests/test_validators.py
+++ b/sfa_api/utils/tests/test_validators.py
@@ -22,7 +22,7 @@ def test_time_format_fail(bad):
 
 @pytest.mark.parametrize('thestring', [
     'mysite', 'Site 1', 'A really long but otherwise OK site',
-    "apostrophe '", 'site_99'
+    "apostrophe '", 'site_99', 'site tucson, az'
 ])
 def test_userstring(thestring):
     assert validators.UserstringValidator()(
@@ -32,7 +32,7 @@ def test_userstring(thestring):
 @pytest.mark.parametrize('thestring', [
     '<script>bac</script>', '<', ';delete',
     'site:a:b', 'site+1', 'site\\G',
-    'site\n', '', ' ', "'", "'   ", '_'
+    'site\n', '', ' ', "'", "'   ", '_', ','
 ])
 def test_invalid_userstring(thestring):
     with pytest.raises(ValidationError):

--- a/sfa_api/utils/validators.py
+++ b/sfa_api/utils/validators.py
@@ -23,10 +23,10 @@ class UserstringValidator(Validator):
     """
     Validates a string the user provides does not include invalid characters.
     Currently must only match word characters (letters, numbers, underscore),
-    space, and apostrophe. Must have not only have non-word characters.
+    space, comma, and apostrophe. Must have not only have non-word characters.
     """
     def __init__(self):
-        self.compiled_re = re.compile("^(?!\\W+$)(?!_+$)[\\w ']+$")
+        self.compiled_re = re.compile("^(?!\\W+$)(?!_+$)[\\w ',]+$")
 
     def __call__(self, value):
         match = self.compiled_re.match(value)

--- a/sfa_api/utils/validators.py
+++ b/sfa_api/utils/validators.py
@@ -1,3 +1,4 @@
+import re
 import time
 
 
@@ -15,4 +16,20 @@ class TimeFormat(Validator):
             time.strptime(value, self.time_format)
         except ValueError:
             raise ValidationError(f'Time not in {self.time_format} format.')
+        return value
+
+
+class UserstringValidator(Validator):
+    """
+    Validates a string the user provides does not include invalid characters.
+    Currently must only match word characters (letters, numbers, underscore),
+    space, and apostrophe. Must have not only have non-word characters.
+    """
+    def __init__(self):
+        self.compiled_re = re.compile("^(?!\\W+$)(?!_+$)[\\w ']+$")
+
+    def __call__(self, value):
+        match = self.compiled_re.match(value)
+        if match is None or match[0] != value:
+            raise ValidationError('Invalid characters in string.')
         return value


### PR DESCRIPTION
closes #80 to validate modeling parameters depending on tracking type. Also closes #90 with a restricted set of allowed characters currently unicode word (a-z0-9_), comma, apostrophe, and space