### PR TITLE
Admin cli

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,5 +57,6 @@ setup(
     entry_points='''
     [console_scripts]
     sfa-api=sfa_api.cli:cli
+    sfa-admin=sfa_api.admincli:admin_cli
     '''
 )

--- a/sfa_api/admincli.py
+++ b/sfa_api/admincli.py
@@ -22,6 +22,9 @@ def create_organization(organization_name):
     try:
         storage._call_procedure_without_user(
             'create_organization', organization_name)
+    except pymysql.err.DataError as e:
+        click.echo(e.args[1])
+        return
     except pymysql.err.IntegrityError as e:
         if e.args[0] == 1062:
             click.echo(f'Organization {organization_name} alread exists.')

--- a/sfa_api/admincli.py
+++ b/sfa_api/admincli.py
@@ -67,7 +67,7 @@ def add_user_to_org(user_id, organization_id):
         if e.args[0] == 1452:
             click.echo('Organization does not exist')
         else:
-            click.echo(e.args[1])
+            raise
     except StorageAuthError as e:
         click.echo(e.args[0])
     else:
@@ -101,7 +101,6 @@ def promote_to_admin(user_id, organization_id):
         if e.args[0] == 1062:
             click.echo('User already granted admin permissions.')
         else:
-            click.echo(e.args[1])
             raise
     except StorageAuthError as e:
         click.echo(e.args[0])

--- a/sfa_api/admincli.py
+++ b/sfa_api/admincli.py
@@ -1,4 +1,5 @@
 import uuid
+import os
 
 
 import click
@@ -9,8 +10,8 @@ import pymysql
 from sfa_api import create_app
 from sfa_api.utils.errors import StorageAuthError
 
-
-app = create_app('AdminTestConfig')
+config = os.getenv('SFA_CLI_CONFIG', 'ProductionConfig')
+app = create_app(config)
 admin_cli = AppGroup('admin')
 
 

--- a/sfa_api/admincli.py
+++ b/sfa_api/admincli.py
@@ -85,7 +85,7 @@ def promote_to_admin(user_id, organization_id):
         click.echo(e.args[0])
 
 
-@admin_cli.command('delete-user')
+@admin_cli.command('move-to-unaffiliated')
 @click.argument('user_id', required=True)
 def move_user_to_unaffiliated(user_id):
     try:
@@ -96,7 +96,7 @@ def move_user_to_unaffiliated(user_id):
     from sfa_api.utils.storage import get_storage
     storage = get_storage()
     storage._call_procedure_without_user(
-        'delete_user', user_id)
+        'move_user_to_unaffiliated', user_id)
 
 
 @admin_cli.command('list-users')

--- a/sfa_api/admincli.py
+++ b/sfa_api/admincli.py
@@ -180,10 +180,38 @@ def set_org_accepted_tou(organization_id):
         storage._call_procedure_without_user(
             'set_org_accepted_tou', (organization_id,))
     except pymysql.err.InternalError as e:
-        click.echo(e.args[1])
+        if e.args[0] == 1305:
+            click.echo(e.args[1])
+        else:
+            raise
     else:
         click.echo(f'Organization {organization_id} has been marked '
                    'as accepting the terms of use.')
+
+
+@admin_cli.command('delete-user')
+@click.argument('user_id', required=True)
+def delete_user(user_id):
+    """
+    Remove a user from the framework.
+    """
+    try:
+        uuid.UUID(user_id, version=1)
+    except ValueError:
+        click.echo('Badly formed user_id')
+        return
+    from sfa_api.utils.storage import get_storage
+    storage = get_storage()
+    try:
+        storage._call_procedure_without_user(
+            'delete_user', user_id)
+    except pymysql.err.InternalError as e:
+        if e.args[0] == 1305:
+            click.echo(e.args[1])
+        else:
+            raise
+    else:
+        click.echo(f'User {user_id} deleted successfully.')
 
 
 app.cli.add_command(admin_cli)

