### PR TITLE
closes #180 handle mysql integrity error 1216

### DIFF
--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -92,7 +92,7 @@ def test_forecast_post_invalid_aggregate(api, missing_id):
     assert res.status_code == 404
 
 
-def test_forecast_post_invalid_aggregate(api, site_id):
+def test_forecast_post_aggregate_id_is_site(api, site_id):
     payload = copy_update(VALID_FORECAST_AGG_JSON, 'aggregate_id', site_id)
     res = api.post('/forecasts/single/',
                    base_url=BASE_URL,

--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -76,8 +76,24 @@ def test_forecast_post_invalid_site(api, missing_id):
     assert res.status_code == 404
 
 
+def test_forecast_post_site_id_is_aggregate(api, aggregate_id):
+    payload = copy_update(VALID_FORECAST_JSON, 'site_id', aggregate_id)
+    res = api.post('/forecasts/single/',
+                   base_url=BASE_URL,
+                   json=payload)
+    assert res.status_code == 404
+
+
 def test_forecast_post_invalid_aggregate(api, missing_id):
     payload = copy_update(VALID_FORECAST_AGG_JSON, 'aggregate_id', missing_id)
+    res = api.post('/forecasts/single/',
+                   base_url=BASE_URL,
+                   json=payload)
+    assert res.status_code == 404
+
+
+def test_forecast_post_invalid_aggregate(api, site_id):
+    payload = copy_update(VALID_FORECAST_AGG_JSON, 'aggregate_id', site_id)
     res = api.post('/forecasts/single/',
                    base_url=BASE_URL,
                    json=payload)

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -135,7 +135,7 @@ def try_query(query_cmd):
     except (pymysql.err.OperationalError, pymysql.err.IntegrityError,
             pymysql.err.InternalError) as e:
         ecode = e.args[0]
-        if ecode == 1142 or ecode == 1143 or ecode == 1411:
+        if ecode == 1142 or ecode == 1143 or ecode == 1411 or ecode == 1216:
             raise StorageAuthError(e.args[1])
         elif ecode == 1451:
             raise DeleteRestrictionError


### PR DESCRIPTION
Catches an error where a user has access to an object with some uuid, and mistakenly uses it in the wrong field e.g. using a site_id as aggregate_id. This passed the user_can_perform_action check and raised an integrity error.