### PR TITLE
Remove admin permissions migration update

### DIFF
--- a/datastore/migrations/0030_remove_admin_permissions.up.sql
+++ b/datastore/migrations/0030_remove_admin_permissions.up.sql
@@ -1,1 +1,7 @@
-DELETE FROM arbiter_data.role_permission_mapping WHERE permission_id in (SELECT id from arbiter_data.permissions WHERE object_type IN ('users', 'roles', 'permissions', 'role_grants'));
+DELETE FROM arbiter_data.role_permission_mapping
+    WHERE permission_id in (
+        SELECT id from arbiter_data.permissions
+            WHERE organization_id = get_organization_id('Organization 1')
+            AND object_type IN ('users', 'roles', 'permissions')
+            AND action != 'read'
+    );


### PR DESCRIPTION
closes #160 
Removes all of the RBAC permissions from 'Organization 1' other than those granting the 'read' action.