### PR TITLE
add user id -> email endpoint

### DIFF
--- a/datastore/migrations/0029_get_user_id.down.sql
+++ b/datastore/migrations/0029_get_user_id.down.sql
@@ -1,2 +1,2 @@
-DROP PROCEDURE IF EXISTS read_user_id;
-DROP PROCEDURE IF EXISTS read_auth0id;
+DROP PROCEDURE read_user_id;
+DROP PROCEDURE read_auth0id;

--- a/datastore/migrations/0029_get_user_id.down.sql
+++ b/datastore/migrations/0029_get_user_id.down.sql
@@ -1,1 +1,2 @@
-DROP PROCEDURE read_user_id;
+DROP PROCEDURE IF EXISTS read_user_id;
+DROP PROCEDURE IF EXISTS read_auth0id;

--- a/datastore/migrations/0029_get_user_id.up.sql
+++ b/datastore/migrations/0029_get_user_id.up.sql
@@ -23,6 +23,7 @@ GRANT EXECUTE ON PROCEDURE read_user_id TO 'apiuser'@'%';
 CREATE DEFINER = 'select_rbac'@'localhost' PROCEDURE read_auth0id (
     IN auth0id VARCHAR(32), IN struserid CHAR(36))
 COMMENT 'Read the auth0id of another user if both orgs have accepted tou'
+READS SQL DATA SQL SECURITY DEFINER
 BEGIN
     DECLARE allowed BOOLEAN DEFAULT FALSE;
     DECLARE caller_id BINARY(16);

--- a/datastore/tests/test_reads.py
+++ b/datastore/tests/test_reads.py
@@ -1457,3 +1457,26 @@ def test_read_user_id_caller_unaffiliated(cursor, insertuser,
     with pytest.raises(pymysql.err.OperationalError) as e:
         cursor.callproc('read_user_id', (u2['auth0_id'], insertuser.auth0id))
     assert e.value.args[0] == 1142
+
+
+def test_read_auth0id(cursor, insertuser, new_user):
+    u2 = new_user()
+    cursor.callproc('read_auth0id', (insertuser.auth0id, bin_to_uuid(u2['id'])))
+    u2auth0id = cursor.fetchone()[0]
+    assert u2auth0id == u2['auth0_id']
+
+
+def test_read_auth0id_other_unaffiliated(cursor, insertuser,
+                                         new_unaffiliated_user):
+    u2 = new_unaffiliated_user()
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('read_auth0id', (insertuser.auth0id, bin_to_uuid(u2['id'])))
+    assert e.value.args[0] == 1142
+
+
+def test_read_auth0id_caller_unaffiliated(cursor, insertuser,
+                                          new_unaffiliated_user):
+    u2 = new_unaffiliated_user()
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('read_auth0id', (u2['auth0_id'], bin_to_uuid(insertuser.user['id'])))
+    assert e.value.args[0] == 1142

--- a/sfa_api/tests/rbac/test_users.py
+++ b/sfa_api/tests/rbac/test_users.py
@@ -221,3 +221,18 @@ def test_add_role_to_user_already_granted_lost_perms(
     assert role_id in roles_on_user
     add_role = api.post(normal_paths + f'/roles/{role_id}', BASE_URL)
     assert add_role.status_code == 404
+
+
+def test_user_email(api, user_id):
+    res = api.get(f'/users/{user_id}/email', BASE_URL)
+    assert res.data.decode('utf-8') == 'testing@solarforecastarbiter.org'
+
+
+def test_user_email_user_dne(api, missing_id):
+    res = api.get(f'/users/{missing_id}/email', BASE_URL)
+    assert res.status_code == 404
+
+
+def test_user_email_user_unaffiliated(api, unaffiliated_userid):
+    res = api.get(f'/users/{unaffiliated_userid}/email', BASE_URL)
+    assert res.status_code == 404

--- a/sfa_api/users.py
+++ b/sfa_api/users.py
@@ -160,6 +160,32 @@ class CurrentUserView(MethodView):
         return jsonify(UserSchema().dump(user_info))
 
 
+class UserIdToEmailView(MethodView):
+    def get(self, user_id):
+        """
+        ---
+        summary: Get user email from user id.
+        tags:
+          - Users
+        responses:
+          200:
+            description: The user's email.
+            content:
+              text/plain:
+                schema:
+                  type: string
+                  example: testing@solarforecastarbiter.org
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+        """
+        storage = get_storage()
+        auth0_id = storage.read_auth0id(user_id)
+        email = get_email_of_user(auth0_id)
+        return email
+
+
 class UserRolesManagementByEmailView(UserRolesManagementView):
     def post(self, email, role_id):
         """
@@ -274,6 +300,9 @@ user_blp.add_url_rule(
 user_blp.add_url_rule(
     '/current',
     view_func=CurrentUserView.as_view('current_user'))
+user_blp.add_url_rule(
+    '/<user_id>/email',
+    view_func=UserIdToEmailView.as_view('user_email'))
 
 
 user_email_blp = Blueprint(

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -1756,3 +1756,25 @@ def read_user_id(auth0_id):
     """
     return _call_procedure_for_single('read_user_id', auth0_id,
                                       cursor_type='standard')[0]
+
+
+def read_auth0id(user_id):
+    """Read the auth0 id of another user. Only allowed if both users
+
+    Parameters
+    ----------
+    user_id: string
+        User id of the auth0id to read.
+
+    Returns
+    -------
+    str
+        The user's auth0 id.
+
+    Raises
+    ------
+    StorageAuthError
+        If either user's organization has not accepted the terms of use.
+    """
+    return _call_procedure_for_single('read_auth0id', user_id,
+                                      cursor_type='standard')[0]

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -1759,7 +1759,8 @@ def read_user_id(auth0_id):
 
 
 def read_auth0id(user_id):
-    """Read the auth0 id of another user. Only allowed if both users
+    """Read the auth0 id of another user. Only allowed if both users are affiliated
+        with organizations that have accepted the TOU.
 
     Parameters
     ----------


### PR DESCRIPTION
Creates an uuid to email conversion endpoint. Requires that both the caller and target belong to organizations that have accepted the TOU. I've added the mysql to the read_user_id migration to save space, but if it should be in it's own migration I can move it.