### PR TITLE
Add trigger on update users to remove permissions from previous orgs

### DIFF
--- a/datastore/migrations/0023_data_sharing.down.sql
+++ b/datastore/migrations/0023_data_sharing.down.sql
@@ -35,11 +35,11 @@ BEGIN
             LEAVE read_loop;
         END IF;
         -- delete the default user role and permissions
-        SELECT id INTO roleid FROM arbiter_data.roles WHERE name = CONCAT('User role ', BIN_TO_UUID(userid, 1));
-        DELETE FROM arbiter_data.roles WHERE id = roleid;
+        SELECT id INTO roleid FROM arbiter_data.roles WHERE name = CONCAT('DEFAULT User role ', BIN_TO_UUID(userid, 1));
         DELETE FROM arbiter_data.permissions WHERE id IN (
             SELECT permission_id FROM role_permission_mapping
             WHERE role_id = roleid);
+        DELETE FROM arbiter_data.roles WHERE id = roleid;
     END LOOP;
 
     CLOSE cur;

--- a/datastore/migrations/0023_data_sharing.up.sql
+++ b/datastore/migrations/0023_data_sharing.up.sql
@@ -302,7 +302,7 @@ BEGIN
     DECLARE userperm BINARY(16);
     DECLARE roleperm BINARY(16);
     SET roleid = UUID_TO_BIN(UUID(), 1);
