### PR TITLE
use RQ

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ redis
 rq
 fakeredis
 sentry_sdk
+blinker

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ git+git://github.com/solararbiter/solarforecastarbiter-core#egg=solarforecastarb
 redis
 rq
 fakeredis
+sentry_sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ sqlalchemy
 git+git://github.com/solararbiter/solarforecastarbiter-core#egg=solarforecastarbiter [all]
 redis
 rq
+fakeredis

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ pyyaml
 pymysql
 sqlalchemy
 git+git://github.com/solararbiter/solarforecastarbiter-core#egg=solarforecastarbiter [all]
+redis
+rq

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(path.abspath(path.dirname(__file__)), 'README.md')) as f:
 
 EXTRAS_REQUIRE = {
     'test': ['pytest', 'pytest-cov', 'pytest-mock', 'flake8'],
-    'cli': ['click', 'pyyaml', 'sentry_sdk'],
+    'cli': ['click', 'sentry_sdk'],
     'queue': ['rq', 'redis']
 }
 EXTRAS_REQUIRE['all'] = [

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(path.abspath(path.dirname(__file__)), 'README.md')) as f:
 
 EXTRAS_REQUIRE = {
     'test': ['pytest', 'pytest-cov', 'pytest-mock', 'flake8'],
-    'cli': ['click', 'sentry_sdk'],
+    'cli': ['click'],
     'queue': ['rq', 'redis']
 }
 EXTRAS_REQUIRE['all'] = [
@@ -45,6 +45,7 @@ setup(
         'sqlalchemy',
         'pymysql',
         'solarforecastarbiter',
+        'sentry_sdk'
     ],
     extras_require=EXTRAS_REQUIRE,
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(
         'sqlalchemy',
         'pymysql',
         'solarforecastarbiter',
-        'sentry_sdk'
+        'sentry_sdk',
+        'blinker'
     ],
     extras_require=EXTRAS_REQUIRE,
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,15 @@ with open(path.join(path.abspath(path.dirname(__file__)), 'README.md')) as f:
     long_description = f.read()
 
 
+EXTRAS_REQUIRE = {
+    'test': ['pytest', 'pytest-cov', 'pytest-mock', 'flake8'],
+    'cli': ['click', 'pyyaml', 'sentry_sdk'],
+    'queue': ['rq', 'redis']
+}
+EXTRAS_REQUIRE['all'] = [
+    vv for v in EXTRAS_REQUIRE.values() for vv in v]
+
+
 setup(
     name='sfa-api',
     version=versioneer.get_version(),
@@ -36,14 +45,14 @@ setup(
         'sqlalchemy',
         'pymysql',
         'solarforecastarbiter',
-        'redis',
-        'rq'
     ],
-    extra_requires={
-        'test': ['pytest', 'coverage']
-    },
+    extras_require=EXTRAS_REQUIRE,
     project_urls={
         'Bug Reports': 'https://github.com/solararbiter/solarforecastarbiter-api/issues',  # NOQA,
         'Source': 'https://github.com/solararbiter/solarforecastarbiter-api'
-    }
+    },
+    entry_points='''
+    [console_scripts]
+    sfa-api=sfa_api.cli:cli
+    '''
 )

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,9 @@ setup(
         'pandas',
         'sqlalchemy',
         'pymysql',
-        'solarforecastarbiter'
+        'solarforecastarbiter',
+        'redis',
+        'rq'
     ],
     extra_requires={
         'test': ['pytest', 'coverage']

--- a/sfa_api/__init__.py
+++ b/sfa_api/__init__.py
@@ -6,12 +6,14 @@ del get_versions
 import os  # NOQA
 
 
-from flask import Flask, Response, jsonify, json, render_template, url_for  # NOQA
+from flask import Flask, Response, json, jsonify, render_template, url_for  # NOQA
 from flask_marshmallow import Marshmallow  # NOQA
 from flask_talisman import Talisman  # NOQA
+import sentry_sdk  # NOQA
+from sentry_sdk.integrations.flask import FlaskIntegration  # NOQA
 
 
-from sfa_api.spec import spec   # NOQA
+from sfa_api.spec import spec  # NOQA
 from sfa_api.error_handlers import register_error_handlers  # NOQA
 from sfa_api.utils.auth import requires_auth  # NOQA
 
@@ -28,7 +30,8 @@ def protect_endpoint():
 
 
 def create_app(config_name='ProductionConfig'):
-
+    sentry_sdk.init(send_default_pii=False,
+                    integrations=[FlaskIntegration()])
     app = Flask(__name__)
     app.config.from_object(f'sfa_api.config.{config_name}')
     if 'REDIS_SETTINGS' in os.environ:

--- a/sfa_api/__init__.py
+++ b/sfa_api/__init__.py
@@ -14,7 +14,6 @@ from flask_talisman import Talisman  # NOQA
 from sfa_api.spec import spec   # NOQA
 from sfa_api.error_handlers import register_error_handlers  # NOQA
 from sfa_api.utils.auth import requires_auth  # NOQA
-from sfa_api.utils.queuing import get_queue  # NOQA
 
 
 ma = Marshmallow()

--- a/sfa_api/__init__.py
+++ b/sfa_api/__init__.py
@@ -3,6 +3,9 @@ __version__ = get_versions()['version']
 del get_versions
 
 
+import os  # NOQA
+
+
 from flask import Flask, Response, jsonify, json, render_template, url_for  # NOQA
 from flask_marshmallow import Marshmallow  # NOQA
 from flask_talisman import Talisman  # NOQA
@@ -11,6 +14,7 @@ from flask_talisman import Talisman  # NOQA
 from sfa_api.spec import spec   # NOQA
 from sfa_api.error_handlers import register_error_handlers  # NOQA
 from sfa_api.utils.auth import requires_auth  # NOQA
+from sfa_api.utils.queuing import get_queue  # NOQA
 
 
 ma = Marshmallow()
@@ -28,6 +32,10 @@ def create_app(config_name='ProductionConfig'):
 
     app = Flask(__name__)
     app.config.from_object(f'sfa_api.config.{config_name}')
+    if 'MYSQL_SETTINGS' in os.environ:
+        app.config.from_envvar('MYSQL_SETTINGS')
+    if 'REDIS_SETTINGS' in os.environ:
+        app.config.from_envvar('REDIS_SETTINGS')
     ma.init_app(app)
     register_error_handlers(app)
     redoc_script = f"https://cdn.jsdelivr.net/npm/redoc@{app.config['REDOC_VERSION']}/bundles/redoc.standalone.js"  # NOQA

--- a/sfa_api/__init__.py
+++ b/sfa_api/__init__.py
@@ -32,8 +32,6 @@ def create_app(config_name='ProductionConfig'):
 
     app = Flask(__name__)
     app.config.from_object(f'sfa_api.config.{config_name}')
-    if 'MYSQL_SETTINGS' in os.environ:
-        app.config.from_envvar('MYSQL_SETTINGS')
     if 'REDIS_SETTINGS' in os.environ:
         app.config.from_envvar('REDIS_SETTINGS')
     ma.init_app(app)

--- a/sfa_api/cli.py
+++ b/sfa_api/cli.py
@@ -35,7 +35,7 @@ def worker(verbose, queues, config_file):
     config = Config(Path.cwd())
     config.from_pyfile(config_file)
 
-    if 'LOG_LEVEL' in config:
+    if 'LOG_LEVEL' in config:  # pragma: no cover
         loglevel = config['LOG_LEVEL']
     else:
         if verbose == 1:
@@ -45,7 +45,7 @@ def worker(verbose, queues, config_file):
         else:
             loglevel = 'WARNING'
 
-    if 'QUEUES' in config:
+    if 'QUEUES' in config:  # pragma: no cover
         queues = config['QUEUES']
 
     # will likely want to add prometheus in here somewhere,
@@ -68,5 +68,5 @@ def devserver(port, config_name):
     app.run(port=port)
 
 
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: no cover
     cli()

--- a/sfa_api/cli.py
+++ b/sfa_api/cli.py
@@ -16,11 +16,17 @@ def cli():
 
 @cli.command()
 @click.option('-v', '--verbose', count=True, help='Increase logging verbosity')
-@click.option('-q', '--queues', multiple=True)
+@click.option('-q', '--queues', multiple=True, help='RQ queues',
+              default=['default'])
 @click.argument('config_file')
 def worker(verbose, queues, config_file):
+    """
+    Run an RQ worker, with config loaded from CONFIG_FILE,
+    to process commands on the QUEUES.
+    """
     from sentry_sdk.integrations.rq import RqIntegration
-    sentry_sdk.init(integrations=[RqIntegration()])
+    sentry_sdk.init(send_default_pii=False,
+                    integrations=[RqIntegration()])
 
     from rq import Connection, Worker
     import solarforecastarbiter  # NOQA preload
@@ -41,8 +47,6 @@ def worker(verbose, queues, config_file):
 
     if 'QUEUES' in config:
         queues = config['QUEUES']
-    elif not queues:
-        queues = ['default']
 
     # will likely want to add prometheus in here somewhere,
     # perhaps as custom worker class
@@ -50,6 +54,19 @@ def worker(verbose, queues, config_file):
     with Connection(red):
         w = Worker(queues)
         w.work(logging_level=loglevel)
+
+
+@cli.command()
+@click.option('-v', '--verbose', count=True, help='Increase logging verbosity')
+@click.option('-p', '--port', type=int, help='Port for the server to run on',
+              default=5000)
+@click.argument('config_name', required=False,
+                default='DevelopmentConfig')
+def devserver(verbose, port, config_name):
+    """Run a flask development server with config from CONFIG_NAME"""
+    from sfa_api import create_app
+    app = create_app(config_name)
+    app.run(port=port)
 
 
 if __name__ == '__main__':

--- a/sfa_api/cli.py
+++ b/sfa_api/cli.py
@@ -57,12 +57,11 @@ def worker(verbose, queues, config_file):
 
 
 @cli.command()
-@click.option('-v', '--verbose', count=True, help='Increase logging verbosity')
 @click.option('-p', '--port', type=int, help='Port for the server to run on',
               default=5000)
 @click.argument('config_name', required=False,
                 default='DevelopmentConfig')
-def devserver(verbose, port, config_name):
+def devserver(port, config_name):
     """Run a flask development server with config from CONFIG_NAME"""
     from sfa_api import create_app
     app = create_app(config_name)

--- a/sfa_api/cli.py
+++ b/sfa_api/cli.py
@@ -1,6 +1,9 @@
+from pathlib import Path
+
+
 import click
+from flask import Config
 import sentry_sdk
-import yaml
 
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
@@ -23,8 +26,8 @@ def worker(verbose, queues, config_file):
     import solarforecastarbiter  # NOQA preload
     from sfa_api.utils.queuing import make_redis_connection
 
-    with open(config_file, 'r') as f:
-        config = yaml.safe_load(f)
+    config = Config(Path.cwd())
+    config.from_pyfile(config_file)
 
     if 'LOG_LEVEL' in config:
         loglevel = config['LOG_LEVEL']

--- a/sfa_api/cli.py
+++ b/sfa_api/cli.py
@@ -41,6 +41,8 @@ def worker(verbose, queues, config_file):
 
     if 'QUEUES' in config:
         queues = config['QUEUES']
+    elif not queues:
+        queues = ['default']
 
     # will likely want to add prometheus in here somewhere,
     # perhaps as custom worker class

--- a/sfa_api/cli.py
+++ b/sfa_api/cli.py
@@ -1,0 +1,51 @@
+import click
+import sentry_sdk
+import yaml
+
+
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+def cli():
+    pass
+
+
+@cli.command()
+@click.option('-v', '--verbose', count=True, help='Increase logging verbosity')
+@click.option('-q', '--queues', multiple=True)
+@click.argument('config_file')
+def worker(verbose, queues, config_file):
+    from sentry_sdk.integrations.rq import RqIntegration
+    sentry_sdk.init(integrations=[RqIntegration()])
+
+    from rq import Connection, Worker
+    import solarforecastarbiter  # NOQA preload
+    from sfa_api.utils.queuing import make_redis_connection
+
+    with open(config_file, 'r') as f:
+        config = yaml.safe_load(f)
+
+    if 'LOG_LEVEL' in config:
+        loglevel = config['LOG_LEVEL']
+    else:
+        if verbose == 1:
+            loglevel = 'INFO'
+        elif verbose > 1:
+            loglevel = 'DEBUG'
+        else:
+            loglevel = 'WARNING'
+
+    if 'QUEUES' in config:
+        queues = config['QUEUES']
+
+    # will likely want to add prometheus in here somewhere,
+    # perhaps as custom worker class
+    red = make_redis_connection(config)
+    with Connection(red):
+        w = Worker(queues)
+        w.work(logging_level=loglevel)
+
+
+if __name__ == '__main__':
+    cli()

--- a/sfa_api/config.py
+++ b/sfa_api/config.py
@@ -31,6 +31,7 @@ class DevelopmentConfig(Config):
     MYSQL_USER = 'apiuser'
     MYSQL_PASSWORD = 'thisisaterribleandpublicpassword'
     MYSQL_DATABASE = 'arbiter_data'
+    USE_FAKE_REDIS = True
 
 
 class TestingConfig(Config):
@@ -38,3 +39,4 @@ class TestingConfig(Config):
     MYSQL_USER = 'apiuser'
     MYSQL_PASSWORD = 'thisisaterribleandpublicpassword'
     MYSQL_DATABASE = 'arbiter_data'
+    USE_FAKE_REDIS = True

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -285,6 +285,6 @@ def site_id_plant():
 
 @pytest.fixture()
 def mocked_validation(mocker):
-    mocked = mocker.patch('solarforecastarbiter.tasks.enqueue_function')
+    mocked = mocker.patch('rq.Queue.enqueue')
     yield
     assert mocked.called

--- a/sfa_api/tests/test_cli.py
+++ b/sfa_api/tests/test_cli.py
@@ -2,16 +2,24 @@ import tempfile
 
 
 from click.testing import CliRunner
+import pytest
+
 
 import sfa_api
 from sfa_api import cli
 
 
-def test_worker(mocker):
+@pytest.mark.parametrize('args', [
+    ['-v'],
+    ['-vv'],
+    ['-q one', '-q two'],
+    ['-v', '-q default'],
+])
+def test_worker(mocker, args):
     w = mocker.patch('rq.Worker')
     runner = CliRunner()
     with tempfile.NamedTemporaryFile('r') as f:
-        r = runner.invoke(cli.cli, ['worker', f.name])
+        r = runner.invoke(cli.cli, ['worker', *args, f.name])
     assert r.exit_code == 0
     w.assert_called
 

--- a/sfa_api/tests/test_cli.py
+++ b/sfa_api/tests/test_cli.py
@@ -1,0 +1,24 @@
+import tempfile
+
+
+from click.testing import CliRunner
+
+import sfa_api
+from sfa_api import cli
+
+
+def test_worker(mocker):
+    w = mocker.patch('rq.Worker')
+    runner = CliRunner()
+    with tempfile.NamedTemporaryFile('r') as f:
+        r = runner.invoke(cli.cli, ['worker', f.name])
+    assert r.exit_code == 0
+    w.assert_called
+
+
+def test_devserver(mocker):
+    app = mocker.patch.object(sfa_api, 'create_app')
+    runner = CliRunner()
+    r = runner.invoke(cli.cli, ['devserver'])
+    assert r.exit_code == 0
+    app.assert_called

--- a/sfa_api/utils/queuing.py
+++ b/sfa_api/utils/queuing.py
@@ -1,0 +1,35 @@
+from functools import partial
+
+
+from flask import current_app
+from redis import Redis
+from rq import Queue
+
+
+def _make_redis_connection_partial():
+    config = current_app.config
+    host = config.get('REDIS_HOST', '127.0.0.1')
+    port = int(config.get('REDIS_PORT', '6379'))
+    db = config.get('REDIS_DB', 0)
+    socket_timeout = config.get('REDIS_SOCKET_TIMEOUT', 10)
+    socket_connect_timeout = config.get('REDIS_SOCKET_CONNECT_TIMEOUT', 5)
+    ssl = config.get('REDIS_USE_SSL', False)
+    ssl_ca_certs = config.get(
+        'REDIS_CA_CERTS', '/var/run/secrets/kubernetes.io/service-ca.crt')
+    getredis = partial(Redis, host=host, port=port, db=db,
+                       socket_timeout=socket_timeout,
+                       socket_connect_timeout=socket_connect_timeout,
+                       ssl=ssl, ssl_ca_certs=ssl_ca_certs)
+    return getredis
+
+
+def get_queue():
+    if not hasattr(current_app, 'background_queue'):
+        if current_app.config.get('USE_FAKE_REDIS', False):
+            from fakeredis import FakeStrictRedis
+            current_app.background_queue = Queue(
+                is_async=False, connection=FakeStrictRedis())
+        else:
+            redis = _make_redis_connection_partial()
+            current_app.background_queue = Queue(connection=redis())
+    return current_app.background_queue

--- a/sfa_api/utils/queuing.py
+++ b/sfa_api/utils/queuing.py
@@ -8,13 +8,14 @@ def make_redis_connection(config):
     host = config.get('REDIS_HOST', '127.0.0.1')
     port = int(config.get('REDIS_PORT', '6379'))
     db = config.get('REDIS_DB', 0)
-    socket_timeout = config.get('REDIS_SOCKET_TIMEOUT', 10)
-    socket_connect_timeout = config.get('REDIS_SOCKET_CONNECT_TIMEOUT', 5)
+    passwd = config.get('REDIS_PASSWORD', None)
+    socket_timeout = config.get('REDIS_SOCKET_TIMEOUT', 60)
+    socket_connect_timeout = config.get('REDIS_SOCKET_CONNECT_TIMEOUT', 15)
     ssl = config.get('REDIS_USE_SSL', False)
     ssl_ca_certs = config.get(
         'REDIS_CA_CERTS',
         '/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt')
-    r = Redis(host=host, port=port, db=db,
+    r = Redis(host=host, port=port, db=db, password=passwd,
               socket_timeout=socket_timeout,
               socket_connect_timeout=socket_connect_timeout,
               ssl=ssl, ssl_ca_certs=ssl_ca_certs)

--- a/sfa_api/utils/queuing.py
+++ b/sfa_api/utils/queuing.py
@@ -3,8 +3,8 @@ from redis import Redis
 from rq import Queue
 
 
-def _make_redis_connection():
-    config = current_app.config
+def make_redis_connection(config):
+    """Make a connection to the Redis configuration provided in config"""
     host = config.get('REDIS_HOST', '127.0.0.1')
     port = int(config.get('REDIS_PORT', '6379'))
     db = config.get('REDIS_DB', 0)
@@ -22,12 +22,13 @@ def _make_redis_connection():
 
 
 def get_queue():
+    """Return the background task queue"""
     if not hasattr(current_app, 'background_queue'):
         if current_app.config.get('USE_FAKE_REDIS', False):
             from fakeredis import FakeStrictRedis
             current_app.background_queue = Queue(
                 is_async=False, connection=FakeStrictRedis())
         else:
-            redis_conn = _make_redis_connection()
+            redis_conn = make_redis_connection(current_app.config)
             current_app.background_queue = Queue(connection=redis_conn)
     return current_app.background_queue

--- a/sfa_api/utils/queuing.py
+++ b/sfa_api/utils/queuing.py
@@ -9,16 +9,16 @@ def make_redis_connection(config):
     port = int(config.get('REDIS_PORT', '6379'))
     db = config.get('REDIS_DB', 0)
     passwd = config.get('REDIS_PASSWORD', None)
-    socket_timeout = config.get('REDIS_SOCKET_TIMEOUT', 60)
     socket_connect_timeout = config.get('REDIS_SOCKET_CONNECT_TIMEOUT', 15)
     ssl = config.get('REDIS_USE_SSL', False)
     ssl_ca_certs = config.get(
         'REDIS_CA_CERTS',
         '/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt')
+    ssl_cert_reqs = config.get('REDIS_CERT_REQS', 'required')
     r = Redis(host=host, port=port, db=db, password=passwd,
-              socket_timeout=socket_timeout,
               socket_connect_timeout=socket_connect_timeout,
-              ssl=ssl, ssl_ca_certs=ssl_ca_certs)
+              ssl=ssl, ssl_ca_certs=ssl_ca_certs,
+              ssl_cert_reqs=ssl_cert_reqs)
     return r
 
 

--- a/sfa_api/utils/queuing.py
+++ b/sfa_api/utils/queuing.py
@@ -12,7 +12,8 @@ def _make_redis_connection():
     socket_connect_timeout = config.get('REDIS_SOCKET_CONNECT_TIMEOUT', 5)
     ssl = config.get('REDIS_USE_SSL', False)
     ssl_ca_certs = config.get(
-        'REDIS_CA_CERTS', '/var/run/secrets/kubernetes.io/service-ca.crt')
+        'REDIS_CA_CERTS',
+        '/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt')
     r = Redis(host=host, port=port, db=db,
               socket_timeout=socket_timeout,
               socket_connect_timeout=socket_connect_timeout,

--- a/sfa_api/utils/tests/test_queuing.py
+++ b/sfa_api/utils/tests/test_queuing.py
@@ -1,0 +1,30 @@
+from flask import current_app
+from redis import Redis
+from rq import Queue
+
+
+from sfa_api.utils import queuing
+
+
+def test_make_redis_connection(demo_app):
+    with demo_app.app_context():
+        r = queuing._make_redis_connection()
+    assert isinstance(r, Redis)
+
+
+def test_get_queue_real(mocker, demo_app):
+    mocked = mocker.patch.object(queuing, '_make_redis_connection')
+    with demo_app.app_context():
+        current_app.config['USE_FAKE_REDIS'] = False
+        q = queuing.get_queue()
+    assert isinstance(q, Queue)
+    assert mocked.called
+
+
+def test_get_queue_fake(mocker, demo_app):
+    mocked = mocker.patch('fakeredis.FakeStrictRedis')
+    with demo_app.app_context():
+        current_app.config['USE_FAKE_REDIS'] = True
+        q = queuing.get_queue()
+    assert isinstance(q, Queue)
+    assert mocked.called

--- a/sfa_api/utils/tests/test_queuing.py
+++ b/sfa_api/utils/tests/test_queuing.py
@@ -8,12 +8,12 @@ from sfa_api.utils import queuing
 
 def test_make_redis_connection(demo_app):
     with demo_app.app_context():
-        r = queuing._make_redis_connection()
+        r = queuing.make_redis_connection(current_app.config)
     assert isinstance(r, Redis)
 
 
 def test_get_queue_real(mocker, demo_app):
-    mocked = mocker.patch.object(queuing, '_make_redis_connection')
+    mocked = mocker.patch.object(queuing, 'make_redis_connection')
     with demo_app.app_context():
         current_app.config['USE_FAKE_REDIS'] = False
         q = queuing.get_queue()


### PR DESCRIPTION
after solararbiter/solarforecastarbiter-core#86
Move queuing to the API and use RQ as the queue. RQ is even simpler than dramatiq now that we've decided redis is an OK message broker (and used in production by the likes of Netflix). It also better decouples the queuing from the actual tasks.
