### PR TITLE
Role/Permission Endpoints

### DIFF
--- a/datastore/migrations/0002_permissions_tables.up.sql
+++ b/datastore/migrations/0002_permissions_tables.up.sql
@@ -35,7 +35,6 @@ CREATE TABLE arbiter_data.roles (
   modified_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 
   PRIMARY KEY (id),
-  UNIQUE KEY (name, organization_id),
   KEY (organization_id),
   FOREIGN KEY (organization_id)
     REFERENCES organizations(id)

--- a/datastore/migrations/0002_permissions_tables.up.sql
+++ b/datastore/migrations/0002_permissions_tables.up.sql
@@ -35,6 +35,7 @@ CREATE TABLE arbiter_data.roles (
   modified_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 
   PRIMARY KEY (id),
+  UNIQUE KEY (name, organization_id),
   KEY (organization_id),
   FOREIGN KEY (organization_id)
     REFERENCES organizations(id)

--- a/datastore/migrations/0004_trigger_permission_inserts.up.sql
+++ b/datastore/migrations/0004_trigger_permission_inserts.up.sql
@@ -113,6 +113,10 @@ FOR EACH ROW DELETE FROM arbiter_data.permission_object_mapping WHERE object_id 
 CREATE DEFINER = 'permission_trig'@'localhost' TRIGGER remove_object_perm_on_roles_delete AFTER DELETE ON arbiter_data.roles
 FOR EACH ROW DELETE FROM arbiter_data.permission_object_mapping WHERE object_id = OLD.id;
 
+-- add trigger for deletion from permissions table
+CREATE DEFINER = 'permission_trig'@'localhost' TRIGGER remove_perm_on_perm_delete AFTER DELETE ON arbiter_data.permissions
+FOR EACH ROW DELETE FROM arbiter_data.permission_object_mapping WHERE object_id = OLD.id;
+
 
 -- add trigger for deletion from sites table
 CREATE DEFINER = 'permission_trig'@'localhost' TRIGGER remove_object_perm_on_sites_delete AFTER DELETE ON arbiter_data.sites

--- a/datastore/migrations/0015_test_metadata.up.sql
+++ b/datastore/migrations/0015_test_metadata.up.sql
@@ -7,6 +7,7 @@ SET @userid = (SELECT UUID_TO_BIN(UUID(), 1));
 INSERT INTO arbiter_data.users (id, auth0_id, organization_id) VALUES (
        @userid, 'auth0|5be343df7025406237820b85', @orgid);
 
+
 SET @roleid = (SELECT UUID_TO_BIN(UUID(), 1));
 INSERT INTO arbiter_data.roles (name, description, id, organization_id) VALUES (
     'Test user role', 'Role for the test user to read, create, delete test objects',
@@ -53,7 +54,14 @@ INSERT INTO arbiter_data.permissions (description, organization_id, action, obje
     'Write forecast values', @orgid, 'write_values', 'forecasts', TRUE), (
     'Write cdf forecast values', @orgid, 'write_values', 'cdf_forecasts', TRUE), (
     'Write observation values', @orgid, 'write_values', 'observations', TRUE), (
-    'update cdf group', @orgid, 'update', 'cdf_forecasts', TRUE);
+    'update cdf group', @orgid, 'update', 'cdf_forecasts', TRUE), (
+    'Read Roles', @orgid, 'read', 'roles', TRUE), (
+    'Read Permissions', @orgid, 'read', 'permissions', TRUE), (
+    'Create Roles', @orgid, 'create', 'roles', TRUE), (
+    'Create Permissions', @orgid, 'create', 'permissions', TRUE), (
+    'Update Roles', @orgid, 'update', 'roles', TRUE), (
+    'Update User', @orgid, 'update', 'users', TRUE), (
+    'Update Permissions', @orgid, 'update', 'permissions', TRUE);
 
 INSERT INTO arbiter_data.role_permission_mapping (role_id, permission_id) SELECT @roleid, id FROM arbiter_data.permissions WHERE organization_id = @orgid;
 
@@ -198,3 +206,23 @@ GRANT EXECUTE ON PROCEDURE arbiter_data.list_observations TO 'apiuser'@'%';
 GRANT EXECUTE ON PROCEDURE arbiter_data.list_forecasts TO 'apiuser'@'%';
 GRANT EXECUTE ON PROCEDURE arbiter_data.list_cdf_forecasts_groups TO 'apiuser'@'%';
 GRANT EXECUTE ON PROCEDURE arbiter_data.list_cdf_forecasts_singles TO 'apiuser'@'%';
+
+-- User/ Role / Permissions procedures
+GRANT EXECUTE ON PROCEDURE arbiter_data.read_user TO 'apiuser'@'%';
+GRANT EXECUTE ON PROCEDURE arbiter_data.list_users TO 'apiuser'@'%';
+GRANT EXECUTE ON PROCEDURE arbiter_data.add_role_to_user TO 'apiuser'@'%';
+GRANT EXECUTE ON PROCEDURE arbiter_data.remove_role_from_user TO 'apiuser'@'%';
+
+
+GRANT EXECUTE ON PROCEDURE arbiter_data.create_role TO 'apiuser'@'%';
+GRANT EXECUTE ON PROCEDURE arbiter_data.read_role TO 'apiuser'@'%';
+GRANT EXECUTE ON PROCEDURE arbiter_data.list_roles TO 'apiuser'@'%';
+
+
+
+GRANT EXECUTE ON PROCEDURE arbiter_data.list_permissions TO 'apiuser'@'%';
+GRANT EXECUTE ON PROCEDURE arbiter_data.create_permission TO 'apiuser'@'%';
+GRANT EXECUTE ON PROCEDURE arbiter_data.read_permission TO 'apiuser'@'%';
+GRANT EXECUTE ON PROCEDURE arbiter_data.delete_permission TO 'apiuser'@'%';
+GRANT EXECUTE ON PROCEDURE arbiter_data.add_permission_to_role TO 'apiuser'@'%';
+GRANT EXECUTE ON PROCEDURE arbiter_data.remove_permission_from_role TO 'apiuser'@'%';

--- a/datastore/migrations/0015_test_metadata.up.sql
+++ b/datastore/migrations/0015_test_metadata.up.sql
@@ -3,7 +3,7 @@ SET @orgid = (SELECT UUID_TO_BIN('b76ab62e-4fe1-11e9-9e44-64006a511e6f', 1));
 INSERT INTO arbiter_data.organizations (name, id, accepted_tou) VALUES (
     'Organization 1', @orgid, TRUE);
 
-SET @userid = (SELECT UUID_TO_BIN(UUID(), 1));
+SET @userid = (SELECT UUID_TO_BIN('0c90950a-7cca-11e9-a81f-54bf64606445', 1));
 INSERT INTO arbiter_data.users (id, auth0_id, organization_id) VALUES (
        @userid, 'auth0|5be343df7025406237820b85', @orgid);
 
@@ -54,7 +54,9 @@ INSERT INTO arbiter_data.permissions (description, organization_id, action, obje
     'Write forecast values', @orgid, 'write_values', 'forecasts', TRUE), (
     'Write cdf forecast values', @orgid, 'write_values', 'cdf_forecasts', TRUE), (
     'Write observation values', @orgid, 'write_values', 'observations', TRUE), (
-    'update cdf group', @orgid, 'update', 'cdf_forecasts', TRUE), (
+    'update cdf group', @orgid, 'update', 'cdf_forecasts', TRUE);
+
+INSERT INTO arbiter_data.permissions (description, organization_id, action, object_type, applies_to_all) VALUES (
     'Read Roles', @orgid, 'read', 'roles', TRUE), (
     'Read Permissions', @orgid, 'read', 'permissions', TRUE), (
     'Create Roles', @orgid, 'create', 'roles', TRUE), (

--- a/datastore/migrations/0015_test_metadata.up.sql
+++ b/datastore/migrations/0015_test_metadata.up.sql
@@ -58,12 +58,15 @@ INSERT INTO arbiter_data.permissions (description, organization_id, action, obje
 
 INSERT INTO arbiter_data.permissions (description, organization_id, action, object_type, applies_to_all) VALUES (
     'Read Roles', @orgid, 'read', 'roles', TRUE), (
+    'Read Users', @orgid, 'read', 'users', TRUE), (
     'Read Permissions', @orgid, 'read', 'permissions', TRUE), (
     'Create Roles', @orgid, 'create', 'roles', TRUE), (
     'Create Permissions', @orgid, 'create', 'permissions', TRUE), (
     'Update Roles', @orgid, 'update', 'roles', TRUE), (
     'Update User', @orgid, 'update', 'users', TRUE), (
-    'Update Permissions', @orgid, 'update', 'permissions', TRUE);
+    'Update Permissions', @orgid, 'update', 'permissions', TRUE), (
+    'Delete Roles', @orgid, 'delete', 'roles', TRUE), (
+    'Delete Permissions', @orgid, 'delete', 'permissions', TRUE);
 
 INSERT INTO arbiter_data.role_permission_mapping (role_id, permission_id) SELECT @roleid, id FROM arbiter_data.permissions WHERE organization_id = @orgid;
 
@@ -219,12 +222,14 @@ GRANT EXECUTE ON PROCEDURE arbiter_data.remove_role_from_user TO 'apiuser'@'%';
 GRANT EXECUTE ON PROCEDURE arbiter_data.create_role TO 'apiuser'@'%';
 GRANT EXECUTE ON PROCEDURE arbiter_data.read_role TO 'apiuser'@'%';
 GRANT EXECUTE ON PROCEDURE arbiter_data.list_roles TO 'apiuser'@'%';
-
-
+GRANT EXECUTE ON PROCEDURE arbiter_data.delete_role TO 'apiuser'@'%';
+GRANT EXECUTE ON PROCEDURE arbiter_data.remove_permission_from_role TO 'apiuser'@'%';
+GRANT EXECUTE ON PROCEDURE arbiter_data.add_permission_to_role TO 'apiuser'@'%';
 
 GRANT EXECUTE ON PROCEDURE arbiter_data.list_permissions TO 'apiuser'@'%';
 GRANT EXECUTE ON PROCEDURE arbiter_data.create_permission TO 'apiuser'@'%';
 GRANT EXECUTE ON PROCEDURE arbiter_data.read_permission TO 'apiuser'@'%';
 GRANT EXECUTE ON PROCEDURE arbiter_data.delete_permission TO 'apiuser'@'%';
-GRANT EXECUTE ON PROCEDURE arbiter_data.add_permission_to_role TO 'apiuser'@'%';
-GRANT EXECUTE ON PROCEDURE arbiter_data.remove_permission_from_role TO 'apiuser'@'%';
+GRANT EXECUTE ON PROCEDURE arbiter_data.add_object_to_permission TO 'apiuser'@'%';
+GRANT EXECUTE ON PROCEDURE arbiter_data.remove_object_from_permission TO 'apiuser'@'%';
+

--- a/datastore/migrations/0021_remove_admin_permissions.up.sql
+++ b/datastore/migrations/0021_remove_admin_permissions.up.sql
@@ -1,0 +1,1 @@
+DELETE FROM arbiter_data.role_permission_mapping WHERE permission_id in (SELECT id from arbiter_data.permissions WHERE object_type IN ('users', 'roles', 'permissions'));

--- a/sfa_api/__init__.py
+++ b/sfa_api/__init__.py
@@ -57,8 +57,11 @@ def create_app(config_name='ProductionConfig'):
     from sfa_api.forecasts import forecast_blp
     from sfa_api.sites import site_blp
     from sfa_api.users import user_blp
+    from sfa_api.roles import role_blp
+    from sfa_api.permissions import permission_blp
 
-    for blp in (obs_blp, forecast_blp, site_blp, user_blp):
+    for blp in (obs_blp, forecast_blp, site_blp, user_blp,
+                role_blp, permission_blp):
         blp.before_request(protect_endpoint)
         app.register_blueprint(blp)
 

--- a/sfa_api/__init__.py
+++ b/sfa_api/__init__.py
@@ -56,8 +56,9 @@ def create_app(config_name='ProductionConfig'):
     from sfa_api.observations import obs_blp
     from sfa_api.forecasts import forecast_blp
     from sfa_api.sites import site_blp
+    from sfa_api.users import user_blp
 
-    for blp in (obs_blp, forecast_blp, site_blp):
+    for blp in (obs_blp, forecast_blp, site_blp, user_blp):
         blp.before_request(protect_endpoint)
         app.register_blueprint(blp)
 

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -144,8 +144,8 @@ def _make_sql_app():
             yield app
 
 
-@pytest.fixture()
-def sql_app(mocker):
+@pytest.fixture(scope='module')
+def sql_app():
     with _make_sql_app() as app:
         yield app
 

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -154,8 +154,7 @@ def sql_app(mocker):
 def sql_app_no_commit(mocker):
     with _make_sql_app() as app:
         with _make_nocommit_cursor(mocker):
-                yield app
-
+            yield app
 
 
 @pytest.fixture()

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -144,10 +144,18 @@ def _make_sql_app():
             yield app
 
 
-@pytest.fixture(scope='module')
-def sql_app():
+@pytest.fixture()
+def sql_app(mocker):
     with _make_sql_app() as app:
         yield app
+
+
+@pytest.fixture()
+def sql_app_no_commit(mocker):
+    with _make_sql_app() as app:
+        with _make_nocommit_cursor(mocker):
+                yield app
+
 
 
 @pytest.fixture()

--- a/sfa_api/permissions.py
+++ b/sfa_api/permissions.py
@@ -111,6 +111,7 @@ class PermissionView(MethodView):
         storage.delete_permission(permission_id)
         return '', 204
 
+
 class PermissionObjectManagementView(MethodView):
     def post(self, permission_id, uuid):
         """
@@ -147,6 +148,7 @@ class PermissionObjectManagementView(MethodView):
         storage = get_storage()
         storage.remove_object_from_permission(permission_id, uuid)
         return '', 204
+
 
 permission_blp = Blueprint(
     'permissions', 'permissions', url_prefix='/permissions',

--- a/sfa_api/permissions.py
+++ b/sfa_api/permissions.py
@@ -1,0 +1,117 @@
+from flask import Blueprint, request, jsonify, make_response, url_for, abort
+from flask.views import MethodView
+
+
+from sfa_api import spec
+from sfa_api.utils.storage import get_storage
+from sfa_api.schema import (PermissionSchema,
+                            PermissionPostSchema)
+
+
+class AllPermissionsView(MethodView):
+    def get(self):
+        """
+        ---
+        summary: List Permissions.
+        description: List all Permissionss that the user has access to.
+        tags:
+          - Permissions
+        responses:
+          200:
+            description: Retrieved permissions successfully.
+            content:
+              applicaiton/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/PermissionSchema'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+        """
+        storage = get_storage()
+        permissions = storage.list_permissions()
+        return jsonify(PermissionSchema(many=True).dump(permissions))
+
+    def post(self):
+        """
+        ---
+        summary: Create a new Permission.
+        tags:
+          - Permissions
+        requestBody:
+          description: JSON representation of a Permission.
+          required: True
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PermissionPostSchema'
+        responses:
+          200:
+            description: Permission created successfully.
+          400:
+            $ref: '#/components/responses/400-BadRequest'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+        """
+        data = request.get_json()
+        try:
+            permission = PermissionPostSchema().load(data)
+        except ValidationError as err:
+            raise BadAPIRequest(err.messages)
+        storage = get_storage()
+        permission_id = storage.store_permission(permission)
+        return permission_id, 201
+
+
+class PermissionView(MethodView):
+    def get(self, permission_id):
+        """
+        ---
+        summary: Get information about a Permission.
+        tags:
+          - Permissions
+        responses:
+          200:
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/PermissionSchema'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+        """
+        storage = get_storage()
+        permission = storage.read_permission(permission_id)
+        return jsonify(PermissionSchema().dump(permission))
+
+    def delete(self, permission_id):
+        """
+        ---
+        summary: Delete a Permission
+        tags:
+          - Permissions
+        responses:
+          204:
+            description: Permission deleted successfully.
+          404:
+            $ref: '#/components/responses/404-NotFound'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+        """
+        storage = get_storage()
+        storage.delete_permission(permission_id)
+        return '', 204
+
+
+permission_blp = Blueprint(
+    'permissions', 'permissions', url_prefix='/permissions',
+)
+permission_blp.add_url_rule('/', view_func=AllPermissionsView.as_view('all'))
+permission_blp.add_url_rule(
+    '/<permission_id>',
+    view_func=PermissionView.as_view('single'))

--- a/sfa_api/permissions.py
+++ b/sfa_api/permissions.py
@@ -133,6 +133,7 @@ class PermissionObjectManagementView(MethodView):
 
     def delete(self, permission_id, uuid):
         """
+        ---
         summary: Remove an object from the permission
         tags:
           - Permissions

--- a/sfa_api/permissions.py
+++ b/sfa_api/permissions.py
@@ -1,9 +1,10 @@
-from flask import Blueprint, request, jsonify, make_response, url_for, abort
+from flask import Blueprint, request, jsonify, make_response, url_for
 from flask.views import MethodView
+from marshmallow import ValidationError
 
 
-from sfa_api import spec
 from sfa_api.utils.storage import get_storage
+from sfa_api.utils.errors import BadAPIRequest
 from sfa_api.schema import (PermissionSchema,
                             PermissionPostSchema)
 
@@ -64,7 +65,10 @@ class AllPermissionsView(MethodView):
             raise BadAPIRequest(err.messages)
         storage = get_storage()
         permission_id = storage.store_permission(permission)
-        return permission_id, 201
+        response = make_response(permission_id, 201)
+        response.headers['Location'] = url_for('permissions.single',
+                                               permission_id=permission_id)
+        return response
 
 
 class PermissionView(MethodView):

--- a/sfa_api/permissions.py
+++ b/sfa_api/permissions.py
@@ -120,19 +120,33 @@ class PermissionObjectManagementView(MethodView):
           - Permissions
         reponses:
           204:
-            description: Object added to permission successfilly.
-          400:
-            $ref: '#/components/responses/400-BadRequest'
+            description: Object added to permission successfully.
           404:
             $ref: '#/components/responses/404-NotFound'
           401:
             $ref: '#/components/responses/401-Unauthorized'
         """
-        storage = get_storagE()
-        storage.add_object_to_permission(role_id, permission_id)
+        storage = get_storage()
+        storage.add_object_to_permission(uuid, permission_id)
         return '', 204
 
+    def delete(self, permission_id, uuid):
+        """
+        summary: Remove an object from the permission
+        tags:
+          - Permissions
+        reponses:
+          204:
+            description: Object removed from permission successfully.
+          404:
+            $ref: '#/components/responses/404-NotFound'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
 
+        """
+        storage = get_storage()
+        storage.remove_object_from_permission(permission_id, uuid)
+        return '', 204
 
 permission_blp = Blueprint(
     'permissions', 'permissions', url_prefix='/permissions',
@@ -141,3 +155,6 @@ permission_blp.add_url_rule('/', view_func=AllPermissionsView.as_view('all'))
 permission_blp.add_url_rule(
     '/<permission_id>',
     view_func=PermissionView.as_view('single'))
+permission_blp.add_url_rule(
+    '/<permission_id>/objects/<uuid>',
+    view_func=PermissionObjectManagementView.as_view('objects'))

--- a/sfa_api/permissions.py
+++ b/sfa_api/permissions.py
@@ -111,6 +111,28 @@ class PermissionView(MethodView):
         storage.delete_permission(permission_id)
         return '', 204
 
+class PermissionObjectManagementView(MethodView):
+    def post(self, permission_id, uuid):
+        """
+        ---
+        summary: Add an object to the permission
+        tags:
+          - Permissions
+        reponses:
+          204:
+            description: Object added to permission successfilly.
+          400:
+            $ref: '#/components/responses/400-BadRequest'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+        """
+        storage = get_storagE()
+        storage.add_object_to_permission(role_id, permission_id)
+        return '', 204
+
+
 
 permission_blp = Blueprint(
     'permissions', 'permissions', url_prefix='/permissions',

--- a/sfa_api/roles.py
+++ b/sfa_api/roles.py
@@ -147,6 +147,7 @@ class RolePermissionManagementView(MethodView):
         """
         storage = get_storage()
         storage.remove_permission_from_role(role_id, permission_id)
+        return '', 204
 
 
 role_blp = Blueprint(

--- a/sfa_api/roles.py
+++ b/sfa_api/roles.py
@@ -1,0 +1,157 @@
+from flask import Blueprint, request, jsonify, make_response, url_for, abort
+from flask.views import MethodView
+
+
+from sfa_api import spec
+from sfa_api.utils.storage import get_storage
+from sfa_api.schema import (RoleSchema,
+                            RolePostSchema)
+
+
+class AllRolesView(MethodView):
+    def get(self):
+        """
+        ---
+        summary: List Roles.
+        description: List all Roles that the user has access to.
+        tags:
+          - Roles
+        responses:
+          200:
+            description: Retrieved roles successfully.
+            content:
+              applicaiton/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/RoleSchema'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+        """
+        storage = get_storage()
+        roles = storage.list_roles()
+        return jsonify(RoleSchema(many=True).dump(roles))
+
+    def post(self):
+        """
+        ---
+        summary: Create a new Role.
+        tags:
+          - Roles
+        responses:
+          200:
+            description: Role created successfully.
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/RoleSchema'
+          400:
+            $ref: '#/components/responses/400-BadRequest'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+        """
+        # PROCEDURE: create_role
+        data = request.get_json()
+        try:
+            role = RoleSchema().load(data)
+        except ValidationError as err:
+            raise BadAPIRequest(err.messages)
+        storage = get_storage()
+        role_id = storage.store_role(role)
+        return role_id, 201
+
+
+class RoleView(MethodView):
+    def get(self, role_id):
+        """
+        ---
+        summary: Get information about a Role.
+        tags:
+          - Roles
+        responses:
+          200:
+            description: Role created successfully.
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/RoleSchema'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+        """
+        storage = get_storage()
+        role = storage.read_role(role_id)
+        return jsonify(RoleSchema().dump(role))
+
+    def delete(self, role_id):
+        """
+        ---
+        summary: Delete a Role
+        tags:
+          - Roles
+        responses:
+          204:
+            description: Role deleted successfully.
+          404:
+            $ref: '#/components/responses/404-NotFound'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+        """
+        storage = get_storage()
+        storage.delete_role(role_id)
+        return '', 204
+
+
+class RolePermissionManagementView(MethodView):
+    def post(self, role_id, permission_id):
+        """
+        ---
+        summary: Add a permission to a role
+        tags:
+          - Roles
+        responses:
+          204:
+            description: Permission added to role successfully.
+          400:
+            $ref: '#/components/responses/400-BadRequest'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+        """
+        storage = get_storage()
+        storage.add_permission_to_role(role_id, permission_id)
+        return '', 204
+
+    def delete(self, role_id, permission_id):
+        """
+        ---
+        summary: Remove a permission from a role
+        tags:
+          - Roles
+        responses:
+          204:
+            description: Removed permission successfully.
+          404:
+            $ref: '#/components/responses/404-NotFound'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+        """
+        storage = get_storage()
+        storage.remove_permission_from_role(role_id, permission_id)
+
+
+role_blp = Blueprint(
+    'roles', 'roles', url_prefix='/roles',
+)
+role_blp.add_url_rule('/', view_func=AllRolesView.as_view('all'))
+role_blp.add_url_rule('/<role_id>', view_func=RoleView.as_view('single'))
+role_blp.add_url_rule(
+    '/<role_id>/permissions/<permission_id>',
+    view_func=RolePermissionManagementView.as_view('permissions')
+)

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -29,7 +29,10 @@ VARIABLE_FIELD = ma.String(
     description="The variable being forecast",
     required=True,
     validate=validate.OneOf(VARIABLES))
-
+ORGANIZATION_ID = ma.UUID(
+        title="Organization ID",
+        description="UUID of the Organization the Object belongs to."
+    )
 CREATED_AT = ma.DateTime(
     title="Creation time",
     description="ISO 8601 Datetime when object was created",
@@ -542,6 +545,7 @@ class UserPostSchema(ma.Schema):
         title="Organization ID",
         description="UUID of the Organization the User belongs to."
     )
+    
 
 
 @spec.define_schema('UserSchema')
@@ -558,7 +562,76 @@ class UserSchema(ma.Schema):
         title="User ID",
         description="Unique UUID of the User.",
     )
-    organization_id = ma.UUID(
-        title="Organization ID",
-        description="UUID of the Organization the User belongs to."
+    organization_id = ORGANIZATION_ID
+    created_at = CREATED_AT
+    modified_at = MODIFIED_AT
+
+
+@spec.define_schema('PermissionPostSchema')
+class PermissionPostSchema(ma.Schema):
+    description=ma.String(
+        title='Desctription',
+        required=True,
+        description="Description of the purpose of a permission.",
     )
+    action = ma.String(
+        title='Action',
+        description="The action that the permission allows.",
+        required=True,
+        validate=validate.OneOf(['create', 'read', 'update',
+                                 'delete', 'read_values', 'write_values',
+                                 'delete_values']),
+    )
+    object_type=ma.String(
+        title="Object Type",
+        description="The type of object this permission will act on.",
+        required=True,
+        validate=validate.OneOf(['sites', 'aggregates', 'forecasts',
+                                 'observations', 'users', 'roles',
+                                 'permissions']),
+    )
+    applies_to_all = ma.Boolean(
+        title="Applies to all",
+        default=False,
+        description=("Whether or not the permission applied to all objects "
+                     "of object_type."),
+    )
+
+
+@spec.define_schema('PermissionSchema')
+class PermissionSchema(PermissionPostSchema):
+    permission_id=ma.UUID(
+        title="Permission ID",
+        description="UUID of the Permission",
+    )
+    organization_id = ORGANIZATION_ID
+    created_at = CREATED_AT
+    modified_at = MODIFIED_AT
+
+
+@spec.define_schema('RolePostSchema')
+class RolePostSchema(ma.Schema):
+    name = ma.String(
+        title='Name',
+        description="Name of the Role",
+        required=True,
+        validate=UserstringValidator()
+    )
+    # Perhaps this needs some validation?
+    description = ma.String(
+        title='Description',
+        description= "A description of the responsibility of the role.",
+        required=True,
+    )
+
+
+@spec.define_schema('RoleSchema')
+class RoleSchema(RolePostSchema):
+    role_id = ma.UUID(
+        title='Role ID',
+        description="UUID of the role",
+    )
+    organization_id = ORGANIZATION_ID
+    permissions = ma.Dict()
+    created_at = CREATED_AT
+    modified_at = MODIFIED_AT

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -540,7 +540,7 @@ class UserPostSchema(ma.Schema):
     # organization.
     organization_id = ma.UUID(
         title="Organization ID",
-        description="UUID of the Organization the User belongs to.")
+        description="UUID of the Organization the User belongs to."
     )
 
 
@@ -560,5 +560,5 @@ class UserSchema(ma.Schema):
     )
     organization_id = ma.UUID(
         title="Organization ID",
-        description="UUID of the Organization the User belongs to.")
+        description="UUID of the Organization the User belongs to."
     )

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -576,7 +576,7 @@ class PermissionPostSchema(ma.Schema):
         required=True,
         validate=validate.OneOf(['sites', 'aggregates', 'forecasts',
                                  'observations', 'users', 'roles',
-                                 'permissions']),
+                                 'permissions', 'cdf_forecasts']),
     )
     applies_to_all = ma.Boolean(
         title="Applies to all",

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -30,9 +30,9 @@ VARIABLE_FIELD = ma.String(
     required=True,
     validate=validate.OneOf(VARIABLES))
 ORGANIZATION_ID = ma.UUID(
-        title="Organization ID",
-        description="UUID of the Organization the Object belongs to."
-    )
+    title="Organization ID",
+    description="UUID of the Organization the Object belongs to."
+)
 CREATED_AT = ma.DateTime(
     title="Creation time",
     description="ISO 8601 Datetime when object was created",
@@ -545,7 +545,6 @@ class UserPostSchema(ma.Schema):
         title="Organization ID",
         description="UUID of the Organization the User belongs to."
     )
