### PR TITLE
Sentry issues

### DIFF
--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -128,7 +128,7 @@ REPORT_POST_JSON = {
     'report_parameters': {
         'start': '2019-04-01T07:00:00Z',
         'end': '2019-06-01T06:59:00Z',
-        'metrics': ['MAE', 'RMSE'],
+        'metrics': ['mae', 'rmse'],
         'filters': [],
         'object_pairs': [('123e4567-e89b-12d3-a456-426655440000',
                           '11c20780-76ae-4b11-bef1-7a75bdc784e3')],

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -11,6 +11,7 @@ from solarforecastarbiter.datamodel import ALLOWED_VARIABLES
 # variable: units we just want the variable names here
 VARIABLES = ALLOWED_VARIABLES.keys()
 
+ALLOWED_METRICS = ['mae', 'mbe', 'rmse']
 INTERVAL_LABELS = ['beginning', 'ending', 'instant']
 
 INTERVAL_VALUE_TYPES = ['interval_mean', 'interval_max', 'interval_min',
@@ -654,8 +655,7 @@ class ReportParameters(ma.Schema):
     )
     metrics = ma.List(
         ma.String(
-            validate=lambda x: x.upper() in ['MAE', 'MBE', 'RMSE']
-            # TODO: return informative error and use params from core
+            validate=validate.OneOf(ALLOWED_METRICS)
         ),
         title='Metrics',
         description=('The metrics to include in the report.'),

--- a/sfa_api/tests/test_reports.py
+++ b/sfa_api/tests/test_reports.py
@@ -178,7 +178,7 @@ def test_list_reports(api, new_report):
     ('filters', 'not a list',
      '["Not a valid list."]'),
     ('metrics', ["bad"],
-     '{"0":["Invalid value."]}'),
+        '{"0":["Must be one of: mae, mbe, rmse."]}'),
 ])
 def test_post_report_invalid_report_params(
         api, key, value, error, report_json):

--- a/sfa_api/utils/request_handling.py
+++ b/sfa_api/utils/request_handling.py
@@ -228,6 +228,28 @@ def validate_parsable_values():
     return value_df
 
 
+def parse_to_timestamp(dt_string):
+    """Attempts to parse to Timestamp.
+
+    Parameters
+    ----------
+    dt_string: str
+
+    Returns
+    -------
+    pandas.Timestamp
+
+    Raises
+    ------
+    ValueError
+        If the string cannot be parsed to timestamp, or parses to null
+    """
+    timestamp = pd.Timestamp(dt_string)
+    if pd.isnull(timestamp):
+        raise ValueError
+    return timestamp
+
+
 def validate_start_end():
     """Parses start and end query parameters into pandas
     Timestamps.
@@ -247,12 +269,12 @@ def validate_start_end():
     end = request.args.get('end', None)
     if start is not None:
         try:
-            start = pd.Timestamp(start)
+            start = parse_to_timestamp(start)
         except ValueError:
             errors.update({'start': ['Invalid start date format']})
     if end is not None:
         try:
-            end = pd.Timestamp(end)
+            end = parse_to_timestamp(end)
         except ValueError:
             errors.update({'end': ['Invalid end date format']})
     if errors:

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -147,6 +147,17 @@ def _call_procedure(procedure_name, *args, cursor_type='dict'):
         return cursor.fetchall()
 
 
+def _call_procedure_for_single(procedure_name, *args, cursor_type='dict'):
+    """Wrapper handling try/except logic when a single value is expected
+    """
+    try:
+        result = _call_procedure(procedure_name, *args, cursor_type='dict')[0]
+    except IndexError:
+        raise StorageAuthError()
+    return result
+
+
+
 def _set_modeling_parameters(site_dict):
     out = {}
     modeling_parameters = {}
@@ -283,7 +294,7 @@ def read_observation(observation_id):
         does not exist.
     """
     observation = _set_observation_parameters(
-        _call_procedure('read_observation', observation_id)[0])
+        _call_procedure_for_single('read_observation', observation_id))
     return observation
 
 
@@ -442,7 +453,7 @@ def read_forecast(forecast_id):
         does not exist.
     """
     forecast = _set_forecast_parameters(
-        _call_procedure('read_forecast', forecast_id)[0])
+        _call_procedure_for_single('read_forecast', forecast_id))
     return forecast
 
 
@@ -503,7 +514,7 @@ def read_site(site_id):
         If the user does not have access to the site_id or it doesn't exist
     """
     site = _set_modeling_parameters(
-        _call_procedure('read_site', site_id)[0])
+        _call_procedure_for_single('read_site', site_id))
     return site
 
 
@@ -668,7 +679,7 @@ def read_cdf_forecast(forecast_id):
         does not exist.
     """
     forecast = _set_cdf_forecast_parameters(
-        _call_procedure('read_cdf_forecasts_single', forecast_id)[0])
+        _call_procedure_for_single('read_cdf_forecasts_single', forecast_id))
     return forecast
 
 
@@ -780,7 +791,7 @@ def read_cdf_forecast_group(forecast_id):
         does not exist.
     """
     forecast = _set_cdf_group_forecast_parameters(
-        _call_procedure('read_cdf_forecasts_group', forecast_id)[0])
+        _call_procedure_for_single('read_cdf_forecasts_group', forecast_id))
     return forecast
 
 