--- a/sfa_api/admincli.py
+++ b/sfa_api/admincli.py
@@ -1,0 +1,98 @@
+import uuid
+
+
+import click
+from flask.cli import AppGroup
+import pymysql
+
+
+from sfa_api import create_app
+from sfa_api.utils.errors import StorageAuthError
+
+
+app = create_app('AdminTestConfig')
+admin_cli = AppGroup('admin')
+
+
+@admin_cli.command('create-organization')
+@click.argument('organization_name', required=True)
+def create_organization(organization_name):
+    from sfa_api.utils.storage import get_storage
+    storage = get_storage()
+    try:
+        storage._call_procedure_without_user(
+            'create_organization', organization_name)
+    except pymysql.err.IntegrityError as e:
+        if e.args[0] == 1062:
+            click.echo(f'Organization {organization_name} alread exists.')
+        else:
+            raise
+    else:
+        click.echo(f'Created organization {organization_name}.')
+
+
+@admin_cli.command('add-user-to-org')
+@click.argument('user_id', required=True)
+@click.argument('organization_id', required=True)
+def add_user_to_org(user_id, organization_id):
+    try:
+        uuid.UUID(user_id, version=1)
+    except ValueError:
+        click.echo('Badly formed user_id')
+        return
+    try:
+        uuid.UUID(organization_id, version=1)
+    except ValueError:
+        click.echo('Badly formed organization_id')
+        return
+    from sfa_api.utils.storage import get_storage
+    storage = get_storage()
+
+    try:
+        storage._call_procedure_without_user(
+            'add_user_to_org', user_id, organization_id)
+    except pymysql.err.IntegrityError as e:
+        click.echo(e.args[1])
+    except StorageAuthError as e:
+        click.echo(e.args[0])
+
+
+@admin_cli.command('promote-user-to-org-admin')
+@click.argument('user_id', required=True)
+@click.argument('organization_id', required=True)
+def promote_to_admin(user_id, organization_id):
+    try:
+        uuid.UUID(user_id, version=1)
+    except ValueError:
+        click.echo('Badly formed user_id')
+        return
+    try:
+        uuid.UUID(organization_id, version=1)
+    except ValueError:
+        click.echo('Badly formed organization_id')
+        return
+    from sfa_api.utils.storage import get_storage
+    storage = get_storage()
+    try:
+        storage._call_procedure_without_user(
+            'promote_user_to_org_admin',
+            user_id, organization_id)
+    except Exception as e:
+        click.echo(e.args[0])
+
+
+@admin_cli.command('delete-user')
+@click.argument('user_id', required=True)
+def move_user_to_unaffiliated(user_id):
+    try:
+        uuid.UUID(user_id, version=1)
+    except ValueError:
+        click.echo('Badly formed user_id')
+        return
+    from sfa_api.utils.storage import get_storage
+    storage = get_storage()
+    storage._call_procedure_without_user(
+        'delete_user', user_id)
+
+
+app.cli.add_command(admin_cli)

--- a/sfa_api/admincli.py
+++ b/sfa_api/admincli.py
@@ -98,4 +98,33 @@ def move_user_to_unaffiliated(user_id):
         'delete_user', user_id)
 
 
+@admin_cli.command('list-users')
+def list_users():
+    from sfa_api.utils.storage import get_storage
+    storage = get_storage()
+    users = storage._call_procedure_without_user('list_all_users')
+    table_format = '{:<34}|{:<38}|{:<34}|{:<38}'
+    headers = table_format.format(
+            'auth0_id', 'User ID', 'Organization Name', 'Organization ID')
+    click.echo(headers)
+    click.echo('-'*len(headers))
+    for user in users:
+        click.echo(table_format.format(
+            user['auth0_id'], user['id'], user['organization_name'],
+            user['organization_id']))
+
+
+@admin_cli.command('list-organizations')
+def list_organizations():
+    from sfa_api.utils.storage import get_storage
+    storage = get_storage()
+    organizations = storage._call_procedure_without_user('list_all_organizations')
+    table_format = '{:<34}|{:<38}'
+    headers = table_format.format('Name', 'Organization ID')
+    click.echo(headers)
+    click.echo('-'*len(headers))
+    for org in organizations:
+        click.echo(table_format.format(org['name'], org["id"]))
+
+
 app.cli.add_command(admin_cli)

--- a/sfa_api/config.py
+++ b/sfa_api/config.py
@@ -40,3 +40,8 @@ class TestingConfig(Config):
     MYSQL_PASSWORD = 'thisisaterribleandpublicpassword'
     MYSQL_DATABASE = 'arbiter_data'
     USE_FAKE_REDIS = True
+
+class AdminTestConfig(Config):
+    MYSQL_USER = 'frameworkadmin'
+    MYSQL_PASSWORD = 'thisisaterribleandpublicpassword'
+    MYSQL_DATABASE = 'arbiter_data'

--- a/sfa_api/config.py
+++ b/sfa_api/config.py
@@ -41,6 +41,7 @@ class TestingConfig(Config):
     MYSQL_DATABASE = 'arbiter_data'
     USE_FAKE_REDIS = True
 
+
 class AdminTestConfig(Config):
     MYSQL_USER = 'frameworkadmin'
     MYSQL_PASSWORD = 'thisisaterribleandpublicpassword'

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -320,6 +320,11 @@ def site_id_plant():
 
 
 @pytest.fixture()