-    
 
 
 @spec.define_schema('UserSchema')
@@ -569,7 +568,7 @@ class UserSchema(ma.Schema):
 
 @spec.define_schema('PermissionPostSchema')
 class PermissionPostSchema(ma.Schema):
-    description=ma.String(
+    description = ma.String(
         title='Desctription',
         required=True,
         description="Description of the purpose of a permission.",
@@ -582,7 +581,7 @@ class PermissionPostSchema(ma.Schema):
                                  'delete', 'read_values', 'write_values',
                                  'delete_values']),
     )
-    object_type=ma.String(
+    object_type = ma.String(
         title="Object Type",
         description="The type of object this permission will act on.",
         required=True,
@@ -600,7 +599,7 @@ class PermissionPostSchema(ma.Schema):
 
 @spec.define_schema('PermissionSchema')
 class PermissionSchema(PermissionPostSchema):
-    permission_id=ma.UUID(
+    permission_id = ma.UUID(
         title="Permission ID",
         description="UUID of the Permission",
     )
@@ -620,7 +619,7 @@ class RolePostSchema(ma.Schema):
     # Perhaps this needs some validation?
     description = ma.String(
         title='Description',
-        description= "A description of the responsibility of the role.",
+        description="A description of the responsibility of the role.",
         required=True,
     )
 

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -526,3 +526,39 @@ class CDFForecastGroupSchema(CDFForecastGroupPostSchema):
     constant_values = ma.Nested(CDFForecastSingleSchema, many=True)
     created_at = CREATED_AT
     modified_at = MODIFIED_AT
+
+
+@spec.define_schema('UserPostSchema')
+class UserPostSchema(ma.Schema):
+    auth0_id = ma.String(
+        title="Auth0 ID",
+        description="The User's unique Auth0 identifier.",
+    )
+    # Not sure if this should be here, on one hand we want Admin at an
+    # Organization to only be able to add Users for their organization,
+    # but framework administrators would need a way to add a user to any
+    # organization.
+    organization_id = ma.UUID(
+        title="Organization ID",
+        description="UUID of the Organization the User belongs to.")
+    )
+
+
+@spec.define_schema('UserSchema')
+class UserSchema(ma.Schema):
+    _links = ma.Hyperlinks(
+        {
+            'roles': ma.AbsoluteURLFor('roles.user_roles',
+                                       user_id='<user_id>'),
+        },
+        description="Contains a link to the Users associated Roles."
+    )
+    # Should auth0_id be included in the response schema?
+    user_id = ma.UUID(
+        title="User ID",
+        description="Unique UUID of the User.",
+    )
+    organization_id = ma.UUID(
+        title="Organization ID",
+        description="UUID of the Organization the User belongs to.")
+    )

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -537,10 +537,6 @@ class UserPostSchema(ma.Schema):
         title="Auth0 ID",
         description="The User's unique Auth0 identifier.",
     )