@@ -849,7 +860,7 @@ def read_user(user_id):
     user : dict
         Dictionary of user information.
     """
-    user = _call_procedure('read_user', user_id)[0]
+    user = _call_procedure_for_single('read_user', user_id)
     user['roles'] = json.loads(user['roles'])
     return user
 
@@ -955,7 +966,7 @@ def read_role(role_id):
         If the user does not have permission to read the role or
         the role does not exist.
     """
-    role = _call_procedure('read_role', role_id)[0]
+    role = _call_procedure_for_single('read_role', role_id)
     role['permissions'] = json.loads(role['permissions'])
     return role
 
@@ -1036,7 +1047,7 @@ def read_permission(permission_id):
         or the permission does not exist.
 
     """
-    permission = _call_procedure('read_permission', permission_id)[0]
+    permission = _call_procedure_for_single('read_permission', permission_id)
     permission['objects'] = json.loads(permission['objects'])
     return permission
 
@@ -1224,7 +1235,7 @@ def read_report(report_id):
         permission to read the report.
     """
     report = _decode_report_parameters(
-        _call_procedure('read_report', report_id)[0])
+        _call_procedure_for_single('read_report', report_id))
     report_values = read_report_values(report_id)
     report['values'] = report_values
     return report

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -157,7 +157,6 @@ def _call_procedure_for_single(procedure_name, *args, cursor_type='dict'):
     return result
 
 
-
 def _set_modeling_parameters(site_dict):
     out = {}
     modeling_parameters = {}

--- a/sfa_api/utils/tests/test_request_handling.py
+++ b/sfa_api/utils/tests/test_request_handling.py
@@ -8,7 +8,8 @@ from sfa_api.utils.errors import BadAPIRequest
 
 
 @pytest.mark.parametrize('start,end', [
-    ('invalid', 'invalid')
+    ('invalid', 'invalid'),
+    ('NaT', 'NaT')
 ])
 def test_validate_start_end_fail(app, forecast_id, start, end):
     url = f'/forecasts/single/{forecast_id}/values?start={start}&end={end}'

--- a/sfa_api/utils/tests/test_request_handling.py
+++ b/sfa_api/utils/tests/test_request_handling.py
@@ -176,3 +176,24 @@ def test_parse_values_success(data, mimetype):
 def test_parse_values_failure(data, mimetype):
     with pytest.raises(request_handling.BadAPIRequest):
         request_handling.parse_values(data, mimetype)
+
+
+@pytest.mark.parametrize('dt_string,expected', [
+    ('20190101T1200Z', pd.Timestamp('20190101T1200Z')),
+    ('20190101T1200', pd.Timestamp('20190101T1200')),
+    ('20190101T1200+0700', pd.Timestamp('20190101T0500Z'))
+])
+def test_parse_to_timestamp(dt_string, expected):
+    parsed_dt = request_handling.parse_to_timestamp(dt_string)
+    assert parsed_dt == expected
+
+
+@pytest.mark.parametrize('dt_string', [
+    'invalid datetime',
+    '21454543251345234',
+    '20190101T2500Z',
+    'NaT',
+])
+def test_parse_to_timestamp_error(dt_string):
+    with pytest.raises(ValueError):
+        request_handling.parse_to_timestamp(dt_string)

--- a/sfa_api/utils/tests/test_storage_interface.py
+++ b/sfa_api/utils/tests/test_storage_interface.py
@@ -752,3 +752,9 @@ def test_store_missing_values(
     storage_interface.store_observation_values(new_id, obs_vals)
     stored = storage_interface.read_observation_values(new_id)
     pdt.assert_frame_equal(stored, obs_vals)
+
+
+@pytest.mark.parametrize('forecast_id', demo_forecasts.keys())
+def test_read_wrong_type(sql_app, user, forecast_id):
+    with pytest.raises(storage_interface.StorageAuthError):
+        observation = storage_interface.read_observation(forecast_id)

--- a/sfa_api/utils/tests/test_storage_interface.py
+++ b/sfa_api/utils/tests/test_storage_interface.py
@@ -757,4 +757,4 @@ def test_store_missing_values(
 @pytest.mark.parametrize('forecast_id', demo_forecasts.keys())
 def test_read_wrong_type(sql_app, user, forecast_id):
     with pytest.raises(storage_interface.StorageAuthError):
-        observation = storage_interface.read_observation(forecast_id)
+        storage_interface.read_observation(forecast_id)


### PR DESCRIPTION
Aims to Close a handful of issues found with Sentry. The tests will not pass until the changes in #130 are merged due to the issue with pandas 0.25.0

- Adds validation handling for 'NaT' as a query parameter. 
- Handles the empty list returned when a user has permission to read a uuid of one type, but tries to access it from another endpoint.
- Enforces lowercase metrics for compatibility with core.