-    SET rolename = CONCAT('User role ', BIN_TO_UUID(userid, 1));
+    SET rolename = CONCAT('DEFAULT User role ', BIN_TO_UUID(userid, 1));
     SET userperm = UUID_TO_BIN(UUID(), 1);
     SET roleperm = UUID_TO_BIN(UUID(), 1);
     INSERT INTO arbiter_data.roles(name, description, id, organization_id
@@ -311,14 +311,14 @@ BEGIN
     ) VALUES (userid, roleid);
     INSERT INTO arbiter_data.permissions(id, description, organization_id, action, object_type
     ) VALUES (
-    userperm, CONCAT('Read Self User ', BIN_TO_UUID(userid, 1)), orgid, 'read', 'users');
+    userperm, CONCAT('DEFAULT Read Self User ', BIN_TO_UUID(userid, 1)), orgid, 'read', 'users');
     INSERT INTO arbiter_data.role_permission_mapping(permission_id, role_id
     ) VALUES (userperm, roleid);
     INSERT INTO arbiter_data.permission_object_mapping(permission_id, object_id
     ) VALUES (userperm, userid);
     INSERT INTO arbiter_data.permissions(id, description, organization_id, action, object_type
     ) VALUES(
-    roleperm, CONCAT('Read User Role ', BIN_TO_UUID(userid, 1)), orgid, 'read', 'roles');
+    roleperm, CONCAT('DEFAULT Read User Role ', BIN_TO_UUID(userid, 1)), orgid, 'read', 'roles');
     INSERT INTO arbiter_data.role_permission_mapping(permission_id, role_id
     ) VALUES (roleperm, roleid);
     INSERT INTO arbiter_data.permission_object_mapping(permission_id, object_id

--- a/datastore/migrations/0023_data_sharing.up.sql
+++ b/datastore/migrations/0023_data_sharing.up.sql
@@ -293,16 +293,14 @@ INSERT INTO arbiter_data.users (id, auth0_id, organization_id) VALUES(
  * role.
  */
 CREATE DEFINER = 'insert_rbac'@'localhost' PROCEDURE create_default_user_role(
-    IN userid BINARY(16))
+    IN userid BINARY(16), IN orgid BINARY(16))
 COMMENT 'Creates a default role for a user, granting a read self permission'
 MODIFIES SQL DATA SQL SECURITY DEFINER
 BEGIN
-    DECLARE orgid BINARY(16);
     DECLARE roleid BINARY(16);
     DECLARE rolename VARCHAR(64);
     DECLARE userperm BINARY(16);
     DECLARE roleperm BINARY(16);
-    SET orgid = get_organization_id('Unaffiliated');
     SET roleid = UUID_TO_BIN(UUID(), 1);
     SET rolename = CONCAT('User role ', BIN_TO_UUID(userid, 1));
     SET userperm = UUID_TO_BIN(UUID(), 1);
@@ -350,18 +348,19 @@ MODIFIES SQL DATA
 BEGIN
     DECLARE done INT DEFAULT FALSE;
     DECLARE userid BINARY(16);
+    DECLARE orgid BINARY(16);
 
-    DECLARE cur CURSOR FOR SELECT id FROM arbiter_data.users;
+    DECLARE cur CURSOR FOR SELECT id, organization_id FROM arbiter_data.users;
     DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
 
     OPEN cur;
 
     read_loop: LOOP
-        FETCH cur INTO userid;
+        FETCH cur INTO userid, orgid;
         IF done THEN
             LEAVE read_loop;
         END IF;
-        CALL arbiter_data.create_default_user_role(userid);
+        CALL arbiter_data.create_default_user_role(userid, orgid);
     END LOOP;
 
     CLOSE cur;
@@ -386,7 +385,7 @@ BEGIN
         INSERT INTO arbiter_data.users (id, auth0_id, organization_id) VALUES (
             userid, auth0id, get_organization_id('Unaffiliated'));
         CALL arbiter_data.add_reference_role_to_user(userid);
-        CALL arbiter_data.create_default_user_role(userid);
+        CALL arbiter_data.create_default_user_role(userid, get_organization_id('Unaffiliated'));
     END IF;
 END;
 GRANT EXECUTE ON PROCEDURE arbiter_data.create_user_if_not_exists TO 'insert_rbac'@'localhost';

--- a/datastore/migrations/0023_data_sharing.up.sql
+++ b/datastore/migrations/0023_data_sharing.up.sql
@@ -318,7 +318,7 @@ BEGIN
     ) VALUES (userperm, userid);
     INSERT INTO arbiter_data.permissions(id, description, organization_id, action, object_type
     ) VALUES(
-    roleperm, CONCAT('Read User Role ', BIN_TO_UUID(roleid, 1)), orgid, 'read', 'roles');
+    roleperm, CONCAT('Read User Role ', BIN_TO_UUID(userid, 1)), orgid, 'read', 'roles');
     INSERT INTO arbiter_data.role_permission_mapping(permission_id, role_id
     ) VALUES (roleperm, roleid);
     INSERT INTO arbiter_data.permission_object_mapping(permission_id, object_id

--- a/datastore/migrations/0024_framework_admin.down.sql
+++ b/datastore/migrations/0024_framework_admin.down.sql
@@ -18,6 +18,7 @@ DROP PROCEDURE arbiter_data.remove_org_roles_from_user;
 DROP PROCEDURE arbiter_data.list_all_users;
 DROP PROCEDURE arbiter_data.list_all_organizations;
 DROP PROCEDURE arbiter_data.set_org_accepted_tou;
+DROP PROCEDURE arbiter_data.remove_user_facing_permissions_and_default_roles;
 
 DROP FUNCTION arbiter_data.get_org_role_by_name;
 

--- a/datastore/migrations/0024_framework_admin.down.sql
+++ b/datastore/migrations/0024_framework_admin.down.sql
@@ -20,3 +20,5 @@ DROP PROCEDURE arbiter_data.list_all_organizations;
 DROP PROCEDURE arbiter_data.set_org_accepted_tou;
 
 DROP FUNCTION arbiter_data.get_org_role_by_name;
+
+DROP TRIGGER update_user_perm_on_org_change;

--- a/datastore/migrations/0024_framework_admin.up.sql
+++ b/datastore/migrations/0024_framework_admin.up.sql
@@ -573,6 +573,7 @@ BEGIN
             SELECT id, NEW.id FROM arbiter_data.permissions
             WHERE organization_id = NEW.organization_id
                 AND object_type = 'users'
+                AND action != 'create'
                 AND applies_to_all;
         CALL create_default_user_role(NEW.id, NEW.organization_id);
     END IF;

--- a/datastore/migrations/0024_framework_admin.up.sql
+++ b/datastore/migrations/0024_framework_admin.up.sql
@@ -549,11 +549,11 @@ CREATE DEFINER = 'delete_rbac'@'localhost' PROCEDURE remove_user_facing_permissi
 SQL SECURITY DEFINER MODIFIES SQL DATA
 BEGIN
     -- Remove all mappings that grant actions on the user
-    DELETE FROM arbiter_data.permission_object_mapping WHERE object_id = NEW.id;
+    DELETE FROM arbiter_data.permission_object_mapping WHERE object_id = userid;
     -- delete the default user role and specific default permissions
-    DELETE FROM arbiter_data.roles WHERE name = CONCAT('User role', BIN_TO_UUID(NEW.id, 1));
-    DELETE FROM arbiter_data.permissions WHERE description = CONCAT('Read Self User ', BIN_TO_UUID(NEW.id, 1));
-    DELETE FROM arbiter_data.permissions WHERE description = CONCAT('Read User Role ', BIN_TO_UUID(NEW.id, 1));
+    DELETE FROM arbiter_data.roles WHERE name = CONCAT('User role', BIN_TO_UUID(userid, 1));
+    DELETE FROM arbiter_data.permissions WHERE description = CONCAT('Read Self User ', BIN_TO_UUID(userid, 1));
+    DELETE FROM arbiter_data.permissions WHERE description = CONCAT('Read User Role ', BIN_TO_UUID(userid, 1));
 END;
 GRANT EXECUTE ON PROCEDURE arbiter_data.remove_user_facing_permissions_and_default_roles TO 'delete_rbac'@'localhost';
 GRANT EXECUTE ON PROCEDURE arbiter_data.remove_user_facing_permissions_and_default_roles TO 'permission_trig'@'localhost';

--- a/datastore/migrations/0024_framework_admin.up.sql
+++ b/datastore/migrations/0024_framework_admin.up.sql
@@ -551,10 +551,12 @@ BEGIN
     -- Remove all mappings that grant actions on the user
     DELETE FROM arbiter_data.permission_object_mapping WHERE object_id = userid;
     -- delete the default user role and specific default permissions
-    DELETE FROM arbiter_data.roles WHERE name = CONCAT('User role', BIN_TO_UUID(userid, 1));
-    DELETE FROM arbiter_data.permissions WHERE description = CONCAT('Read Self User ', BIN_TO_UUID(userid, 1));
-    DELETE FROM arbiter_data.permissions WHERE description = CONCAT('Read User Role ', BIN_TO_UUID(userid, 1));
+    DELETE FROM arbiter_data.roles WHERE name = CONCAT('DEFAULT User role ', BIN_TO_UUID(userid, 1));
+    DELETE FROM arbiter_data.permissions WHERE description = CONCAT('DEFAULT Read Self User ', BIN_TO_UUID(userid, 1));
+    DELETE FROM arbiter_data.permissions WHERE description = CONCAT('DEFAULT Read User Role ', BIN_TO_UUID(userid, 1));
 END;
+GRANT SELECT (name) ON arbiter_data.roles TO 'delete_rbac'@'localhost';
+GRANT SELECT (description) ON arbiter_data.permissions TO 'delete_rbac'@'localhost';
 GRANT EXECUTE ON PROCEDURE arbiter_data.remove_user_facing_permissions_and_default_roles TO 'delete_rbac'@'localhost';
 GRANT EXECUTE ON PROCEDURE arbiter_data.remove_user_facing_permissions_and_default_roles TO 'permission_trig'@'localhost';
 

--- a/datastore/tests/test_deletes.py
+++ b/datastore/tests/test_deletes.py
@@ -575,3 +575,35 @@ def test_delete_report_denied(cursor, report_obj):
     with pytest.raises(pymysql.err.OperationalError) as e:
         cursor.callproc('delete_report', (auth0id, report_id))
     assert e.value.args[0] == 1142
+
+
+def test_remove_user_facing_permissions_and_default_roles(
+        cursor, new_user):
+    user = new_user()
+    cursor.callproc('create_default_user_role', (user['id'], user['organization_id']))
+    cursor.execute(
+        f'SELECT 1 FROM arbiter_data.roles WHERE name = CONCAT("DEFAULT User role ", %s)',
+        str(bin_to_uuid(user['id'])))
+    assert cursor.fetchone()[0] == 1
+    cursor.execute(
+        f'SELECT 1 FROM arbiter_data.permissions WHERE description = CONCAT("DEFAULT Read Self User ", %s)',
+        str(bin_to_uuid(user['id'])))
+    assert cursor.fetchone()[0] == 1
+    cursor.execute(
+        f'SELECT 1 FROM arbiter_data.permissions WHERE description = CONCAT("DEFAULT Read User Role ", %s)',
+        str(bin_to_uuid(user['id'])))
+    assert cursor.fetchone()[0] == 1
+
+    cursor.callproc('remove_user_facing_permissions_and_default_roles', (user['id'],))
+    cursor.execute(
+        f'SELECT 1 FROM arbiter_data.roles WHERE name = CONCAT("DEFAULT User role ", %s)',
+        str(bin_to_uuid(user['id'])))
+    assert cursor.fetchone() is None
+    cursor.execute(
+        f'SELECT 1 FROM arbiter_data.permissions WHERE description = CONCAT("DEFAULT Read Self User ", %s)',
+        str(bin_to_uuid(user['id'])))
+    assert cursor.fetchone() is None
+    cursor.execute(
+        f'SELECT 1 FROM arbiter_data.permissions WHERE description = CONCAT("DEFAULT Read User Role ", %s)',
+        str(bin_to_uuid(user['id'])))
+    assert cursor.fetchone() is None

--- a/datastore/tests/test_deletes.py
+++ b/datastore/tests/test_deletes.py
@@ -580,30 +580,40 @@ def test_delete_report_denied(cursor, report_obj):
 def test_remove_user_facing_permissions_and_default_roles(
         cursor, new_user):
     user = new_user()
-    cursor.callproc('create_default_user_role', (user['id'], user['organization_id']))
+    cursor.callproc(
+        'create_default_user_role',
+        (user['id'], user['organization_id']))
     cursor.execute(
-        f'SELECT 1 FROM arbiter_data.roles WHERE name = CONCAT("DEFAULT User role ", %s)',
+        ('SELECT 1 FROM arbiter_data.roles WHERE '
+         'name = CONCAT("DEFAULT User role ", %s)'),
         str(bin_to_uuid(user['id'])))
     assert cursor.fetchone()[0] == 1
     cursor.execute(
-        f'SELECT 1 FROM arbiter_data.permissions WHERE description = CONCAT("DEFAULT Read Self User ", %s)',
+        ('SELECT 1 FROM arbiter_data.permissions WHERE '
+         'description = CONCAT("DEFAULT Read Self User ", %s)'),
         str(bin_to_uuid(user['id'])))
     assert cursor.fetchone()[0] == 1
     cursor.execute(
-        f'SELECT 1 FROM arbiter_data.permissions WHERE description = CONCAT("DEFAULT Read User Role ", %s)',
+        ('SELECT 1 FROM arbiter_data.permissions WHERE '
+         'description = CONCAT("DEFAULT Read User Role ", %s)'),
         str(bin_to_uuid(user['id'])))
     assert cursor.fetchone()[0] == 1
 
-    cursor.callproc('remove_user_facing_permissions_and_default_roles', (user['id'],))
+    cursor.callproc(
+        'remove_user_facing_permissions_and_default_roles',
+        (user['id'],))
     cursor.execute(
-        f'SELECT 1 FROM arbiter_data.roles WHERE name = CONCAT("DEFAULT User role ", %s)',
+        ('SELECT 1 FROM arbiter_data.roles WHERE name '
+         '= CONCAT("DEFAULT User role ", %s)'),
         str(bin_to_uuid(user['id'])))
     assert cursor.fetchone() is None
     cursor.execute(
-        f'SELECT 1 FROM arbiter_data.permissions WHERE description = CONCAT("DEFAULT Read Self User ", %s)',
+        ('SELECT 1 FROM arbiter_data.permissions WHERE '
+         'description = CONCAT("DEFAULT Read Self User ", %s)'),
         str(bin_to_uuid(user['id'])))
     assert cursor.fetchone() is None
     cursor.execute(
-        f'SELECT 1 FROM arbiter_data.permissions WHERE description = CONCAT("DEFAULT Read User Role ", %s)',
+        ('SELECT 1 FROM arbiter_data.permissions WHERE '
+         'description = CONCAT("DEFAULT Read User Role ", %s)'),
         str(bin_to_uuid(user['id'])))
     assert cursor.fetchone() is None

--- a/datastore/tests/test_inserts.py
+++ b/datastore/tests/test_inserts.py
@@ -1094,7 +1094,7 @@ def test_create_user_if_not_exist(dictcursor, valueset_org):
             'SELECT * FROM arbiter_data.roles WHERE id = %s',
             role_id)
         role = dictcursor.fetchone()