-    # Not sure if this should be here, on one hand we want Admin at an
-    # Organization to only be able to add Users for their organization,
-    # but framework administrators would need a way to add a user to any
-    # organization.
     organization_id = ma.UUID(
         title="Organization ID",
         description="UUID of the Organization the User belongs to."
@@ -556,7 +552,6 @@ class UserSchema(ma.Schema):
         },
         description="Contains a link to the Users associated Roles."
     )
-    # Should auth0_id be included in the response schema?
     user_id = ma.UUID(
         title="User ID",
         description="Unique UUID of the User.",

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -549,9 +549,10 @@ class UserSchema(ma.Schema):
         title="User ID",
         description="Unique UUID of the User.",
     )
-    organization_id = ORGANIZATION_ID
+    organization = ma.String(title='Organization')
     created_at = CREATED_AT
     modified_at = MODIFIED_AT
+    roles = ma.Dict()
 
 
 @spec.define_schema('PermissionPostSchema')
@@ -591,8 +592,8 @@ class PermissionSchema(PermissionPostSchema):
         title="Permission ID",
         description="UUID of the Permission",
     )
-    organization = ma.String()
-    #organization_id = ORGANIZATION_ID
+    organization = ma.String(title="Organization")
+    objects = ma.Dict()
     created_at = CREATED_AT
     modified_at = MODIFIED_AT
 
@@ -619,8 +620,7 @@ class RoleSchema(RolePostSchema):
         title='Role ID',
         description="UUID of the role",
     )
-    organization = ma.String()
-    #organization_id = ORGANIZATION_ID
+    organization = ma.String(title="Organization")
     permissions = ma.Dict()
     created_at = CREATED_AT
     modified_at = MODIFIED_AT

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -545,13 +545,6 @@ class UserPostSchema(ma.Schema):
 
 @spec.define_schema('UserSchema')
 class UserSchema(ma.Schema):
-    _links = ma.Hyperlinks(
-        {
-            'roles': ma.AbsoluteURLFor('roles.user_roles',
-                                       user_id='<user_id>'),
-        },
-        description="Contains a link to the Users associated Roles."
-    )
     user_id = ma.UUID(
         title="User ID",
         description="Unique UUID of the User.",
@@ -598,7 +591,8 @@ class PermissionSchema(PermissionPostSchema):
         title="Permission ID",
         description="UUID of the Permission",
     )
-    organization_id = ORGANIZATION_ID
+    organization = ma.String()
+    #organization_id = ORGANIZATION_ID
     created_at = CREATED_AT
     modified_at = MODIFIED_AT
 
@@ -625,7 +619,8 @@ class RoleSchema(RolePostSchema):
         title='Role ID',
         description="UUID of the role",
     )
-    organization_id = ORGANIZATION_ID
+    organization = ma.String()
+    #organization_id = ORGANIZATION_ID
     permissions = ma.Dict()
     created_at = CREATED_AT
     modified_at = MODIFIED_AT

--- a/sfa_api/spec.py
+++ b/sfa_api/spec.py
@@ -294,7 +294,7 @@ spec = APISpec(
                         'API to be determined in March/April 2019.'},
         {'name': 'Trials',
          'description': 'Access information about forecast trials. '
-                        'API to be determined in March/April 2019.'}
+                        'API to be determined in March/April 2019.'},
         {'name': 'Users',
          'description': 'Access and update information about users '
                         'in your Organization.'},

