### PR TITLE
allow report permissions, update tests

### DIFF
--- a/sfa_api/demo/__init__.py
+++ b/sfa_api/demo/__init__.py
@@ -617,4 +617,4 @@ def read_metadata_for_cdf_forecast_values(forecast_id, start):
     return (static_cdf_forecast_groups[
         static_cdf_forecasts[forecast_id]['parent']
     ]['interval_length'],
-            _set_previous_time(start))
+        _set_previous_time(start))

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -577,7 +577,7 @@ class PermissionPostSchema(ma.Schema):
         required=True,
         validate=validate.OneOf(['sites', 'aggregates', 'forecasts',
                                  'observations', 'users', 'roles',
-                                 'permissions', 'cdf_forecasts']),
+                                 'permissions', 'cdf_forecasts', 'reports']),
     )
     applies_to_all = ma.Boolean(
         title="Applies to all",
@@ -709,7 +709,7 @@ class ReportSchema(ReportPostSchema):
         string = True
         ordered = True
     report_id = ma.UUID()
-    organization = ma.String(title="Organization")
+    provider = ma.String(title="Provider")
     metrics = ma.Dict(
         title='Calculated Metrics',
         description='Metrics calculated over the '

--- a/sfa_api/tests/rbac/test_permissions.py
+++ b/sfa_api/tests/rbac/test_permissions.py
@@ -51,7 +51,7 @@ def perm(action, object_type, description, applies_to_all):
     (perm('nope', 'roles', 'role perm', True),
         '{"action":["Must be one of: create, read, update, delete, read_values, write_values, delete_values, grant, revoke."]}'),  # noqa: E501
     (perm('create', 'role', 'role perm', True),
-     '{"object_type":["Must be one of: sites, aggregates, forecasts, observations, users, roles, permissions, cdf_forecasts."]}'),  # noqa: E501
+     '{"object_type":["Must be one of: sites, aggregates, forecasts, observations, users, roles, permissions, cdf_forecasts, reports."]}'),  # noqa: E501
     (perm('create', 'roles', 'role perm', 5),
      '{"applies_to_all":["Not a valid boolean."]}'),
 ])

--- a/sfa_api/tests/test_reports.py
+++ b/sfa_api/tests/test_reports.py
@@ -45,7 +45,14 @@ def test_get_report(api, new_report):
     res = api.get(f'/reports/{report_id}',
                   base_url=BASE_URL)
     assert res.status_code == 200
-
+    report = res.json
+    assert 'report_id' in report
+    assert 'provider' in report
+    assert 'metrics' in report
+    assert 'raw_report' in report
+    assert 'status' in report
+    assert 'created_at' in report
+    assert 'modified_at' in report
 
 def test_get_report_dne(api, missing_id):
     res = api.get(f'/reports/{missing_id}',

--- a/sfa_api/tests/test_reports.py
+++ b/sfa_api/tests/test_reports.py
@@ -54,6 +54,7 @@ def test_get_report(api, new_report):
     assert 'created_at' in report
     assert 'modified_at' in report
 
+
 def test_get_report_dne(api, missing_id):
     res = api.get(f'/reports/{missing_id}',
                   base_url=BASE_URL)


### PR DESCRIPTION
Report permissions were not supported by the api. Reports were also misconfigured to expect an  'organization' field when the sql was returning 'provider'.