-        if role['name'].startswith('User role'):
+        if role['name'].startswith('DEFAULT User role'):
             default_role = role
         else:
             reference_role = role
@@ -1113,10 +1113,10 @@ def test_create_user_if_not_exist(dictcursor, valueset_org):
 
     for p in default_permissions:
         if (p['description'] ==
-                f'Read Self User {str(bin_to_uuid(user["id"]))}'):
+                f'DEFAULT Read Self User {str(bin_to_uuid(user["id"]))}'):
             read_self = p
         if (p['description'] ==
-                f'Read User Role {str(bin_to_uuid(default_role["id"]))}'):
+                f'DEFAULT Read User Role {str(bin_to_uuid(user["id"]))}'):
             read_role = p
     assert read_self['action'] == 'read'
     assert read_self['object_type'] == 'users'

--- a/datastore/tests/test_permission_triggers.py
+++ b/datastore/tests/test_permission_triggers.py
@@ -156,6 +156,7 @@ def test_update_user_perm_on_org_change(
         dictcursor, new_organization, new_user):
     user = new_user()
     org = new_organization()
+    assert org['id'] != user['organization_id']
     dictcursor.callproc(
         'create_default_user_role',
         (user['id'], user['organization_id']))

--- a/datastore/tests/test_permission_triggers.py
+++ b/datastore/tests/test_permission_triggers.py
@@ -156,19 +156,23 @@ def test_update_user_perm_on_org_change(
         dictcursor, new_organization, new_user):
     user = new_user()
     org = new_organization()