--- a/sfa_api/spec.py
+++ b/sfa_api/spec.py
@@ -295,6 +295,13 @@ spec = APISpec(
         {'name': 'Trials',
          'description': 'Access information about forecast trials. '
                         'API to be determined in March/April 2019.'}
+        {'name': 'Users',
+         'description': 'Access and update information about users '
+                        'in your Organization.'},
+        {'name': 'Roles',
+         'description': 'Access and update Roles in your organization.'},
+        {'name': 'Permissions',
+         'description': 'Access and update Permissions in your organization.'},
     ],
     servers=[
         {'url': '//dev-api.solarforecastarbiter.org/',

--- a/sfa_api/tests/rbac/conftest.py
+++ b/sfa_api/tests/rbac/conftest.py
@@ -4,15 +4,79 @@ import pytest
 from flask import _request_ctx_stack
 
 
-from sfa_api.conftest import BASE_URL
+from sfa_api.conftest import BASE_URL, VALID_OBS_JSON
+
+ROLE = {
+    "name": "test created role",
+    "description": "testing role creation",
+}
+
+PERMISSION = {
+    "action": "read",
+    "applies_to_all": False,
+    "description": "test created permission",
+    "object_type": "observations",
+}
 
 
 @pytest.fixture()
-def api(sql_app, mocker):
+def user_id():
+    return '0c90950a-7cca-11e9-a81f-54bf64606445'
+
+
+@pytest.fixture()
+def api(sql_app_no_commit, mocker):
     def add_user():
         _request_ctx_stack.top.user = 'auth0|5be343df7025406237820b85'
         return True
 
     verify = mocker.patch('sfa_api.utils.auth.verify_access_token')
     verify.side_effect = add_user
-    yield sql_app.test_client()
+    yield sql_app_no_commit.test_client()
+
+
+@pytest.fixture
+def new_role(api):
+    def fn():
+        role = api.post(f'/roles/', BASE_URL, json=ROLE)
+        role_id = role.data.decode('utf-8')
+        return role_id
+    return fn
+
+@pytest.fixture
+def new_observation(api):
+    def fn():
+        obs = api.post(f'/observations/', BASE_URL, json=VALID_OBS_JSON)
+        obs_id = obs.data.decode('utf-8')
+        return obs_id
+    return fn
+
+
+@pytest.fixture
+def new_perm(api):
+    def fn():
+        perm = api.post(f'/permissions/', BASE_URL, json=PERMISSION)
+        perm_id = perm.data.decode('utf-8')
+        return perm_id
+    return fn
+
+
+@pytest.fixture
+def current_role(api):    
+    roles_req = api.get('/roles/', BASE_URL)
+    role = roles_req.json[0]
+    return role['role_id']
+
+
+@pytest.fixture
+def remove_perms(api, current_role):
+    def fn(action, object_type):
+        perm_req = api.get('/permissions/', BASE_URL)
+        perms = perm_req.json
+        to_remove = [perm['permission_id'] for perm in perms
+                     if perm['object_type'] == object_type
+                     and perm['action'] == action]
+        for perm_id in to_remove:
+            api.delete(f'/roles/{current_role}/permissions/{perm_id}',
+                       BASE_URL)
+    return fn           

--- a/sfa_api/tests/rbac/conftest.py
+++ b/sfa_api/tests/rbac/conftest.py
@@ -6,6 +6,7 @@ from flask import _request_ctx_stack
 
 from sfa_api.conftest import BASE_URL, VALID_OBS_JSON
 
+
 ROLE = {
     "name": "test created role",
     "description": "testing role creation",
@@ -43,6 +44,7 @@ def new_role(api):
         return role_id
     return fn
 
+
 @pytest.fixture
 def new_observation(api):
     def fn():
@@ -62,7 +64,7 @@ def new_perm(api):
 
 
 @pytest.fixture
-def current_role(api):    
+def current_role(api):
     roles_req = api.get('/roles/', BASE_URL)
     role = roles_req.json[0]
     return role['role_id']
@@ -79,4 +81,4 @@ def remove_perms(api, current_role):
         for perm_id in to_remove:
             api.delete(f'/roles/{current_role}/permissions/{perm_id}',
                        BASE_URL)
-    return fn           
+    return fn

--- a/sfa_api/tests/rbac/conftest.py
+++ b/sfa_api/tests/rbac/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+from flask import _request_ctx_stack
+
+
+from sfa_api.conftest import BASE_URL
+
+
+@pytest.fixture()
+def api(sql_app, mocker):
+    def add_user():
+        _request_ctx_stack.top.user = 'auth0|5be343df7025406237820b85'
+        return True
+
+    verify = mocker.patch('sfa_api.utils.auth.verify_access_token')
+    verify.side_effect = add_user
+    yield sql_app.test_client()

--- a/sfa_api/tests/rbac/test_permissions.py
+++ b/sfa_api/tests/rbac/test_permissions.py
@@ -1,0 +1,162 @@
+import json
+import pytest
+
+from sfa_api.tests.rbac.conftest import PERMISSION
+from sfa_api.conftest import BASE_URL, VALID_OBS_JSON
+from sfa_api.schema import PermissionSchema
+
+
+def test_list_permissions(api):
+    perms = api.get('/permissions/', BASE_URL)
+    assert perms.status_code == 200
+    assert len(perms.json) > 0
+
+
+def test_list_permissions_no_perms(api, remove_perms):
+    remove_perms('read', 'permissions')
+    perms = api.get('/permissions/', BASE_URL)
+    assert perms.status_code == 200
+    assert len(perms.json) == 0
+
+
+def test_create_permission(api):
+    create_perm = api.post('/permissions/', BASE_URL, json=PERMISSION)
+    assert create_perm.status_code == 201
+    perm_id = create_perm.data.decode('utf-8')
+    get_perm = api.get(f'/permissions/{perm_id}', BASE_URL)
+    assert get_perm.status_code == 200
+    
+
+def test_create_permission_no_perms(api, remove_perms):
+    remove_perms('create', 'permissions')
+    failed_create = api.post('/permission/', BASE_URL, json=PERMISSION)
+    assert failed_create.status_code == 404
+
+
+def perm(action, object_type, description, applies_to_all):
+    return {
+        'action': action,
+        'object_type': object_type,
+        'description': description,
+        'applies_to_all': applies_to_all,
+    }
+
+
+@pytest.mark.parametrize('perm,error', [
+    (perm('nope','roles','role perm', True),
+     '{"action":["Must be one of: create, read, update, delete, read_values, write_values, delete_values."]}'),
+    (perm('create','role','role perm', True),
+     '{"object_type":["Must be one of: sites, aggregates, forecasts, observations, users, roles, permissions."]}'),
+    (perm('create','roles','role perm', 5),
+     '{"applies_to_all":["Not a valid boolean."]}'),
+])
+def test_create_permission_invalid_json(api, perm, error):
+    failed_create = api.post('/permissions/', BASE_URL, json=perm)
+    assert failed_create.status_code == 400
+    assert failed_create.get_data(as_text=True) == f'{{"errors":{error}}}\n'
+    
+
+def test_get_permission(api, new_perm):
+    perm_id = new_perm()
+    get_perm = api.get(f'/permissions/{perm_id}', BASE_URL)
+    assert get_perm.status_code == 200
+
+
+def test_get_permission_no_perms(api, remove_perms, new_perm):
+    perm_id = new_perm()
+    remove_perms('read', 'permissions')
+    get_fail = api.get(f'/permissions/{perm_id}', BASE_URL)
+    assert get_fail.status_code == 404
+
+
+def test_delete_permission(api, new_perm):
+    perm_id = new_perm()
+    delete_perm = api.delete(f'/permissions/{perm_id}', BASE_URL)
+    assert delete_perm.status_code == 204
+    assert api.get(f'/permissions/{perm_id}', BASE_URL).status_code == 404
+
+
+def test_delete_permission_no_perms(api, new_perm, remove_perms):
+    perm_id = new_perm()
+    remove_perms('delete', 'permissions')
+    delete_fail = api.delete(f'/permissions/{perm_id}', BASE_URL)
+    assert delete_fail.status_code == 404
+
+
+def test_add_object_to_permission(api, new_perm, new_observation):
+    perm_id = new_perm()
+    new_obs = new_observation()
+    add_to_perm = api.post(f'/permissions/{perm_id}/objects/{new_obs}',
+                           BASE_URL)
+    assert add_to_perm.status_code == 204
+    get_perm = api.get(f'/permissions/{perm_id}', BASE_URL)
+    perm = get_perm.json
+    objects_on_perm = json.loads(perm['objects'])
+    assert new_obs in objects_on_perm.keys()
+
+@pytest.mark.parametrize('action,object_type', [
+    ('update', 'permissions'),
+    ('read', 'observations'),
+])
+def test_add_object_to_permission_no_perms(
+        api, new_perm, new_observation, remove_perms, action, object_type):
+    perm_id = new_perm()
+    obs_id = new_observation()
+    remove_perms(action, object_type)
+    add_to_perm = api.post(f'/permissions/{perm_id}/objects/{obs_id}',
+                           BASE_URL)
+    assert add_to_perm.status_code == 404
+
+def test_remove_object_from_permission(api, new_perm, new_observation):
+    perm_id = new_perm()
+    obs_id = new_observation()
+    add_object = api.post(f'/permissions/{perm_id}/objects/{obs_id}',
+                          BASE_URL).status_code == 204
+    delete_object = api.delete(f'/permissions/{perm_id}/objects/{obs_id}',
+                               BASE_URL)
+    assert delete_object.status_code == 204
+    get_perm = api.get(f'/permissions/{perm_id}', BASE_URL)
+    perm = get_perm.json
+    objects_on_perm = json.loads(perm['objects'])
+    assert obs_id not in objects_on_perm.keys()
+
+
+def test_remove_object_from_permission_perm_dne(api, missing_id, new_observation):
+    obs_id = new_observation()
+    remove_object = api.delete(f'/permissions/{missing_id}/objects/{obs_id}',
+                               BASE_URL)
+    assert remove_object.status_code == 404
+
+
+def test_remove_object_from_permission_object_dne(api, new_perm, missing_id, new_observation):
+    # test that objects list is not altered even though 204 is returned
+    perm_id = new_perm()
+    new_obs = new_observation()
+    add_to_perm = api.post(f'/permissions/{perm_id}/objects/{new_obs}',BASE_URL)
+    get_perm = api.get(f'/permissions/{perm_id}', BASE_URL)
+    perm = get_perm.json
+    objects_on_perm = json.loads(perm['objects'])
+
+    remove_object = api.delete(f'/permissions/{perm_id}/objects/{missing_id}', BASE_URL)
+    assert remove_object.status_code == 204
+
+    get_perm = api.get(f'/permissions/{perm_id}', BASE_URL)
+    perm = get_perm.json
+    new_objects_on_perm = json.loads(perm['objects'])
+    assert objects_on_perm == new_objects_on_perm
+
+
+@pytest.mark.parametrize('action,object_type', [
+    ('update', 'permissions'),
+])
+def test_remove_object_from_permission_no_perms(
+    api, new_perm, new_observation, remove_perms, action, object_type):
+    perm_id = new_perm()
+    obs_id = new_observation()
+    add_object = api.post(f'/permissions/{perm_id}/objects/{obs_id}',
+                          BASE_URL).status_code == 204
+    remove_perms(action, object_type)
+    delete_object = api.delete(f'/permissions/{perm_id}/objects/{obs_id}',
+                               BASE_URL)
+    assert delete_object.status_code == 404
+

--- a/sfa_api/tests/rbac/test_permissions.py
+++ b/sfa_api/tests/rbac/test_permissions.py
@@ -1,4 +1,3 @@
-import json
 import pytest
 
 from sfa_api.tests.rbac.conftest import PERMISSION
@@ -45,7 +44,7 @@ def perm(action, object_type, description, applies_to_all):
     (perm('nope', 'roles', 'role perm', True),
         '{"action":["Must be one of: create, read, update, delete, read_values, write_values, delete_values."]}'),  # noqa: E501
     (perm('create', 'role', 'role perm', True),
-     '{"object_type":["Must be one of: sites, aggregates, forecasts, observations, users, roles, permissions."]}'),  # noqa: E501
+     '{"object_type":["Must be one of: sites, aggregates, forecasts, observations, users, roles, permissions, cdf_forecasts."]}'),  # noqa: E501
     (perm('create', 'roles', 'role perm', 5),
      '{"applies_to_all":["Not a valid boolean."]}'),
 ])