+def test_orgid():
+    return 'b76ab62e-4fe1-11e9-9e44-64006a511e6f'
+
+
+@pytest.fixture()
 def mocked_queuing(mocker):
     mocked = mocker.patch('rq.Queue.enqueue')
     yield

--- a/sfa_api/tests/test_admincli.py
+++ b/sfa_api/tests/test_admincli.py
@@ -275,3 +275,19 @@ def test_move_user_to_unaffiliated_invalid_userid(
         admincli.move_user_to_unaffiliated,
         'baduuid')
     assert r.output == 'Badly formed user_id\n'
+
+
+def test_delete_user(
+        app_cli_runner, dict_cursor, user_id):
+    r = app_cli_runner.invoke(
+        admincli.delete_user,
+        user_id)
+    assert r.output == (f'User {user_id} deleted successfully.\n')
+
+
+def test_delete_user_user_dne(
+        app_cli_runner, dict_cursor, missing_id):
+    r = app_cli_runner.invoke(
+        admincli.delete_user,
+        missing_id)
+    assert r.output == (f'User does not exist\n')

--- a/sfa_api/tests/test_admincli.py
+++ b/sfa_api/tests/test_admincli.py
@@ -1,0 +1,172 @@
+import pytest
+
+
+import pymysql
+from sfa_api import admincli
+from sfa_api import create_app
+from sfa_api.conftest import _make_nocommit_cursor
+from sfa_api.utils import storage_interface
+
+
+@pytest.fixture()
+def app_cli_runner(mocker):
+    app = create_app('AdminTestConfig')
+    with app.app_context():
+        try:
+            storage_interface.mysql_connection()
+        except pymysql.err.OperationalError:
+            pytest.skip('No connection to test database')
+        else:
+            with _make_nocommit_cursor(mocker):
+                yield app.test_cli_runner()
+
+
+@pytest.fixture()
+def dict_cursor():
+    yield storage_interface.get_cursor('dict', commit=False)
+
+
+def test_create_org(mocker, app_cli_runner, dict_cursor):
+    r = app_cli_runner.invoke(admincli.create_organization, ['clitestorg'])
+    assert 'Created organization clitestorg.\n' == r.output
+
+    with dict_cursor as sql_cursor:
+        sql_cursor.callproc('list_all_organizations')
+        orgs = sql_cursor.fetchall()
+        assert 'clitestorg' in [o['name'] for o in orgs]
+
+
+def test_create_org_org_exists(mocker, app_cli_runner):
+    r = app_cli_runner.invoke(admincli.create_organization, ['clitestorg'])
+    assert 'Created organization clitestorg.\n' == r.output
+    r = app_cli_runner.invoke(admincli.create_organization, ['clitestorg'])
+    assert 'Organization clitestorg already exists.\n' == r.output
+
+
+def test_create_org_name_too_long(mocker, app_cli_runner):
+    r = app_cli_runner.invoke(
+        admincli.create_organization,
+        ['This organization name is too long and will error'])
+    assert "Organization name must be 32 characters or fewer.\n" == r.output
+
+
+def test_add_user_to_org(
+        app_cli_runner, unaffiliated_userid, test_orgid,
+        dict_cursor):
+    r = app_cli_runner.invoke(
+        admincli.add_user_to_org,
+        [unaffiliated_userid, test_orgid])
+    assert (f'Added user {unaffiliated_userid} to organization '
+            f'{test_orgid}\n') == r.output
+    with dict_cursor as cursor:
+        cursor.callproc('list_all_users')
+        users = cursor.fetchall()
+        for user in users:
+            if user['id'] == unaffiliated_userid:
+                assert user['organization_id'] == test_orgid
+
+
+def test_add_user_to_org_affiliated_user(
+        app_cli_runner, user_id, test_orgid):
+    r = app_cli_runner.invoke(
+        admincli.add_user_to_org,
+        [user_id, test_orgid])
+    assert 'Cannot add affiliated user to organization\n' == r.output
+
+
+def test_add_user_to_org_invalid_orgid(
+        app_cli_runner, unaffiliated_userid):
+    r = app_cli_runner.invoke(
+        admincli.add_user_to_org,
+        [unaffiliated_userid, 'invalid-uuid'])
+    assert 'Badly formed organization_id\n' == r.output
+
+
+def test_add_user_to_org_invalid_userid(
+        app_cli_runner, test_orgid):
+    r = app_cli_runner.invoke(
+        admincli.add_user_to_org,
+        ['invalid-uuid', test_orgid])
+    assert 'Badly formed user_id\n' == r.output
+
+
+def test_add_user_to_org_org_dne(
+        app_cli_runner, unaffiliated_userid, missing_id):
+    r = app_cli_runner.invoke(
+        admincli.add_user_to_org,
+        [unaffiliated_userid, missing_id])
+    assert ('Cannot add or update a child row: a foreign '
+            'key constraint fails\n') == r.output
+
+
+@pytest.fixture(scope='function')
+def new_org_with_user(dict_cursor, unaffiliated_userid):
+    with dict_cursor as sql_cursor:
+        sql_cursor.callproc('create_organization', ('clitestorg',))
+        sql_cursor.callproc('list_all_organizations')
+        orgid = [o['id'] for o in sql_cursor.fetchall()
+                 if o['name'] == 'clitestorg'][0]
+        sql_cursor.callproc('add_user_to_org', (unaffiliated_userid, orgid))
+    return (orgid, unaffiliated_userid)
+
+
+@pytest.fixture(scope='function')
+def new_org_without_user(dict_cursor):
+    with dict_cursor as sql_cursor:
+        sql_cursor.callproc('create_organization', ('clitestorg',))
+        sql_cursor.callproc('list_all_organizations')
+        orgid = [o['id'] for o in sql_cursor.fetchall()
+                 if o['name'] == 'clitestorg'][0]
+    return orgid
+
+
+def test_promote_to_admin(
+        dict_cursor, app_cli_runner, new_org_with_user):
+    orgid = new_org_with_user[0]
+    userid = new_org_with_user[1]
+    r = app_cli_runner.invoke(
+        admincli.promote_to_admin,
+        [userid, orgid])
+    assert (f'Promoted user {userid} to administrate '
+            f'organization {orgid}\n') == r.output
+
+
+def test_promote_to_admin_already_granted(
+        dict_cursor, app_cli_runner, new_org_with_user):
+    orgid = new_org_with_user[0]
+    userid = new_org_with_user[1]
+    app_cli_runner.invoke(
+        admincli.promote_to_admin,
+        [userid, orgid])
+    r = app_cli_runner.invoke(
+        admincli.promote_to_admin,
+        [userid, orgid])
+    assert (f'User already granted admin permissions.\n') == r.output
+
+
+def test_promote_to_admin_not_in_org(
+        dict_cursor, app_cli_runner, unaffiliated_userid,
+        new_org_without_user):
+    r = app_cli_runner.invoke(
+        admincli.promote_to_admin,
+        [unaffiliated_userid, new_org_without_user])
+    assert 'Cannot promote admin from outside organization.\n' == r.output
+
+
+def test_list_all_users(app_cli_runner, dict_cursor):
+    r = app_cli_runner.invoke(
+        admincli.list_users)
+    output_lines = r.output.split('\n')
+    assert len(output_lines) == 9
+    for line in output_lines[2:-1]:
+        assert line.startswith('auth0|')
+        assert len(line.split('|')) == 5
+
+
+def test_list_all_organizations(app_cli_runner, dict_cursor):
+    r = app_cli_runner.invoke(
+        admincli.list_organizations)
+    output_lines = r.output.split('\n')
+    assert len(output_lines) == 9
+    for line in output_lines[2:-1]:
+        assert len(line.split('|')) == 2

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -135,6 +135,19 @@ def try_query(query_cmd):
             raise
 
 
+def _call_procedure_without_user(procedure_name, *args, cursor_type='dict'):
+    """
+    Can't user callproc since it doesn't properly use converters.
+    Will not handle OUT or INOUT parameters without first setting
+    local variables and retrieving from those variables
+    """
+    with get_cursor(cursor_type) as cursor:
+        query = f'CALL {procedure_name}({",".join(["%s"] * (len(args)))})'
+        query_cmd = partial(cursor.execute, query, (*args,))
+        try_query(query_cmd)
+        return cursor.fetchall()
+
+
 def _call_procedure(procedure_name, *args, cursor_type='dict'):
     """
     Can't user callproc since it doesn't properly use converters.


### PR DESCRIPTION
Adds a basic admin cli using the built in flask cli so we can use the storage interface. Still somewhat rough, needs some refactoring, ideally a way to repeat command arguments/options. Will require #155, needs to be rebased after that's merged. 
Running requires installing the API and setting the `FLASK_APP` environment variable to `sfa_api.admincli` and the `MYSQL_*` variables appropriately. Then the cli can be run with `flask admin <command>`.
Testing would require setting the `SFA_CLI_CONFIG`  env var to `AdminTestConfig`, or setting the environment variables individually.
closes #150 