-    dictcursor.callproc('create_default_user_role',
-                        (user['id'], user['organization_id']))
+    dictcursor.callproc(
+        'create_default_user_role',
+        (user['id'], user['organization_id']))
     # assert the default roles exist and are set to the correct org_id
     dictcursor.execute(
-        'SELECT * FROM arbiter_data.roles WHERE name = CONCAT("DEFAULT User role ", %s)',
+        ('SELECT * FROM arbiter_data.roles WHERE '
+         'name = CONCAT("DEFAULT User role ", %s)'),
         str(bin_to_uuid(user['id'])))
     assert dictcursor.fetchone()['organization_id'] == user['organization_id']
     dictcursor.execute(
-        'SELECT * FROM arbiter_data.permissions WHERE description = CONCAT("DEFAULT Read Self User ", %s)',
+        ('SELECT * FROM arbiter_data.permissions WHERE '
+         'description = CONCAT("DEFAULT Read Self User ", %s)'),
         str(bin_to_uuid(user['id'])))
     assert dictcursor.fetchone()['organization_id'] == user['organization_id']
     dictcursor.execute(
-        'SELECT * FROM arbiter_data.permissions WHERE description = CONCAT("DEFAULT Read User Role ", %s)',
+        ('SELECT * FROM arbiter_data.permissions WHERE '
+         'description = CONCAT("DEFAULT Read User Role ", %s)'),
         str(bin_to_uuid(user['id'])))
     assert dictcursor.fetchone()['organization_id'] == user['organization_id']
     # update the org