@@ -90,7 +89,7 @@ def test_add_object_to_permission(api, new_perm, new_observation):
     assert add_to_perm.status_code == 204
     get_perm = api.get(f'/permissions/{perm_id}', BASE_URL)
     perm = get_perm.json
-    objects_on_perm = json.loads(perm['objects'])
+    objects_on_perm = perm['objects']
     assert new_obs in objects_on_perm.keys()
 
 
@@ -119,7 +118,7 @@ def test_remove_object_from_permission(api, new_perm, new_observation):
     assert delete_object.status_code == 204
     get_perm = api.get(f'/permissions/{perm_id}', BASE_URL)
     perm = get_perm.json
-    objects_on_perm = json.loads(perm['objects'])
+    objects_on_perm = perm['objects']
     assert obs_id not in objects_on_perm.keys()
 
 
@@ -141,7 +140,7 @@ def test_remove_object_from_permission_object_dne(
     assert add_to_perm.status_code == 204
     get_perm = api.get(f'/permissions/{perm_id}', BASE_URL)
     perm = get_perm.json
-    objects_on_perm = json.loads(perm['objects'])
+    objects_on_perm = perm['objects']
 
     remove_object = api.delete(f'/permissions/{perm_id}/objects/{missing_id}',
                                BASE_URL)
@@ -149,7 +148,7 @@ def test_remove_object_from_permission_object_dne(
 
     get_perm = api.get(f'/permissions/{perm_id}', BASE_URL)
     perm = get_perm.json
-    new_objects_on_perm = json.loads(perm['objects'])
+    new_objects_on_perm = perm['objects']
     assert objects_on_perm == new_objects_on_perm
 
 

--- a/sfa_api/tests/rbac/test_permissions.py
+++ b/sfa_api/tests/rbac/test_permissions.py
@@ -2,8 +2,7 @@ import json
 import pytest
 
 from sfa_api.tests.rbac.conftest import PERMISSION
-from sfa_api.conftest import BASE_URL, VALID_OBS_JSON
-from sfa_api.schema import PermissionSchema
+from sfa_api.conftest import BASE_URL
 
 
 def test_list_permissions(api):
@@ -25,7 +24,7 @@ def test_create_permission(api):
     perm_id = create_perm.data.decode('utf-8')
     get_perm = api.get(f'/permissions/{perm_id}', BASE_URL)
     assert get_perm.status_code == 200
-    
+
 
 def test_create_permission_no_perms(api, remove_perms):
     remove_perms('create', 'permissions')
@@ -43,18 +42,18 @@ def perm(action, object_type, description, applies_to_all):
 
 
 @pytest.mark.parametrize('perm,error', [
-    (perm('nope','roles','role perm', True),
-     '{"action":["Must be one of: create, read, update, delete, read_values, write_values, delete_values."]}'),
-    (perm('create','role','role perm', True),
-     '{"object_type":["Must be one of: sites, aggregates, forecasts, observations, users, roles, permissions."]}'),
-    (perm('create','roles','role perm', 5),
+    (perm('nope', 'roles', 'role perm', True),
+        '{"action":["Must be one of: create, read, update, delete, read_values, write_values, delete_values."]}'),  # noqa: E501
+    (perm('create', 'role', 'role perm', True),
+     '{"object_type":["Must be one of: sites, aggregates, forecasts, observations, users, roles, permissions."]}'),  # noqa: E501
+    (perm('create', 'roles', 'role perm', 5),
      '{"applies_to_all":["Not a valid boolean."]}'),
 ])
 def test_create_permission_invalid_json(api, perm, error):
     failed_create = api.post('/permissions/', BASE_URL, json=perm)
     assert failed_create.status_code == 400
     assert failed_create.get_data(as_text=True) == f'{{"errors":{error}}}\n'
-    
+
 
 def test_get_permission(api, new_perm):
     perm_id = new_perm()
@@ -94,6 +93,7 @@ def test_add_object_to_permission(api, new_perm, new_observation):
     objects_on_perm = json.loads(perm['objects'])
     assert new_obs in objects_on_perm.keys()
 
+
 @pytest.mark.parametrize('action,object_type', [
     ('update', 'permissions'),
     ('read', 'observations'),
@@ -107,11 +107,13 @@ def test_add_object_to_permission_no_perms(
                            BASE_URL)
     assert add_to_perm.status_code == 404
 
+
 def test_remove_object_from_permission(api, new_perm, new_observation):
     perm_id = new_perm()
     obs_id = new_observation()
     add_object = api.post(f'/permissions/{perm_id}/objects/{obs_id}',
-                          BASE_URL).status_code == 204
+                          BASE_URL)
+    assert add_object.status_code == 204
     delete_object = api.delete(f'/permissions/{perm_id}/objects/{obs_id}',
                                BASE_URL)
     assert delete_object.status_code == 204
@@ -121,23 +123,28 @@ def test_remove_object_from_permission(api, new_perm, new_observation):
     assert obs_id not in objects_on_perm.keys()
 
 
-def test_remove_object_from_permission_perm_dne(api, missing_id, new_observation):
+def test_remove_object_from_permission_perm_dne(
+        api, missing_id, new_observation):
     obs_id = new_observation()
     remove_object = api.delete(f'/permissions/{missing_id}/objects/{obs_id}',
                                BASE_URL)
     assert remove_object.status_code == 404
 
 
-def test_remove_object_from_permission_object_dne(api, new_perm, missing_id, new_observation):
+def test_remove_object_from_permission_object_dne(
+        api, new_perm, missing_id, new_observation):
     # test that objects list is not altered even though 204 is returned
     perm_id = new_perm()
     new_obs = new_observation()
-    add_to_perm = api.post(f'/permissions/{perm_id}/objects/{new_obs}',BASE_URL)
+    add_to_perm = api.post(f'/permissions/{perm_id}/objects/{new_obs}',
+                           BASE_URL)
+    assert add_to_perm.status_code == 204
     get_perm = api.get(f'/permissions/{perm_id}', BASE_URL)
     perm = get_perm.json
     objects_on_perm = json.loads(perm['objects'])
 
-    remove_object = api.delete(f'/permissions/{perm_id}/objects/{missing_id}', BASE_URL)
+    remove_object = api.delete(f'/permissions/{perm_id}/objects/{missing_id}',
+                               BASE_URL)
     assert remove_object.status_code == 204
 
     get_perm = api.get(f'/permissions/{perm_id}', BASE_URL)
@@ -150,13 +157,13 @@ def test_remove_object_from_permission_object_dne(api, new_perm, missing_id, new
     ('update', 'permissions'),
 ])
 def test_remove_object_from_permission_no_perms(
-    api, new_perm, new_observation, remove_perms, action, object_type):
+        api, new_perm, new_observation, remove_perms, action, object_type):
     perm_id = new_perm()
     obs_id = new_observation()
     add_object = api.post(f'/permissions/{perm_id}/objects/{obs_id}',
-                          BASE_URL).status_code == 204
+                          BASE_URL)
+    assert add_object.status_code == 204
     remove_perms(action, object_type)
     delete_object = api.delete(f'/permissions/{perm_id}/objects/{obs_id}',
                                BASE_URL)
     assert delete_object.status_code == 404
-

--- a/sfa_api/tests/rbac/test_roles.py
+++ b/sfa_api/tests/rbac/test_roles.py
@@ -1,64 +1,157 @@
+import json
 import pytest
 
 
-def test_list_roles():
-    assert req.status_code == 200
+from sfa_api.conftest import BASE_URL
+from sfa_api.tests.rbac.conftest import ROLE, PERMISSION
 
 
-def test_list_roles_missing_perms():
-    assert req.status_code == 404
+def get_role(api, role_id):
+    return api.get(f'/roles/{role_id}', BASE_URL)
 
 
-def test_create_role():
-    assert req.status_code == 404
+def get_perm(api, perm_id):
+    return api.get(f'/permissions/{perm_id}', BASE_URL)
 
 
-def test_create_role_invalid_json():
-    assert req.status_code == 404
+def test_list_roles_get_role(api):
+    roles = api.get('/roles/',
+                    BASE_URL)
+    assert roles.json[0]['name'] == 'Test user role'
+    assert roles.status_code == 200
+    role = api.get(f'/roles/{roles.json[0]["role_id"]}',
+                   BASE_URL)
 
 
-def test_create_role_missing_perms():
-    assert req.status_code == 404
+def test_list_roles_missing_perms(api, remove_perms):
+    remove_perms('read', 'roles')
+    roles = api.get('/roles/', BASE_URL)
+    assert roles.status_code == 200
+    assert len(roles.json) == 0
 
 
-def test_get_role():
-    assert req.status_code == 200
+def test_create_delete_role(api):
+    new_role_id = api.post('/roles/', BASE_URL, json=ROLE)
+    assert new_role_id.status_code == 201
+    new_role_id = new_role_id.data.decode('utf-8')
+    new_role = api.get(f'/roles/{new_role_id}', BASE_URL)
+    assert new_role.status_code == 200
+    deleted = api.delete(f'/roles/{new_role_id}', BASE_URL)
+    assert deleted.status_code ==204
+    role_dne = api.get(f'/roles/{new_role_id}', BASE_URL)
+    assert role_dne.status_code == 404
+
+    
+
+@pytest.mark.parametrize('role,error', [
+    ({'name': 'brad'}, '{"description":["Missing data for required field."]}'),
+    ({'description': 'brad role'}, '{"name":["Missing data for required field."]}'),
+    ({'name': '!@$^Y','description': 'description'}, '{"name":["Invalid characters in string."]}'),
+])
+def test_create_role_invalid_json(api, role, error):
+    failed_role = api.post('/roles/',BASE_URL, json=role)
+    assert failed_role.status_code == 400
+    assert failed_role.get_data(as_text=True) == f'{{"errors":{error}}}\n'
 
 
-def test_get_role_dne():
-    assert req.status_code == 404
+def test_create_role_missing_perms(api, remove_perms):
+    remove_perms('create', 'roles')
+    failed_role = api.post(f'/roles/', BASE_URL, json=ROLE)
+    assert failed_role.status_code == 404
 
 
-def test_get_role_missing_perms():
-    assert req.status_code == 404
+def test_get_role_dne(api, missing_id):
+    missing = api.get(f'/roles/{missing_id}', BASE_URL)
+    assert missing.status_code == 404
 
 
-def test_delete_role():
-    assert req.status_code == 204
+def test_get_role_missing_perms(api, new_role, remove_perms):
+    role_id = new_role()
+    assert api.get(f'/roles/{role_id}', BASE_URL).status_code == 200
+    remove_perms('read', 'roles')
+    assert  api.get(f'/roles/{role_id}', BASE_URL).status_code == 404
 
 
-def test_delete_role_dne():
-    assert req.status_code == 404
+
+def test_delete_role(api, new_role):
+    role_id = new_role()
+    assert api.get(f'/roles/{role_id}', BASE_URL).status_code == 200
+    deleted = api.delete(f'/roles/{role_id}', BASE_URL)
+    assert deleted.status_code == 204
+    assert api.get(f'/roles/{role_id}', BASE_URL).status_code == 404
 
 
-def test_delete_role_missing_perms():
-    assert req.status_code == 404
+def test_delete_role_dne(api, missing_id):
+    missing = api.delete(f'/roles/{missing_id}', BASE_URL)
+    assert missing.status_code == 404
 
 
-def test_add_perm_to_role():
-    assert req.status_Code == 204
+def test_delete_role_missing_perms(api, new_role, remove_perms):
+    role_id = new_role()
+    remove_perms('delete', 'roles')
+    failed_delete = api.delete(f'/roles/{role_id}', BASE_URL)
+    assert failed_delete.status_code == 404
 
 
-def test_add_perm_to_role_perm_dne():
-    assert req.status_code == 404
+def test_add_perm_to_role(api, new_role, new_perm, missing_id):
+    role_id = new_role()
+    perm_id = new_perm()
+    perms = api.get('/permissions/', BASE_URL)
+    assert perm_id in [ perm['permission_id'] for perm in perms.json]
+    added_perm = api.post(f'/roles/{role_id}/permissions/{perm_id}',
+                          BASE_URL )
+    assert added_perm.status_code == 204
+    assert perm_id in json.loads(get_role(api, role_id).json['permissions']).keys()
+
+def test_add_perm_to_role_role_dne(api, missing_id, new_perm):
+    perm_id = new_perm()
+    role_dne = api.post(f'/roles/{missing_id}/permissions/{perm_id}',
+                        BASE_URL)
+    assert role_dne.status_code == 404
 
 
-def test_add_perm_to_role_role_dne():
-    assert req.status_code == 404
+def test_add_perm_to_role_perm_dne(api, missing_id, new_role):
+    role_id = new_role()
+    perm_dne =api.post(f'/roles/{role_id}/permissions/{missing_id}',
+                       BASE_URL)
+    assert perm_dne.status_code == 404
+                         
+def test_remove_perm_from_role(api, new_role, new_perm):
+    role_id = new_role()
+    perm_id = new_perm()
+    added_perm = api.post(f'roles/{role_id}/permissions/{perm_id}',
+                          BASE_URL)
+    assert added_perm.status_code == 204
+    removed_perm = api.delete(f'/roles/{role_id}/permissions/{perm_id}',
+                              BASE_URL)
+    assert removed_perm.status_code == 204
+    assert perm_id not in json.loads(get_role(api, role_id).json['permissions']).keys()
 
-def test_add_perm_to_role_missing_perm():
-    # parametrize with:
-    # no update role
-    # to read role
-    # no read permission
-    assert req.status_code == 404
+def test_remove_perm_from_role_role_dne(api, missing_id, new_perm):
+    perm_id = new_perm()
+    removed_perm = api.delete(f'/roles/{missing_id}/permissions/{perm_id}',
+                              BASE_URL)
+    assert removed_perm.status_code == 404
+
+def test_remove_perm_from_role_perm_dne(api, new_role, missing_id):
+    # test that perms aren't modified even though a 204 is returned
+    role_id = new_role()
+    get_role = api.get(f'/roles/{role_id}', BASE_URL)
+    role = get_role.json
+    perms_on_role = json.loads(role['permissions'])
+    removed_perm = api.delete(f'/roles/{role_id}/permissions/{missing_id}',
+                              BASE_URL)
+    assert removed_perm.status_code == 204
+    get_role = api.get(f'/roles/{role_id}', BASE_URL)
+    role = get_role.json
+    new_perms_on_role = json.loads(role['permissions'])
+    assert perms_on_role == new_perms_on_role
+
+
+def test_add_perm_to_role_missing_perm(api, new_role, new_perm, remove_perms):
+    remove_perms('update', 'roles')
+    role_id = new_role()
+    perm_id = new_perm()
+    failed_add = api.post(f'/roles/{role_id}/permissions/{perm_id}',
+                          BASE_URL)
+    assert failed_add.status_code == 404

--- a/sfa_api/tests/rbac/test_roles.py
+++ b/sfa_api/tests/rbac/test_roles.py
@@ -1,4 +1,3 @@
-import json
 import pytest
 
 
@@ -106,7 +105,7 @@ def test_add_perm_to_role(api, new_role, new_perm, missing_id):
                           BASE_URL)
     assert added_perm.status_code == 204
     role = get_role(api, role_id).json
