### PR TITLE
Enable restrictions of forecast times

### DIFF
--- a/datastore/tests/test_reads.py
+++ b/datastore/tests/test_reads.py
@@ -1275,7 +1275,7 @@ def test_read_metadata_for_value_write_fx(
     res = dictcursor.fetchone()
     assert isinstance(res['interval_length'], int)
     assert res['previous_time'] == time_
-
+    assert isinstance(res['extra_parameters'], str)
 
 def test_read_metadata_for_value_write_fx_before(
         dictcursor, insertuser, allow_write_values):
@@ -1290,6 +1290,7 @@ def test_read_metadata_for_value_write_fx_before(
     res = dictcursor.fetchone()
     assert isinstance(res['interval_length'], int)
     assert res['previous_time'] is None
+    assert isinstance(res['extra_parameters'], str)
 
 
 def test_read_metadata_for_value_write_fx_no_vals(
@@ -1301,6 +1302,7 @@ def test_read_metadata_for_value_write_fx_no_vals(
     res = dictcursor.fetchone()
     assert isinstance(res['interval_length'], int)
     assert res['previous_time'] is None
+    assert isinstance(res['extra_parameters'], str)
 
 
 def test_read_metadata_for_value_write_fx_no_write(
@@ -1326,6 +1328,7 @@ def test_read_metadata_for_value_write_obs(
     res = dictcursor.fetchone()
     assert isinstance(res['interval_length'], int)
     assert res['previous_time'] == time_
+    assert isinstance(res['extra_parameters'], str)
 
 
 def test_read_metadata_for_value_write_obs_before(
@@ -1341,6 +1344,7 @@ def test_read_metadata_for_value_write_obs_before(
     res = dictcursor.fetchone()
     assert isinstance(res['interval_length'], int)
     assert res['previous_time'] is None
+    assert isinstance(res['extra_parameters'], str)
 
 
 def test_read_metadata_for_value_write_obs_no_vals(
@@ -1352,6 +1356,7 @@ def test_read_metadata_for_value_write_obs_no_vals(
     res = dictcursor.fetchone()
     assert isinstance(res['interval_length'], int)
     assert res['previous_time'] is None
+    assert isinstance(res['extra_parameters'], str)
 
 
 def test_read_metadata_for_value_write_obs_no_write(
@@ -1378,6 +1383,7 @@ def test_read_metadata_for_value_write_cdf(
     res = dictcursor.fetchone()
     assert isinstance(res['interval_length'], int)
     assert res['previous_time'] == time_
+    assert isinstance(res['extra_parameters'], str)
 
 
 def test_read_metadata_for_value_write_cdf_before(
@@ -1394,6 +1400,7 @@ def test_read_metadata_for_value_write_cdf_before(
     res = dictcursor.fetchone()
     assert isinstance(res['interval_length'], int)
     assert res['previous_time'] is None
+    assert isinstance(res['extra_parameters'], str)
 
 
 def test_read_metadata_for_value_write_cdf_no_vals(
@@ -1406,6 +1413,7 @@ def test_read_metadata_for_value_write_cdf_no_vals(
     res = dictcursor.fetchone()
     assert isinstance(res['interval_length'], int)
     assert res['previous_time'] is None
+    assert isinstance(res['extra_parameters'], str)
 
 
 def test_read_metadata_for_value_write_cdf_fx_no_write(

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -138,6 +138,18 @@ VALID_FX_VALUE_JSON = {
          'value': 3.0}
     ]
 }
+ADJ_FX_VALUE_JSON = {
+    'id': '123e4567-e89b-12d3-a456-426655440000',
+    'values': [
+        {'timestamp': "2019-11-01T07:00:00+00:00",
+         'value': 1.0},
+        {'timestamp': "2019-11-01T07:05:00+00:00",
+         'value': 32.0},
+        {'timestamp': "2019-11-01T07:10:00+00:00",
+         'value': 3.0}
+    ]
+}
+
 UNSORTED_FX_VALUE_JSON = {
     'id': '123e4567-e89b-12d3-a456-426655440000',
     'values': [
@@ -366,6 +378,17 @@ def mock_previous(mocker):
         new=meta)
     meta.return_value = None
     return meta
+
+
+@pytest.fixture()
+def restrict_fx_upload(mocker):
+    mocker.patch(
+        'sfa_api.utils.storage_interface._set_extra_params',
+        return_value='{"restrict_upload": true}')
+    cut = mocker.patch(
+        'sfa_api.utils.request_handling._current_utc_timestamp',
+    )
+    return cut
 
 
 demo_sites = {

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -138,6 +138,17 @@ VALID_FX_VALUE_JSON = {
          'value': 3.0}
     ]
 }
+UNSORTED_FX_VALUE_JSON = {
+    'id': '123e4567-e89b-12d3-a456-426655440000',
+    'values': [
+        {'timestamp': "2019-01-22T17:59:00+00:00",
+         'value': 32.0},
+        {'timestamp': "2019-01-22T17:54:00+00:00",
+         'value': 1.0},
+        {'timestamp': "2019-01-22T18:04:00+00:00",
+         'value': 3.0}
+    ]
+}
 FORECAST_CSV = (
     'timestamp,value\n'
     '20190122T12:05:00+0000,7.0\n'

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -1,7 +1,6 @@
 from flask import Blueprint, request, jsonify, make_response, url_for
 from flask.views import MethodView
 from marshmallow import ValidationError
-import pandas as pd
 
 
 from sfa_api import spec
@@ -18,44 +17,8 @@ from sfa_api.utils.errors import BadAPIRequest
 from sfa_api.utils.storage import get_storage
 from sfa_api.utils.request_handling import (validate_parsable_values,
                                             validate_start_end,
-                                            validate_index_period)
-
-
-def validate_forecast_values(forecast_df):
-    """Validates that posted values are parseable and of the expectedtypes.
-
-    Parameters
-    ----------
-    forecast_df: Pandas DataFrame
-
-    Raises
-    ------
-    BadAPIRequestError
-        If an expected field is missing or contains an entry of incorrect
-        type.
-    """
-    errors = {}
-    try:
-        forecast_df['value'] = pd.to_numeric(forecast_df['value'],
-                                             downcast='float')
-    except ValueError:
-        error = ('Invalid item in "value" field. Ensure that all values '
-                 'are integers, floats, empty, NaN, or NULL.')
-        errors.update({'value': [error]})
-    except KeyError:
-        errors.update({'value': ['Missing "value" field.']})
-    try:
-        forecast_df['timestamp'] = pd.to_datetime(
-            forecast_df['timestamp'],
-            utc=True)
-    except ValueError:
-        error = ('Invalid item in "timestamp" field. Ensure that '
-                 'timestamps are ISO8601 compliant')
-        errors.update({'timestamp': [error]})
-    except KeyError:
-        errors.update({'timestamp': ['Missing "timestamp" field.']})
-    if errors:
-        raise BadAPIRequest(errors)
+                                            validate_index_period,
+                                            validate_forecast_values)
 
 
 class AllForecastsView(MethodView):

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -269,8 +269,10 @@ class ForecastValuesView(MethodView):
         validate_forecast_values(forecast_df)
         forecast_df = forecast_df.set_index('timestamp')
         storage = get_storage()
-        interval_length, previous_time = storage.read_metadata_for_forecast_values(  # NOQA
-            forecast_id, forecast_df.index[0])
+        interval_length, previous_time, extra_params = (
+            storage.read_metadata_for_forecast_values(
+                forecast_id, forecast_df.index[0])
+        )
         validate_index_period(forecast_df.index, interval_length,
                               previous_time)
         stored = storage.store_forecast_values(forecast_id, forecast_df)
@@ -547,8 +549,10 @@ class CDFForecastValues(MethodView):
         validate_forecast_values(forecast_df)
         forecast_df = forecast_df.set_index('timestamp')
         storage = get_storage()
-        interval_length, previous_time = storage.read_metadata_for_cdf_forecast_values(  # NOQA
-            forecast_id, forecast_df.index[0])
+        interval_length, previous_time, extra_params = (
+            storage.read_metadata_for_cdf_forecast_values(
+                forecast_id, forecast_df.index[0])
+        )
         validate_index_period(forecast_df.index, interval_length,
                               previous_time)
         stored = storage.store_cdf_forecast_values(forecast_id, forecast_df)

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -230,7 +230,7 @@ class ForecastValuesView(MethodView):
         """
         forecast_df = validate_parsable_values()
         validate_forecast_values(forecast_df)
-        forecast_df = forecast_df.set_index('timestamp')
+        forecast_df = forecast_df.set_index('timestamp').sort_index()
         storage = get_storage()
         interval_length, previous_time, extra_params = (
             storage.read_metadata_for_forecast_values(
@@ -510,7 +510,7 @@ class CDFForecastValues(MethodView):
         """
         forecast_df = validate_parsable_values()
         validate_forecast_values(forecast_df)
-        forecast_df = forecast_df.set_index('timestamp')
+        forecast_df = forecast_df.set_index('timestamp').sort_index()
         storage = get_storage()
         interval_length, previous_time, extra_params = (
             storage.read_metadata_for_cdf_forecast_values(

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -246,8 +246,10 @@ class ObservationValuesView(MethodView):
             validate_parsable_values(), qf_range)
         observation_df = observation_df.set_index('timestamp')
         storage = get_storage()
-        interval_length, previous_time = storage.read_metadata_for_observation_values(  # NOQA
-            observation_id, observation_df.index[0])
+        interval_length, previous_time, _ = (
+            storage.read_metadata_for_observation_values(
+                observation_id, observation_df.index[0])
+        )
         validate_index_period(observation_df.index,
                               interval_length, previous_time)
         stored = storage.store_observation_values(

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -419,7 +419,7 @@ class ForecastPostSchema(ma.Schema):
         required=True,
         validate=TimeFormat('%H:%M'),
         description=('The time of day that a forecast run is issued specified '
-                     'in the timezone of the site in HH:MM format, e.g. 00:30.'
+                     'in UTC in HH:MM format, e.g. 00:30.'
                      'For forecast runs issued multiple times within one day '
                      '(e.g. hourly), this specifies the first issue time of '
                      'day. Additional issue times are uniquely determined by '

--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -6,7 +6,7 @@ from sfa_api.conftest import (variables, interval_value_types, interval_labels,
                               BASE_URL, VALID_CDF_FORECAST_JSON, copy_update,
                               VALID_FX_VALUE_JSON, VALID_CDF_VALUE_CSV,
                               VALID_CDF_FORECAST_AGG_JSON,
-                              UNSORTED_FX_VALUE_JSON)
+                              UNSORTED_FX_VALUE_JSON, ADJ_FX_VALUE_JSON)
 
 
 INVALID_NAME = copy_update(VALID_CDF_FORECAST_JSON, 'name', '@drain')
@@ -150,6 +150,26 @@ def test_post_forecast_values_valid_json(api, cdf_forecast_id, mock_previous,
                    base_url=BASE_URL,
                    json=val)
     assert res.status_code == 201
+
+
+def test_post_forecast_values_valid_json_with_restriction(
+        api, cdf_forecast_id, mock_previous, restrict_fx_upload):
+    mock_previous.return_value = pd.Timestamp('2019-11-01T06:55Z')
+    restrict_fx_upload.return_value = pd.Timestamp('2019-11-01T05:59Z')
+    res = api.post(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
+                   base_url=BASE_URL,
+                   json=ADJ_FX_VALUE_JSON)
+    assert res.status_code == 201
+
+
+def test_post_forecast_values_valid_json_restricted(
+        api, cdf_forecast_id, mock_previous, restrict_fx_upload):
+    mock_previous.return_value = pd.Timestamp('2019-11-01T06:55Z')
+    restrict_fx_upload.return_value = pd.Timestamp('2019-11-01T06:59Z')
+    res = api.post(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
+                   base_url=BASE_URL,
+                   json=ADJ_FX_VALUE_JSON)
+    assert res.status_code == 400
 
 
 @pytest.fixture()

--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -5,7 +5,8 @@ import pytest
 from sfa_api.conftest import (variables, interval_value_types, interval_labels,
                               BASE_URL, VALID_CDF_FORECAST_JSON, copy_update,
                               VALID_FX_VALUE_JSON, VALID_CDF_VALUE_CSV,
-                              VALID_CDF_FORECAST_AGG_JSON)
+                              VALID_CDF_FORECAST_AGG_JSON,
+                              UNSORTED_FX_VALUE_JSON)
 
 
 INVALID_NAME = copy_update(VALID_CDF_FORECAST_JSON, 'name', '@drain')
@@ -142,10 +143,12 @@ WRONG_DATE_FORMAT_CSV = "timestamp,value\nksdfjgn,32.93"
 NON_NUMERICAL_VALUE_CSV = "timestamp,value\n2018-10-29T12:04:23Z,fgh" # NOQA
 
 
-def test_post_forecast_values_valid_json(api, cdf_forecast_id, mock_previous):
+@pytest.mark.parametrize('val', (VALID_FX_VALUE_JSON, UNSORTED_FX_VALUE_JSON))
+def test_post_forecast_values_valid_json(api, cdf_forecast_id, mock_previous,
+                                         val):
     res = api.post(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
                    base_url=BASE_URL,
-                   json=VALID_FX_VALUE_JSON)
+                   json=val)
     assert res.status_code == 201
 
 

--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -5,7 +5,7 @@ import pytest
 from sfa_api.conftest import (variables, interval_value_types, interval_labels,
                               BASE_URL, VALID_FORECAST_JSON, copy_update,
                               VALID_FX_VALUE_JSON, VALID_FX_VALUE_CSV,
-                              VALID_FORECAST_AGG_JSON)
+                              VALID_FORECAST_AGG_JSON, UNSORTED_FX_VALUE_JSON)
 
 
 INVALID_NAME = copy_update(VALID_FORECAST_JSON, 'name', 'Bad semicolon;')
@@ -159,11 +159,13 @@ WRONG_DATE_FORMAT_CSV = "timestamp,value\nksdfjgn,32.93"
 NON_NUMERICAL_VALUE_CSV = "timestamp,value\n2018-10-29T12:04:00:00+00,fgh" # NOQA
 
 
-def test_post_forecast_values_valid_json(api, forecast_id, mock_previous):
+@pytest.mark.parametrize('vals', (VALID_FX_VALUE_JSON, UNSORTED_FX_VALUE_JSON))
+def test_post_forecast_values_valid_json(api, forecast_id, mock_previous,
+                                         vals):
     mock_previous.return_value = pd.Timestamp('2019-01-22T17:44Z')
     res = api.post(f'/forecasts/single/{forecast_id}/values',
                    base_url=BASE_URL,
-                   json=VALID_FX_VALUE_JSON)
+                   json=vals)
     assert res.status_code == 201
 
 

--- a/sfa_api/utils/request_handling.py
+++ b/sfa_api/utils/request_handling.py
@@ -391,7 +391,7 @@ def restrict_forecast_upload_window(extra_parameters, get_forecast,
         return
 
     try:
-        fx_dict = get_forecast()
+        fx_dict = get_forecast().copy()
     except (StorageAuthError, NotFoundException):
         raise NotFoundException(errors={
             '404': 'Cannot read forecast or forecast does not exist'})

--- a/sfa_api/utils/request_handling.py
+++ b/sfa_api/utils/request_handling.py
@@ -400,8 +400,11 @@ def restrict_forecast_upload_window(extra_parameters, get_forecast,
     fx = Forecast.from_dict(fx_dict)
     next_issue_time = fx_utils.get_next_issue_time(
         fx, _current_utc_timestamp())
-    issue_time_of_values = first_time - fx.lead_time_to_start
-    if issue_time_of_values != next_issue_time:
+    expected_start = next_issue_time + fx.lead_time_to_start
+    if fx.interval_label == 'ending':
+        expected_start += fx.interval_length
+    if first_time != expected_start:
         raise BadAPIRequest(errors={'issue_time': (
-            f'Currently only accepting forecasts issued for {next_issue_time}'
+            f'Currently only accepting forecasts issued for {next_issue_time}.'
+            f' Expecting forecast series to start at {expected_start}.'
         )})

--- a/sfa_api/utils/request_handling.py
+++ b/sfa_api/utils/request_handling.py
@@ -331,3 +331,42 @@ def validate_index_period(index, interval_length, previous_time):
                 f'{previous_time.isoformat()}.')
     if errors:
         raise BadAPIRequest({'timestamp': errors})
+
+
+def validate_forecast_values(forecast_df):
+    """Validates that posted values are parseable and of the expectedtypes.
+
+    Parameters
+    ----------
+    forecast_df: Pandas DataFrame
+
+    Raises
+    ------
+    BadAPIRequestError
+        If an expected field is missing or contains an entry of incorrect
+        type.
+    """
+    errors = {}
+    try:
+        forecast_df['value'] = pd.to_numeric(forecast_df['value'],
+                                             downcast='float')
+    except ValueError:
+        error = ('Invalid item in "value" field. Ensure that all values '
+                 'are integers, floats, empty, NaN, or NULL.')
+        errors.update({'value': [error]})
+    except KeyError:
+        errors.update({'value': ['Missing "value" field.']})
+    try:
+        forecast_df['timestamp'] = pd.to_datetime(
+            forecast_df['timestamp'],
+            utc=True)
+    except ValueError:
+        error = ('Invalid item in "timestamp" field. Ensure that '
+                 'timestamps are ISO8601 compliant')
+        errors.update({'timestamp': [error]})
+    except KeyError:
+        errors.update({'timestamp': ['Missing "timestamp" field.']})
+    if errors:
+        raise BadAPIRequest(errors)
+
+

--- a/sfa_api/utils/request_handling.py
+++ b/sfa_api/utils/request_handling.py
@@ -387,6 +387,32 @@ def _current_utc_timestamp():
 
 def restrict_forecast_upload_window(extra_parameters, get_forecast,
                                     first_time):
+    """
+    Check that the first_time falls within the window before the
+    next initialization time of the forecast from the current time.
+    Accounts for forecast lead_time_to_start and interval_label.
+    Requires 'read' permission on the forecast in question.
+
+    Parameters
+    ----------
+    extra_parameters : str
+        The extra_parameters string for the forecast. If
+        '"restrict_upload": true' is not found in the string, no restriction
+        occurs and this function returns immediately.
+    get_forecast : func
+        Function to get the forecast from the database.
+    first_time : datetime-like
+        First timestamp in the posted forecast timeseries.
+
+    Raises
+    ------
+    NotFoundException
+        When the user does not have 'read' permission for the forecast or
+        it doesn't exist.
+    BadAPIRequest
+        If the first_time of the timeseries is not consistent for the
+        next initaliziation time of the forecast.
+    """
     if not _restrict_in_extra(extra_parameters):
         return
 

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -1423,19 +1423,25 @@ def user_exists():
     return exists.get(f"does_user_exist('{current_user}')") == 1
 
 
-def _set_previous_time(previous_time):
+def _set_previous_time(out):
     # easier mocking
+    previous_time = out['previous_time']
     if previous_time is not None:
         previous_time = pd.Timestamp(previous_time)
     return previous_time
+
+
+def _set_extra_params(out):
+    # for mocking
+    return out['extra_parameters']
 
 
 def _read_metadata_for_write(obj_id, type_, start):
     out = _call_procedure_for_single(
         'read_metadata_for_value_write', obj_id, type_, start)
     interval_length = out['interval_length']
-    previous_time = _set_previous_time(out['previous_time'])
-    extra_parameters = out['extra_parameters']
+    previous_time = _set_previous_time(out)
+    extra_parameters = _set_extra_params(out)
     return interval_length, previous_time, extra_parameters
 
 

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -165,7 +165,8 @@ def _call_procedure_for_single(procedure_name, *args, cursor_type='dict'):
     """Wrapper handling try/except logic when a single value is expected
     """
     try:
-        result = _call_procedure(procedure_name, *args, cursor_type='dict')[0]
+        result = _call_procedure(procedure_name, *args,
+                                 cursor_type=cursor_type)[0]
     except IndexError:
         raise StorageAuthError()
     return result
@@ -1434,7 +1435,8 @@ def _read_metadata_for_write(obj_id, type_, start):
         'read_metadata_for_value_write', obj_id, type_, start)
     interval_length = out['interval_length']
     previous_time = _set_previous_time(out['previous_time'])
-    return interval_length, previous_time
+    extra_parameters = out['extra_parameters']
+    return interval_length, previous_time, extra_parameters
 
 
 def read_metadata_for_forecast_values(forecast_id, start):
@@ -1451,9 +1453,11 @@ def read_metadata_for_forecast_values(forecast_id, start):
     Returns
     -------
     interval_length : int
-        The interval length of the observation
+        The interval length of the forecast
     previous_time : pandas.Timestamp or None
        The most recent timestamp before start or None if no times
+    extra_parameters : str
+       The extra parameters of the forecast
 
     Raises
     ------
@@ -1477,9 +1481,11 @@ def read_metadata_for_cdf_forecast_values(forecast_id, start):
     Returns
     -------
     interval_length : int
-        The interval length of the observation
+        The interval length of the forecast
     previous_time : pandas.Timestamp or None
        The most recent timestamp before start or None if no times
+    extra_parameters : str
+       The extra parameters of the forecast
 
     Raises
     ------
@@ -1507,6 +1513,8 @@ def read_metadata_for_observation_values(observation_id, start):
         The interval length of the observation
     previous_time : pandas.Timestamp or None
        The most recent timestamp before start or None if no times
+    extra_parameters : str
+       The extra parameters of the observation
 
     Raises
     ------

--- a/sfa_api/utils/tests/test_request_handling.py
+++ b/sfa_api/utils/tests/test_request_handling.py
@@ -3,8 +3,10 @@ import pandas.testing as pdt
 import pytest
 
 
+from sfa_api.conftest import VALID_FORECAST_JSON
 from sfa_api.utils import request_handling
-from sfa_api.utils.errors import BadAPIRequest
+from sfa_api.utils.errors import (
+    BadAPIRequest, StorageAuthError, NotFoundException)
 
 
 @pytest.mark.parametrize('start,end', [
@@ -212,6 +214,12 @@ def test_parse_to_timestamp_error(dt_string):
                        '2019-09-01T0020Z']),
      7,
      pd.Timestamp('2019-08-31T2352Z')),
+    # out of order
+    pytest.param(
+        pd.DatetimeIndex(['2019-09-01T0013Z', '2019-09-01T0006Z',
+                          '2019-09-01T0020Z']),
+        7,
+        pd.Timestamp('2019-08-31T2352Z'), marks=pytest.mark.xfail),
     (pd.date_range(start='2019-03-10 00:00', end='2019-03-10 05:00',
                    tz='America/Denver', freq='1h'),
      60, None),  # DST transition
@@ -308,3 +316,68 @@ def test_validate_index_period_previous(index, interval_length, previous_time):
     errs = e.value.errors['timestamp']
     assert len(errs) == 1
     assert 'previous time' in errs[0]
+
+
+@pytest.mark.parametrize('ep,res', [
+    ('{"restrict_upload": true}', True),
+    ('{"restrict_upload": true, "other_key": 1}', True),
+    ('{"restrict_upload" : true}', True),
+    ('{"restrict_upload" : True}', True),
+    ('{"restrict_upload": 1}', False),
+    ('{"restrict_upload": false}', False),
+    ('{"restrict_uploa": true}', False),
+    ('{"upload_restrict_upload": true}', False),
+])
+def test__restrict_in_extra(ep, res):
+    assert request_handling._restrict_in_extra(ep) is res
+
+
+def test_restrict_upload_window_noop():
+    assert request_handling.restrict_forecast_upload_window(
+        '', None, None) is None
+
+
+@pytest.mark.parametrize('now,first', [
+    (pd.Timestamp('2019-11-01T11:59Z'), pd.Timestamp('2019-11-01T13:00Z')),
+    (pd.Timestamp('2019-11-01T12:00Z'), pd.Timestamp('2019-11-01T13:00Z')),
+    (pd.Timestamp('2019-11-01T00:00Z'), pd.Timestamp('2019-11-01T13:00Z')),
+    (pd.Timestamp('2019-11-01T12:01Z'), pd.Timestamp('2019-11-02T13:00Z')),
+])
+def test_restrict_upload_window(mocker, now, first):
+    fxd = VALID_FORECAST_JSON.copy()
+    ep = '{"restrict_upload": true}'
+    mocker.patch(
+        'sfa_api.utils.request_handling._current_utc_timestamp',
+        return_value=now)
+    request_handling.restrict_forecast_upload_window(ep, lambda: fxd, first)
+
+
+def test_restrict_upload_window_cant_get(mocker):
+    now = pd.Timestamp('2019-11-01T11:59Z')
+    first = pd.Timestamp('2019-11-01T13:00Z')
+
+    ep = '{"restrict_upload": true}'
+    mocker.patch(
+        'sfa_api.utils.request_handling._current_utc_timestamp',
+        return_value=now)
+    get = mocker.MagicMock(side_effect=StorageAuthError)
+    with pytest.raises(NotFoundException):
+        request_handling.restrict_forecast_upload_window(ep, get, first)
+
+
+@pytest.mark.parametrize('now,first', [
+    (pd.Timestamp('2019-11-01T11:59Z'), pd.Timestamp('2019-11-01T14:00Z')),
+    (pd.Timestamp('2019-11-01T12:00:00.000001Z'),
+     pd.Timestamp('2019-11-01T13:00Z')),
+    (pd.Timestamp('2019-11-01T11:59Z'), pd.Timestamp('2019-11-02T13:00Z')),
+])
+def test_restrict_upload_window_bad(mocker, now, first):
+    fxd = VALID_FORECAST_JSON.copy()
+    ep = '{"restrict_upload": true}'
+    mocker.patch(
+        'sfa_api.utils.request_handling._current_utc_timestamp',
+        return_value=now)
+    with pytest.raises(BadAPIRequest) as err:
+        request_handling.restrict_forecast_upload_window(
+            ep, lambda: fxd, first)
+    assert 'only accepting' in err.value.errors['issue_time'][0]

--- a/sfa_api/utils/tests/test_request_handling.py
+++ b/sfa_api/utils/tests/test_request_handling.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import pandas.testing as pdt
 import pytest
+import pytz
 
 
 from sfa_api.conftest import (
@@ -331,6 +332,12 @@ def test_validate_index_period_previous(index, interval_length, previous_time):
 ])
 def test__restrict_in_extra(ep, res):
     assert request_handling._restrict_in_extra(ep) is res
+
+
+def test__current_utc_timestamp():
+    t = request_handling._current_utc_timestamp()
+    assert isinstance(t, pd.Timestamp)
+    assert t.tzinfo == pytz.utc
 
 
 def test_restrict_upload_window_noop():

--- a/sfa_api/utils/tests/test_request_handling.py
+++ b/sfa_api/utils/tests/test_request_handling.py
@@ -420,3 +420,25 @@ def test_restrict_upload_window_bad(mocker, now, first):
         request_handling.restrict_forecast_upload_window(
             ep, lambda: fxd, first)
     assert 'only accepting' in err.value.errors['issue_time'][0]
+
+
+@pytest.mark.parametrize('now,first,label', [
+    (pd.Timestamp('2019-11-01T11:59Z'), pd.Timestamp('2019-11-01T13:00Z'),
+     'beginning'),
+    (pd.Timestamp('2019-11-01T11:59Z'), pd.Timestamp('2019-11-01T13:00Z'),
+     'instant'),
+    (pd.Timestamp('2019-11-01T12:00Z'), pd.Timestamp('2019-11-01T13:05Z'),
+     'ending'),
+    pytest.param(
+        pd.Timestamp('2019-11-01T11:59Z'), pd.Timestamp('2019-11-01T13:00Z'),
+        'ending', marks=pytest.mark.xfail
+    ),
+])
+def test_restrict_upload_interval_label(mocker, now, first, label):
+    fxd = VALID_FORECAST_JSON.copy()
+    fxd['interval_label'] = label
+    ep = '{"restrict_upload": true}'
+    mocker.patch(
+        'sfa_api.utils.request_handling._current_utc_timestamp',
+        return_value=now)
+    request_handling.restrict_forecast_upload_window(ep, lambda: fxd, first)

--- a/sfa_api/utils/tests/test_storage_interface.py
+++ b/sfa_api/utils/tests/test_storage_interface.py
@@ -786,65 +786,71 @@ def test_create_new_user(sql_app, fake_user, run, nocommit_cursor):
 def test_read_metadata_for_observation_values(sql_app, user, nocommit_cursor,
                                               observation):
     start = pd.Timestamp('1970-01-02')
-    iv, pt = storage_interface.read_metadata_for_observation_values(
+    iv, pt, ep = storage_interface.read_metadata_for_observation_values(
         observation['observation_id'], start)
     assert iv == observation['interval_length']
     assert pt is None
+    assert isinstance(ep, str)
 
 
 def test_read_metadata_for_observation_values_start(
         sql_app, user, nocommit_cursor):
     observation = list(demo_observations.values())[0]
     start = pd.Timestamp('2019-09-02')
-    iv, pt = storage_interface.read_metadata_for_observation_values(
+    iv, pt, ep = storage_interface.read_metadata_for_observation_values(
         observation['observation_id'], start)
     assert iv == observation['interval_length']
     assert isinstance(pt, pd.Timestamp)
     assert pt.tzinfo is not None
+    assert isinstance(ep, str)
 
 
 @pytest.mark.parametrize('forecast', demo_forecasts.values())
 def test_read_metadata_for_forecast_values(sql_app, user, nocommit_cursor,
                                            forecast):
     start = pd.Timestamp('1970-01-02')
-    iv, pt = storage_interface.read_metadata_for_forecast_values(
+    iv, pt, ep = storage_interface.read_metadata_for_forecast_values(
         forecast['forecast_id'], start)
     assert iv == forecast['interval_length']
     assert pt is None
+    assert isinstance(ep, str)
 
 
 def test_read_metadata_for_forecast_values_start(
         sql_app, user, nocommit_cursor):
     forecast = list(demo_forecasts.values())[0]
     start = pd.Timestamp('2019-09-02')
-    iv, pt = storage_interface.read_metadata_for_forecast_values(
+    iv, pt, ep = storage_interface.read_metadata_for_forecast_values(
         forecast['forecast_id'], start)
     assert iv == forecast['interval_length']
     assert isinstance(pt, pd.Timestamp)
     assert pt.tzinfo is not None
+    assert isinstance(ep, str)
 
 
 @pytest.mark.parametrize('cdf_forecast_id', demo_single_cdf.keys())
 def test_read_metadata_for_cdf_forecast_values(
         sql_app, user, nocommit_cursor, cdf_forecast_id):
     start = pd.Timestamp('1970-01-02')
-    iv, pt = storage_interface.read_metadata_for_cdf_forecast_values(
+    iv, pt, ep = storage_interface.read_metadata_for_cdf_forecast_values(
         cdf_forecast_id, start)
     assert iv == demo_group_cdf[demo_single_cdf[
         cdf_forecast_id]['parent']]['interval_length']
     assert pt is None
+    assert isinstance(ep, str)
 
 
 def test_read_metadata_for_cdf_forecast_values_start(
         sql_app, user, nocommit_cursor):
     cdf_forecast_id = list(demo_single_cdf.keys())[0]
     start = pd.Timestamp('2019-09-02')
-    iv, pt = storage_interface.read_metadata_for_cdf_forecast_values(
+    iv, pt, ep = storage_interface.read_metadata_for_cdf_forecast_values(
         cdf_forecast_id, start)
     assert iv == demo_group_cdf[demo_single_cdf[
         cdf_forecast_id]['parent']]['interval_length']
     assert isinstance(pt, pd.Timestamp)
     assert pt.tzinfo is not None
+    assert isinstance(ep, str)
 
 
 @pytest.mark.parametrize('aggregate_id', demo_aggregates.keys())


### PR DESCRIPTION
when ``"restrict_upload": true`` is in extra_parameters for a forecast (or cdf fx), only values that start with what should be the next init_time + lead_time_to_start are allowed to be posted.

I.e for a forecast with issue_time_of_day = 05:00 , run length of 6 hours, and lead_time_to_start of 1 hour, at 10:00 only a forecast series that begins with 12:00 will be allowed. And from 11:00:00.00001 to 16:59:59.99999, only a series with first time of 18:00 is allowed.