@@ -177,14 +181,17 @@ def test_update_user_perm_on_org_change(
         (org['id'], user['id']))
     # ensure the trigger fired and recreated the roles in the new organization
     dictcursor.execute(
-        'SELECT * FROM arbiter_data.roles WHERE name = CONCAT("DEFAULT User role ", %s)',
+        ('SELECT * FROM arbiter_data.roles WHERE '
+         'name = CONCAT("DEFAULT User role ", %s)'),
         str(bin_to_uuid(user['id'])))
     assert dictcursor.fetchone()['organization_id'] == org['id']
     dictcursor.execute(
-        'SELECT * FROM arbiter_data.permissions WHERE description = CONCAT("DEFAULT Read Self User ", %s)',
+        ('SELECT * FROM arbiter_data.permissions WHERE '
+         'description = CONCAT("DEFAULT Read Self User ", %s)'),
         str(bin_to_uuid(user['id'])))
     assert dictcursor.fetchone()['organization_id'] == org['id']
     dictcursor.execute(
-        'SELECT * FROM arbiter_data.permissions WHERE description = CONCAT("DEFAULT Read User Role ", %s)',
+        ('SELECT * FROM arbiter_data.permissions WHERE '
+         'description = CONCAT("DEFAULT Read User Role ", %s)'),
         str(bin_to_uuid(user['id'])))
     assert dictcursor.fetchone()['organization_id'] == org['id']