-    permissions_on_role = json.loads(role['permissions']).keys()
+    permissions_on_role = role['permissions'].keys()
     assert perm_id in permissions_on_role
 
 
@@ -134,7 +133,7 @@ def test_remove_perm_from_role(api, new_role, new_perm):
                               BASE_URL)
     assert removed_perm.status_code == 204
     role = get_role(api, role_id).json
-    permissions_on_role = json.loads(role['permissions']).keys()
+    permissions_on_role = role['permissions'].keys()
     assert perm_id not in permissions_on_role
 
 
@@ -150,13 +149,13 @@ def test_remove_perm_from_role_perm_dne(api, new_role, missing_id):
     role_id = new_role()
     get_role = api.get(f'/roles/{role_id}', BASE_URL)
     role = get_role.json
-    perms_on_role = json.loads(role['permissions'])
+    perms_on_role = role['permissions']
     removed_perm = api.delete(f'/roles/{role_id}/permissions/{missing_id}',
                               BASE_URL)
     assert removed_perm.status_code == 204
     get_role = api.get(f'/roles/{role_id}', BASE_URL)
     role = get_role.json
-    new_perms_on_role = json.loads(role['permissions'])
+    new_perms_on_role = role['permissions']
     assert perms_on_role == new_perms_on_role
 
 

--- a/sfa_api/tests/rbac/test_roles.py
+++ b/sfa_api/tests/rbac/test_roles.py
@@ -1,0 +1,64 @@
+import pytest
+
+
+def test_list_roles():
+    assert req.status_code == 200
+
+
+def test_list_roles_missing_perms():
+    assert req.status_code == 404
+
+
+def test_create_role():
+    assert req.status_code == 404
+
+
+def test_create_role_invalid_json():
+    assert req.status_code == 404
+
+
+def test_create_role_missing_perms():
+    assert req.status_code == 404
+
+
+def test_get_role():
+    assert req.status_code == 200
+
+
+def test_get_role_dne():
+    assert req.status_code == 404
+
+
+def test_get_role_missing_perms():
+    assert req.status_code == 404
+
+
+def test_delete_role():
+    assert req.status_code == 204
+
+
+def test_delete_role_dne():
+    assert req.status_code == 404
+
+
+def test_delete_role_missing_perms():
+    assert req.status_code == 404
+
+
+def test_add_perm_to_role():
+    assert req.status_Code == 204
+
+
+def test_add_perm_to_role_perm_dne():
+    assert req.status_code == 404
+
+
+def test_add_perm_to_role_role_dne():
+    assert req.status_code == 404
+
+def test_add_perm_to_role_missing_perm():
+    # parametrize with:
+    # no update role
+    # to read role
+    # no read permission
+    assert req.status_code == 404

--- a/sfa_api/tests/rbac/test_users.py
+++ b/sfa_api/tests/rbac/test_users.py
@@ -1,7 +1,4 @@
 import json
-import pytest
-
-
 from sfa_api.conftest import BASE_URL
 
 
@@ -34,6 +31,7 @@ def test_list_users(api, user_id):
     assert len(user_list) > 0
     assert user_id in [user['user_id'] for user in user_list]
 
+
 def test_list_users_no_perm(api, remove_perms):
     remove_perms('read', 'users')
     get_users = api.get('/users/', BASE_URL)
@@ -49,16 +47,18 @@ def test_add_role_to_user(api, user_id, new_role):
     user = get_user.json
     roles_on_user = json.loads(user['roles']).keys()
     assert role_id in roles_on_user
-    
+
 
 def test_add_role_to_user_user_dne(api, missing_id, new_role):
     role_id = new_role()
     add_role = api.post(f'/users/{missing_id}/roles/{role_id}', BASE_URL)
     assert add_role.status_code == 404
 
+
 def test_add_role_to_user_role_dne(api, user_id, missing_id):
     add_role = api.post(f'/users/{user_id}/roles/{missing_id}', BASE_URL)
     assert add_role.status_code == 404
+
 
 def test_add_role_to_user_no_perms(api, user_id, new_role, remove_perms):
     role_id = new_role()
@@ -69,6 +69,7 @@ def test_add_role_to_user_no_perms(api, user_id, new_role, remove_perms):
     user = get_user.json
     roles_on_user = json.loads(user['roles']).keys()
     assert role_id not in roles_on_user
+
 
 def test_remove_role_from_user(api, user_id, new_role):
     role_id = new_role()
@@ -101,6 +102,7 @@ def test_remove_role_from_user_role_dne(api, user_id, missing_id):
     user = get_user.json
     new_roles_on_user = json.loads(user['roles']).keys()
     assert roles_on_user == new_roles_on_user
+
 
 def test_remove_role_from_user_no_perms(api, user_id, new_role, remove_perms):
     role_id = new_role()

--- a/sfa_api/tests/rbac/test_users.py
+++ b/sfa_api/tests/rbac/test_users.py
@@ -1,4 +1,3 @@
-import json
 from sfa_api.conftest import BASE_URL
 
 
@@ -45,7 +44,7 @@ def test_add_role_to_user(api, user_id, new_role):
     assert add_role.status_code == 204
     get_user = api.get(f'/users/{user_id}', BASE_URL)
     user = get_user.json
-    roles_on_user = json.loads(user['roles']).keys()
+    roles_on_user = user['roles'].keys()
     assert role_id in roles_on_user
 
 
@@ -67,7 +66,7 @@ def test_add_role_to_user_no_perms(api, user_id, new_role, remove_perms):
     assert add_role.status_code == 404
     get_user = api.get(f'/users/{user_id}', BASE_URL)
     user = get_user.json
-    roles_on_user = json.loads(user['roles']).keys()
+    roles_on_user = user['roles'].keys()
     assert role_id not in roles_on_user
 
 
@@ -79,7 +78,7 @@ def test_remove_role_from_user(api, user_id, new_role):
     assert remove_role.status_code == 204
     get_user = api.get(f'/users/{user_id}', BASE_URL)
     user = get_user.json
-    roles_on_user = json.loads(user['roles']).keys()
+    roles_on_user = user['roles'].keys()
     assert role_id not in roles_on_user
 
 
@@ -93,14 +92,14 @@ def test_remove_role_from_user_role_dne(api, user_id, missing_id):
     # test that no change is made, even though 204 is returned.
     get_user = api.get(f'/users/{user_id}', BASE_URL)
     user = get_user.json
-    roles_on_user = json.loads(user['roles']).keys()
+    roles_on_user = user['roles'].keys()
 
     add_role = api.delete(f'/users/{user_id}/roles/{missing_id}', BASE_URL)
     assert add_role.status_code == 204
 
     get_user = api.get(f'/users/{user_id}', BASE_URL)
     user = get_user.json
-    new_roles_on_user = json.loads(user['roles']).keys()
+    new_roles_on_user = user['roles'].keys()
     assert roles_on_user == new_roles_on_user
 
 

--- a/sfa_api/tests/rbac/test_users.py
+++ b/sfa_api/tests/rbac/test_users.py
@@ -1,0 +1,111 @@
+import json
+import pytest
+
+
+from sfa_api.conftest import BASE_URL
+
+
+def test_get_user(api, user_id):
+    get_user = api.get(f'/users/{user_id}', BASE_URL)
+    assert get_user.status_code == 200
+    user_fields = get_user.json.keys()
+    assert 'user_id' in user_fields
+    assert 'organization' in user_fields
+    assert 'created_at' in user_fields
+    assert 'modified_at' in user_fields
+    assert 'roles' in user_fields
+
+
+def test_get_user_dne(api, missing_id):
+    get_user = api.get(f'/users/{missing_id}', BASE_URL)
+    assert get_user.status_code == 404
+
+
+def test_get_user_no_perms(api, user_id, remove_perms):
+    remove_perms('read', 'users')
+    get_user = api.get(f'/users/{user_id}', BASE_URL)
+    assert get_user.status_code == 404
+
+
+def test_list_users(api, user_id):
+    get_users = api.get('/users/', BASE_URL)
+    assert get_users.status_code == 200
+    user_list = get_users.json
+    assert len(user_list) > 0
+    assert user_id in [user['user_id'] for user in user_list]
+
+def test_list_users_no_perm(api, remove_perms):
+    remove_perms('read', 'users')
+    get_users = api.get('/users/', BASE_URL)
+    assert get_users.status_code == 200
+    assert get_users.json == []
+
+
+def test_add_role_to_user(api, user_id, new_role):
+    role_id = new_role()
+    add_role = api.post(f'/users/{user_id}/roles/{role_id}', BASE_URL)
+    assert add_role.status_code == 204
+    get_user = api.get(f'/users/{user_id}', BASE_URL)
+    user = get_user.json
+    roles_on_user = json.loads(user['roles']).keys()
+    assert role_id in roles_on_user
+    
+
+def test_add_role_to_user_user_dne(api, missing_id, new_role):
+    role_id = new_role()
+    add_role = api.post(f'/users/{missing_id}/roles/{role_id}', BASE_URL)
+    assert add_role.status_code == 404
+
+def test_add_role_to_user_role_dne(api, user_id, missing_id):
+    add_role = api.post(f'/users/{user_id}/roles/{missing_id}', BASE_URL)
+    assert add_role.status_code == 404
+
+def test_add_role_to_user_no_perms(api, user_id, new_role, remove_perms):
+    role_id = new_role()
+    remove_perms('update', 'users')
+    add_role = api.post(f'/users/{user_id}/roles/{role_id}', BASE_URL)
+    assert add_role.status_code == 404
+    get_user = api.get(f'/users/{user_id}', BASE_URL)
+    user = get_user.json
+    roles_on_user = json.loads(user['roles']).keys()
+    assert role_id not in roles_on_user
+
+def test_remove_role_from_user(api, user_id, new_role):
+    role_id = new_role()
+    add_role = api.post(f'/users/{user_id}/roles/{role_id}', BASE_URL)
+    assert add_role.status_code == 204
+    remove_role = api.delete(f'/users/{user_id}/roles/{role_id}', BASE_URL)
+    assert remove_role.status_code == 204
+    get_user = api.get(f'/users/{user_id}', BASE_URL)
+    user = get_user.json
+    roles_on_user = json.loads(user['roles']).keys()
+    assert role_id not in roles_on_user
+
+
+def test_remove_role_from_user_user_dne(api, missing_id, new_role):
+    role_id = new_role()
+    add_role = api.post(f'/users/{missing_id}/roles/{role_id}', BASE_URL)
+    assert add_role.status_code == 404
+
+
+def test_remove_role_from_user_role_dne(api, user_id, missing_id):
+    # test that no change is made, even though 204 is returned.
+    get_user = api.get(f'/users/{user_id}', BASE_URL)
+    user = get_user.json
+    roles_on_user = json.loads(user['roles']).keys()
+
+    add_role = api.delete(f'/users/{user_id}/roles/{missing_id}', BASE_URL)
+    assert add_role.status_code == 204
+
+    get_user = api.get(f'/users/{user_id}', BASE_URL)
+    user = get_user.json
+    new_roles_on_user = json.loads(user['roles']).keys()
+    assert roles_on_user == new_roles_on_user
+
+def test_remove_role_from_user_no_perms(api, user_id, new_role, remove_perms):
+    role_id = new_role()
+    add_role = api.post(f'/users/{user_id}/roles/{role_id}', BASE_URL)
+    assert add_role.status_code == 204
+    remove_perms('update', 'users')
+    remove_role = api.delete(f'/users/{user_id}/roles/{role_id}', BASE_URL)
+    assert remove_role.status_code == 404

--- a/sfa_api/users.py
+++ b/sfa_api/users.py
@@ -99,8 +99,73 @@ class UserView(MethodView):
         pass
 
 
+class UserRolesView(MethodView):
+    def get(self, user_id):
+        """
+        ---
+        summary: List Roles of User.
+        tags:
+          - Users
+          - Roles
+        responses:
+          200:
+            description: List of User's roles retrieved successfully.
+          404:
+            $ref: '#/components/responses/404-NotFound'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+        """
+        # PROCEDURE: list_roles
+        pass
+
+
+class UserRolesManagementView(MethodView):
+    def post(self, user_id, role_id):
+        """
+        ---
+        summary: Add a Role to a User.
+        tags:
+          - Users
+          - Roles
+        responses:
+          200:
+            description: Role Added Successfully.
+          404:
+            $ref: '#/components/responses/404-NotFound'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+        """
+        # PROCEDURE: add_role_to_user
+        pass
+
+    def delete(self, user_id, role_id):
+        """
+        ---
+        summary: Remove a role from a User.
+        tags:
+          - Users
+          - Roles
+        responses:
+          200:
+            description: Role removed successfully..
+          404:
+            $ref: '#/components/responses/404-NotFound'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+        """
+        # PROCEDURE: remove_role_from_user
+        pass
+
+
 user_blp = Blueprint(
     'users', 'users', url_prefix='/users',
 )
 user_blp.add_url_rule('/', view_func=AllUsersView.as_view('all'))
 user_blp.add_url_rule('/<user_id>', view_func=UserView.as_view('single'))
+user_blp.add_url_rule(
+    '/<user_id>/roles/',
+    view_func=UserRolesView.as_view('user_roles'))
+user_blp.add_url_rule(
+    '/<user_id>/roles/<role_id>',
+    view_func=UserRolesManagementView.as_view('user_roles_management')
+)

--- a/sfa_api/users.py
+++ b/sfa_api/users.py
@@ -1,5 +1,10 @@
+import pdb
 from flask import Blueprint
 from flask.views import MethodView
+
+
+from sfa_api import spec
+from sfa_api.utils.storage import get_storage
 
 
 class AllUsersView(MethodView):
@@ -24,8 +29,11 @@ class AllUsersView(MethodView):
           401:
             $ref: '#/components/responses/401-Unauthorized'
         """
+        storage = get_storage()
+        users = storage.list_users()
+        pdb.set_trace()
         # PROCEDURE: list_users
-        pass
+        return users
 
     def post(self):
         """

--- a/sfa_api/users.py
+++ b/sfa_api/users.py
@@ -1,10 +1,7 @@
-import pdb
+"""Currently just method stubs.
+"""
 from flask import Blueprint
 from flask.views import MethodView
-
-
-from sfa_api import spec
-from sfa_api.utils.storage import get_storage
 
 
 class AllUsersView(MethodView):
@@ -29,11 +26,7 @@ class AllUsersView(MethodView):
           401:
             $ref: '#/components/responses/401-Unauthorized'
         """
-        storage = get_storage()
-        users = storage.list_users()
-        pdb.set_trace()
-        # PROCEDURE: list_users
-        return users
+        pass
 
     def post(self):
         """

--- a/sfa_api/users.py
+++ b/sfa_api/users.py
@@ -26,7 +26,9 @@ class AllUsersView(MethodView):
           401:
             $ref: '#/components/responses/401-Unauthorized'
         """
-        pass
+        storage = get_storage()
+        users = storage.list_users()
+        return jsonify(UserSchema(many=True).load(users))
 
     def post(self):
         """
@@ -79,8 +81,9 @@ class UserView(MethodView):
           401:
             $ref: '#/components/responses/401-Unauthorized'
         """
-        # PROCEDURE: read_user
-        pass
+        storage = get_storage()
+        user = storage.read_user(user_id)
+        return jsonify(UserSchema().load(user))
 
     def delete(self, user_id):
         """
@@ -100,26 +103,6 @@ class UserView(MethodView):
         pass
 
 
-class UserRolesView(MethodView):
-    def get(self, user_id):
-        """
-        ---
-        summary: List Roles of User.
-        tags:
-          - Users
-          - Roles
-        responses:
-          200:
-            description: List of User's roles retrieved successfully.
-          404:
-            $ref: '#/components/responses/404-NotFound'
-          401:
-            $ref: '#/components/responses/401-Unauthorized'
-        """
-        # PROCEDURE: list_roles
-        pass
-
-
 class UserRolesManagementView(MethodView):
     def post(self, user_id, role_id):
         """
@@ -136,8 +119,9 @@ class UserRolesManagementView(MethodView):
           401:
             $ref: '#/components/responses/401-Unauthorized'
         """
-        # PROCEDURE: add_role_to_user
-        pass
+        storage = get_storage()
+        storage.add_role_to_user(user_id, role_id)
+        return '', 204
 
     def delete(self, user_id, role_id):
         """
@@ -154,8 +138,9 @@ class UserRolesManagementView(MethodView):
           401:
             $ref: '#/components/responses/401-Unauthorized'
         """