--- a/datastore/tests/test_permission_triggers.py
+++ b/datastore/tests/test_permission_triggers.py
@@ -5,6 +5,8 @@ permission_object_mapping
 import pymysql
 import pytest
 
+from conftest import bin_to_uuid
+
 
 def test_permissions_not_updatable(cursor, new_permission):
     """Test that permission objects  cant be updated"""
@@ -146,3 +148,43 @@ def test_object_mapping_remove_obj(cursor, action, getfcn, new_permission,
         'SELECT object_id FROM permission_object_mapping WHERE '
         'permission_id = %s', perm['id'])
     assert cursor.fetchone() is None
+
+
+# Note: This test depends on the create_default_user_role
+# function found in 0024_framework_admin.up.sql
+def test_update_user_perm_on_org_change(
+        dictcursor, new_organization, new_user):
+    user = new_user()
+    org = new_organization()
+    dictcursor.callproc('create_default_user_role',
+                        (user['id'], user['organization_id']))
+    # assert the default roles exist and are set to the correct org_id
+    dictcursor.execute(
+        'SELECT * FROM arbiter_data.roles WHERE name = CONCAT("DEFAULT User role ", %s)',
+        str(bin_to_uuid(user['id'])))
+    assert dictcursor.fetchone()['organization_id'] == user['organization_id']
+    dictcursor.execute(
+        'SELECT * FROM arbiter_data.permissions WHERE description = CONCAT("DEFAULT Read Self User ", %s)',
+        str(bin_to_uuid(user['id'])))
+    assert dictcursor.fetchone()['organization_id'] == user['organization_id']
+    dictcursor.execute(
+        'SELECT * FROM arbiter_data.permissions WHERE description = CONCAT("DEFAULT Read User Role ", %s)',
+        str(bin_to_uuid(user['id'])))
+    assert dictcursor.fetchone()['organization_id'] == user['organization_id']
+    # update the org
+    dictcursor.execute(
+        'UPDATE arbiter_data.users SET organization_id = %s WHERE id = %s',
+        (org['id'], user['id']))
+    # ensure the trigger fired and recreated the roles in the new organization
+    dictcursor.execute(
+        'SELECT * FROM arbiter_data.roles WHERE name = CONCAT("DEFAULT User role ", %s)',
+        str(bin_to_uuid(user['id'])))
+    assert dictcursor.fetchone()['organization_id'] == org['id']
+    dictcursor.execute(
+        'SELECT * FROM arbiter_data.permissions WHERE description = CONCAT("DEFAULT Read Self User ", %s)',
+        str(bin_to_uuid(user['id'])))
+    assert dictcursor.fetchone()['organization_id'] == org['id']
+    dictcursor.execute(
+        'SELECT * FROM arbiter_data.permissions WHERE description = CONCAT("DEFAULT Read User Role ", %s)',
+        str(bin_to_uuid(user['id'])))
+    assert dictcursor.fetchone()['organization_id'] == org['id']

--- a/sfa_api/tests/rbac/test_roles.py
+++ b/sfa_api/tests/rbac/test_roles.py
@@ -39,7 +39,7 @@ def test_list_roles_missing_perms(api, user_id, remove_perms):
     assert roles.status_code == 200
     user_roles = roles.json
     assert len(user_roles) == 1
-    assert user_roles[0]['name'] == f'User role {user_id}'
+    assert user_roles[0]['name'] == f'DEFAULT User role {user_id}'
 
 
 def test_create_delete_role(api):

--- a/sfa_api/utils/tests/test_storage_interface.py
+++ b/sfa_api/utils/tests/test_storage_interface.py
@@ -781,7 +781,7 @@ def test_create_new_user(sql_app, fake_user, run):
     new_user = storage_interface.get_current_user_info()
     assert len(new_user_roles) == 1
     user_role = new_user_roles[0]
-    assert user_role['name'] == f'User role {new_user["user_id"]}'
+    assert user_role['name'] == f'DEFAULT User role {new_user["user_id"]}'
     assert len(user_role['permissions']) == 2
     assert new_user['auth0_id'] == 'auth0|create_me'
     assert new_user['organization'] == 'Unaffiliated'


### PR DESCRIPTION
Added to address #162 
Not sure if this should go somewhere else or if it can be tacked on to the framework admin sql migration.