-        # PROCEDURE: remove_role_from_user
-        pass
+        storage = get_storage()
+        storage.remove_role_from_user(user_id, role_id)
+        return '', 204
 
 
 user_blp = Blueprint(
@@ -163,9 +148,6 @@ user_blp = Blueprint(
 )
 user_blp.add_url_rule('/', view_func=AllUsersView.as_view('all'))
 user_blp.add_url_rule('/<user_id>', view_func=UserView.as_view('single'))
-user_blp.add_url_rule(
-    '/<user_id>/roles/',
-    view_func=UserRolesView.as_view('user_roles'))
 user_blp.add_url_rule(
     '/<user_id>/roles/<role_id>',
     view_func=UserRolesManagementView.as_view('user_roles_management')

--- a/sfa_api/users.py
+++ b/sfa_api/users.py
@@ -1,0 +1,106 @@
+from flask import Blueprint
+from flask.views import MethodView
+
+
+class AllUsersView(MethodView):
+    def get(self):
+        """
+        ---
+        summary: List Users.
+        description: List all Users that current User has access to.
+        tags:
+          - Users
+        responses:
+          200:
+            description: A list of Users
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/UserSchema'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+        """
+        # PROCEDURE: list_users
+        pass
+
+    def post(self):
+        """
+        ---
+        summary: Create a new User
+        description: >-
+          Create a new User by posting metadata containing an auth0_id and
+          organization_id.
+        tags:
+          - Users
+        requestBody:
+          description: JSON containing fields to create new user.
+          required: True
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserPostSchema'
+        responses:
+          201:
+            description: Created the User successfully
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UserSchema'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+        """
+        # PROCEDURE: create_user
+        pass
+
+
+class UserView(MethodView):
+    def get(self, user_id):
+        """
+        ---
+        summary: Get User Metadata.
+        tags:
+          - Users
+        responses:
+          200:
+            description: User successully retrieved.
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UserSchema'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+        """
+        # PROCEDURE: read_user
+        pass
+
+    def delete(self, user_id):
+        """
+        ---
+        summary: Delete a User.
+        tags:
+          - Users
+        responses:
+          204:
+            description: User Deleted successfully.
+          404:
+            $ref: '#/components/responses/404-NotFound'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+        """
+        # PROCEDURE: no remove_user procedure
+        pass
+
+
+user_blp = Blueprint(
+    'users', 'users', url_prefix='/users',
+)
+user_blp.add_url_rule('/', view_func=AllUsersView.as_view('all'))
+user_blp.add_url_rule('/<user_id>', view_func=UserView.as_view('single'))

--- a/sfa_api/users.py
+++ b/sfa_api/users.py
@@ -1,7 +1,10 @@
 """Currently just method stubs.
 """
-from flask import Blueprint
+from flask import Blueprint, jsonify
 from flask.views import MethodView
+
+from sfa_api.schema import UserSchema
+from sfa_api.utils.storage import get_storage
 
 
 class AllUsersView(MethodView):
@@ -28,7 +31,7 @@ class AllUsersView(MethodView):
         """
         storage = get_storage()
         users = storage.list_users()
-        return jsonify(UserSchema(many=True).load(users))
+        return jsonify(UserSchema(many=True).dump(users))
 
     def post(self):
         """
@@ -83,7 +86,7 @@ class UserView(MethodView):
         """
         storage = get_storage()
         user = storage.read_user(user_id)
-        return jsonify(UserSchema().load(user))
+        return jsonify(UserSchema().dump(user))
 
     def delete(self, user_id):
         """

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -786,3 +786,14 @@ def list_cdf_forecast_groups(site_id=None):
                  for fx in _call_procedure('list_cdf_forecasts_groups')
                  if site_id is None or fx['site_id'] == site_id]
     return forecasts
+
+
+def list_users():
+    """List all users that calling user has access to.
+
+    Returns
+    -------
+        List of dictionaries of user information.
+    """
+    users = _call_procedure('list_users')
+    return users

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -798,6 +798,7 @@ def list_users():
     users = _call_procedure('list_users')
     return users
 
+
 def read_user(user_id):
     """Read user information.
 
@@ -1083,6 +1084,7 @@ def add_object_to_permission(permission_id, uuid):
     _call_procedure('add_object_to_permission',
                     permission_id, uuid)
 
+
 def remove_object_from_permission(permission_id, uuid):
     """
     Parameters
@@ -1100,6 +1102,6 @@ def remove_object_from_permission(permission_id, uuid):
           both permission and object.
         - If the user does not have permission to update
           the permission.
-    """   
+    """
     _call_procedure('remove_object_from_permission',
                     uuid, permission_id)

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -797,3 +797,202 @@ def list_users():
     """
     users = _call_procedure('list_users')
     return users
+
+
+def list_roles():
+    """List all roles a user has access to.
+
+    Returns
+    -------
+    list
+        List of dictionaries of Role information.
+    """
+    roles = _call_procedure('list_roles')
+    return roles
+
+
+def store_role(role):
+    """Create a new role.
+
+    Parameters
+    ----------
+    role : dict
+        A Dictionary containing the role's name and description.
+
+    Returns
+    -------
+    string
+        The UUID of the new Role.
+
+    Raises
+    ------
+    StorageAuthError
+        If the user does not have permission to create roles.
+    """
+    role_id = generate_uuid()
+    name = role['name']
+    description = role['description']
+    role = _call_procedure('create_role', role_id, name, description)
+    return role_id
+
+
+def read_role(role_id):
+    """
+    Parameters
+    ----------
+    role_id : str
+        The UUID of the role to read.
+
+    Returns
+    -------
+    dict
+        Dictionary of role information.
+    Raises
+    ------
+    StorageAuthError
+        If the user does not have permission to read the role or
+        the role does not exist.
+    """
+    role = _call_procedure('read_role', role_id)[0]
+    return role
+
+
+def delete_role(role_id):
+    """
+    Parameters
+    ----------
+    role_id : str
+        The UUID of the role to delete.
+
+    Raises
+    ------
+    StorageAuthError
+        If the user does not have permission to delete the role or
+        the role does not exist.
+
+    """
+    _call_procedure('delete_role', role_id)
+
+
+def add_permission_to_role(role_id, permission_id):
+    """
+    Parameters
+    ----------
+    role_id : str
+        The UUID of the Role to add a permission to.
+    permission_id : str
+        The UUID of the permission to add.
+
+    Raises
+    ------
+    StorageAuthError
+        If the user does not have permission to update the role or
+        the role does not exist.
+    """
+    _call_procedure('add_permission_to_role', role_id, permission_id)
+
+
+def remove_permission_from_role(role_id, permission_id):
+    """
+    Parameters
+    ----------
+    role_id : str
+        The UUID of the Role to remove a permission from.
+    permission_id : str
+        The UUID of the permission to remove.
+
+    Raises
+    ------
+    StorageAuthError
+        If the user does not have permission to alter the role or
+        the role does not exist.
+    """
+    _call_procedure('remove_permission_from_role', role_id, permission_id)
+
+
+def read_permission(permission_id):
+    """
+    Parameters
+    ----------
+    permission_id : str
+        The UUID of the Permission to read.
+
+    Returns
+    -------
+    dict
+        Dict of permission information.
+
+    Raises
+    ------
+    StorageAuthError
+        If the user does not have permission to read the permission
+        or the permission does not exist.
+
+    """
+    permission = _call_procedure('read_permission', permission_id)[0]
+    return permission
+
+
+def delete_permission(permission_id):
+    """
+    Parameters
+    ----------
+    permission_id : str
+        The UUID of the Permission to delete.
+
+    Raises
+    ------
+    StorageAuthError
+        If the user does not have permission to delete the permission,
+        or the permission does not exist.
+    """
+    _call_procedure('delete_permission', permission_id)
+
+
+def list_permissions():
+    """List all permissions readable by the user.
+
+    Returns
+    -------
+    list of dicts
+        A list of dicts of Permissions information
+
+    Raises
+    ------
+    StorageAuthError
+        If the User does not have permission to list permissions.
+        
+    """
+    permissions = _call_procedure('list_permissions')
+    return permissions
+
+
+def store_permission(permission):
+    """Create a new permission.
+    
+    Parameters
+    ----------
+    permission : dict
+        Dictionary of permission data.
+
+    Returns
+    -------
+    str
+        UUID of the newly created permission.
+
+    Raises
+    ------
+    StorageAuthError
+        If the user does not have permission to create new
+        permissions.
+    """
+    uuid = generate_uuid()
+    _call_procedure(
+        'create_permission',
+        uuid,
+        permission['description'],
+        permission['action'],
+        permission['object_type'],
+        permission['applies_to_all']
+    )
+    return uuid

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -961,7 +961,6 @@ def list_permissions():
     ------
     StorageAuthError
         If the User does not have permission to list permissions.
-        
     """
     permissions = _call_procedure('list_permissions')
     return permissions
@@ -969,7 +968,7 @@ def list_permissions():
 
 def store_permission(permission):
     """Create a new permission.
-    
+
     Parameters
     ----------
     permission : dict

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -796,6 +796,8 @@ def list_users():
         List of dictionaries of user information.
     """
     users = _call_procedure('list_users')
+    for user in users:
+        user['roles'] = json.loads(user['roles'])
     return users
 
 
@@ -870,6 +872,8 @@ def list_roles():
         List of dictionaries of Role information.
     """
     roles = _call_procedure('list_roles')
+    for role in roles:
+        role['permissions'] = json.loads(role['permissions'])
     return roles
 
 
@@ -1032,6 +1036,8 @@ def list_permissions():
         If the User does not have permission to list permissions.
     """
     permissions = _call_procedure('list_permissions')
+    for permission in permissions:
+        permission['objects'] = json.loads(permission['objects'])
     return permissions
 
 

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -813,6 +813,7 @@ def read_user(user_id):
         Dictionary of user information.
     """
     user = _call_procedure('read_user', user_id)[0]
+    user['roles'] = json.loads(user['roles'])
     return user
 
 
@@ -916,6 +917,7 @@ def read_role(role_id):
         the role does not exist.
     """
     role = _call_procedure('read_role', role_id)[0]
+    role['permissions'] = json.loads(role['permissions'])
     return role
 
 
@@ -996,6 +998,7 @@ def read_permission(permission_id):
 
     """
     permission = _call_procedure('read_permission', permission_id)[0]
+    permission['objects'] = json.loads(permission['objects'])
     return permission
 
 

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -798,6 +798,66 @@ def list_users():
     users = _call_procedure('list_users')
     return users
 
+def read_user(user_id):
+    """Read user information.
+
+    Parameters
+    ----------
+    user_id : str
+        The UUID of the user to read.
+
+    Returns
+    -------
+    user : dict
+        Dictionary of user information.
+    """
+    user = _call_procedure('read_user', user_id)[0]
+    return user
+
+
+def remove_role_from_user(user_id, role_id):
+    """
+    Parameters
+    ----------
+    user_id : str
+        UUID of the user to remove role from.
+    role_id : str
+        UUID of role to remove from user
+
+    Raises
+    ------
+    StorageAuthError
+        - If the user or role does not exist
+        - If the calling user does not have
+          permissions to read role and user.
+        - If the calling user does not have
+          permission to update the user.
+    """
+    _call_procedure('remove_role_from_user',
+                    role_id, user_id)
+
+
+def add_role_to_user(user_id, role_id):
+    """
+    Parameters
+    ----------
+    user_id : str
+        UUID of the user to remove role from.
+    role_id : str
+        UUID of role to remove from user
+
+    Raises
+    ------
+    StorageAuthError
+        - If the user or role does not exist
+        - If the calling user does not have
+          permissions to read role and user.
+        - If the calling user does not have
+          permission to update the user.
+    """
+    _call_procedure('add_role_to_user',
+                    user_id, role_id)
+
 
 def list_roles():
     """List all roles a user has access to.
@@ -837,7 +897,8 @@ def store_role(role):
 
 
 def read_role(role_id):
-    """
+    """Read role information.
+
     Parameters
     ----------
     role_id : str
@@ -886,8 +947,10 @@ def add_permission_to_role(role_id, permission_id):
     Raises
     ------
     StorageAuthError
-        If the user does not have permission to update the role or
-        the role does not exist.
+        - If the user does not have permission to update the role.
+        - If the role or permission does not exist.
+        - If the iser does not have permission to read the role and
+          permission.
     """
     _call_procedure('add_permission_to_role', role_id, permission_id)
 
@@ -904,10 +967,12 @@ def remove_permission_from_role(role_id, permission_id):
     Raises
     ------
     StorageAuthError
-        If the user does not have permission to alter the role or
-        the role does not exist.
+        - If the user does not have permission to update the role.
+        - If the role or permission does not exist.
+        - If the iser does not have permission to read the role and
+          permission.
     """
-    _call_procedure('remove_permission_from_role', role_id, permission_id)
+    _call_procedure('remove_permission_from_role', permission_id, role_id)
 
 
 def read_permission(permission_id):
@@ -995,3 +1060,46 @@ def store_permission(permission):
         permission['applies_to_all']
     )
     return uuid
+
+
+def add_object_to_permission(permission_id, uuid):
+    """
+    Parameters
+    ----------
+    permission_id: str
+        The UUID of the permission to add the object to.
+    uuid: str
+        UUID of the object to add.
+
+    Raises
+    ------
+    StorageAuthError
+        - If the object or permission does not exist.
+        - If user does not have permissions to read
+          both permission and object.
+        - If the user does not have permission to update
+          the permission.
+    """
+    _call_procedure('add_object_to_permission',
+                    permission_id, uuid)
+
+def remove_object_from_permission(permission_id, uuid):
+    """
+    Parameters
+    ----------
+    permission_id: str
+        The UUID of the permission to remove the object from.
+    uuid: str
+        UUID of the object to remove.
+
+    Raises
+    ------
+    StorageAuthError
+        - If the object or permission does not exist.
+        - If user does not have permissions to read
+          both permission and object.
+        - If the user does not have permission to update
+          the permission.
+    """   
+    _call_procedure('remove_object_from_permission',
+                    uuid, permission_id)


### PR DESCRIPTION
Adds User, Role and Permissions endpoints to the API. User creation/deletion endpoints are just method stubs and documentation at the moment to get feedback on the layout of the endpoints, I noted the procedures that each endpoint would end up calling.
I added the User->Role mapping functions to Users, but tagged them with both 'Users' and 'Roles'  so that they can be found in both sections of the documentation, this could be repeated for the Roles -> Permissions mappings.

A couple of things I noted while working on this:
- There is no `delete_user` procedure, should that exist or is that going to be something we defer to auth0?
- Should auth0_id be treated as a secret, and the internal SolarForecastArbiter UUID used to identify users? other way around? neither? 