### PR TITLE
add job user for an org

### DIFF
--- a/datastore/migrations/0030_job_user.down.sql
+++ b/datastore/migrations/0030_job_user.down.sql
@@ -1,3 +1,6 @@
+DROP PROCEDURE create_forecast_generation_role;
+DROP PROCEDURE create_data_validation_role;
+DROP PROCEDURE create_report_creation_role;
 DROP PROCEDURE create_job_user;
 DROP PROCEDURE store_token;
 DROP USER 'token_user'@'localhost';

--- a/datastore/migrations/0030_job_user.down.sql
+++ b/datastore/migrations/0030_job_user.down.sql
@@ -1,0 +1,4 @@
+DROP PROCEDURE create_job_user;
+DROP PROCEDURE store_token;
+DROP USER 'token_user'@'localhost';
+DROP TABLE arbiter_data.job_tokens;

--- a/datastore/migrations/0030_job_user.down.sql
+++ b/datastore/migrations/0030_job_user.down.sql
@@ -1,3 +1,4 @@
+DROP PROCEDURE grant_job_role;
 DROP PROCEDURE create_forecast_generation_role;
 DROP PROCEDURE create_data_validation_role;
 DROP PROCEDURE create_report_creation_role;

--- a/datastore/migrations/0030_job_user.up.sql
+++ b/datastore/migrations/0030_job_user.up.sql
@@ -1,0 +1,49 @@
+CREATE TABLE arbiter_data.job_tokens(
+  id BINARY(16) NOT NULL,
+  token VARCHAR(256) NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  modified_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+  PRIMARY KEY (id),
+  FOREIGN KEY (id)
+    REFERENCES users(id)
+    ON DELETE CASCADE ON UPDATE RESTRICT
+) ENGINE=INNODB ENCRYPTION='Y' ROW_FORMAT=COMPRESSED;
+
+
+CREATE USER 'token_user'@'localhost' IDENTIFIED WITH caching_sha2_password as '$A$005$THISISACOMBINATIONOFINVALIDSALTANDPASSWORDTHATMUSTNEVERBRBEUSED' ACCOUNT LOCK;
+
+
+CREATE DEFINER = 'token_user'@'localhost' PROCEDURE store_token (IN auth0id VARCHAR(32), IN token VARCHAR(256))
+COMMENT 'Store the encrypted token in the table'
+MODIFIES SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE user_id BINARY(16);
+    SET user_id = (SELECT id FROM arbiter_data.users WHERE auth0_id = auth0id);
+    INSERT INTO arbiter_data.job_tokens (id, token) VALUES (user_id, token)
+      ON DUPLICATE KEY UPDATE token = VALUES(token);
+END;
+
+GRANT SELECT(id, auth0_id) ON arbiter_data.users TO 'token_user'@'localhost';
+GRANT SELECT, INSERT, UPDATE(token) ON arbiter_data.job_tokens TO 'token_user'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.store_token TO 'token_user'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.store_token TO 'frameworkadmin'@'%';
+
+
+CREATE DEFINER = 'insert_rbac'@'localhost' PROCEDURE create_job_user(IN auth0id VARCHAR(32), IN orgid CHAR(36))
+COMMENT 'Inserts a new job user into the organization and add permission to read reference data only, returning new user id'
+MODIFIES SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE userid BINARY(16);
+    DECLARE binorgid BINARY(16);
+    SET userid = UUID_TO_BIN(UUID(), 1);
+    SET binorgid = UUID_TO_BIN(orgid, 1);
+    INSERT INTO arbiter_data.users (id, auth0_id, organization_id) VALUES (
+        userid, auth0id, binorgid);
+    CALL arbiter_data.add_reference_role_to_user(userid);
+    CALL arbiter_data.create_default_user_role(userid, binorgid);
+    SELECT BIN_TO_UUID(userid, 1);
+END;
+
+GRANT EXECUTE ON PROCEDURE arbiter_data.create_job_user TO 'insert_rbac'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.create_job_user TO 'frameworkadmin'@'%';

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ setup(
         'pymysql',
         'solarforecastarbiter',
         'sentry_sdk',
-        'blinker'
+        'blinker',
+        'cryptography'
     ],
     extras_require=EXTRAS_REQUIRE,
     project_urls={

--- a/sfa_api/admincli.py
+++ b/sfa_api/admincli.py
@@ -3,7 +3,7 @@ import sys
 
 import click
 from flask import Flask
-from flask.cli import AppGroup
+from flask.cli import FlaskGroup
 import pymysql
 
 
@@ -11,9 +11,13 @@ from sfa_api.utils.errors import StorageAuthError
 
 
 app = Flask(__name__)
-admin_cli = AppGroup(
-    'admin',
-    help="Tool for administering the Solar Forecast Arbiter Framework")
+
+
+@click.group(cls=FlaskGroup, create_app=lambda: app,
+             add_default_commands=False)
+def admin_cli():
+    """Tool for administering the Solar Forecast Arbiter Framework"""
+    pass
 
 
 config_opt = click.option(
@@ -212,6 +216,3 @@ def delete_user(user_id, **kwargs):
             raise
     else:
         click.echo(f'User {user_id} deleted successfully.')
-
-
-app.cli.add_command(admin_cli)

--- a/sfa_api/admincli.py
+++ b/sfa_api/admincli.py
@@ -16,7 +16,7 @@ app = Flask(__name__)
 
 @click.group(cls=FlaskGroup, create_app=lambda: app,
              add_default_commands=False)
-def admin_cli():
+def admin_cli():  # pragma: no cover
     """Tool for administering the Solar Forecast Arbiter Framework"""
     pass
 

--- a/sfa_api/admincli.py
+++ b/sfa_api/admincli.py
@@ -108,7 +108,21 @@ def create_job_user(organization_name, encryption_key, **kwargs):
     sec_token = f.encrypt(refresh_token.encode())
     storage._call_procedure('store_token', auth0_id, sec_token,
                             with_current_user=False)
-    click.echo(f'Created user {username}')
+    click.echo(f'Created user {username} with Auth0 ID {auth0_id}')
+
+
+@admin_cli.command('add-job-role')
+@with_default_options
+@click.argument('user_id', required=True, type=click.UUID)
+@click.argument('role_name', nargs=-1, type=click.Choice(
+    ['Create reports', 'Validate observations',
+     'Generate reference forecasts']))
+def add_job_role(user_id, role_name, **kwargs):
+    import sfa_api.utils.storage_interface as storage
+    for role in role_name:
+        storage._call_procedure('grant_job_role', str(user_id), role,
+                                with_current_user=False)
+        click.echo(f'Added role {role} to user {user_id}')
 
 
 @admin_cli.command('add-user-to-org')

--- a/sfa_api/tests/test_admincli.py
+++ b/sfa_api/tests/test_admincli.py
@@ -352,3 +352,49 @@ def test_create_job_user_no_org(app_cli_runner, mocker):
         ['--encryption-key', Fernet.generate_key()] + auth_args + [org])
     assert res.exit_code == 1
     assert 'Organization Organization 1 not found' in res.output
+
+
+@pytest.mark.parametrize('role', [
+    'Create reports', 'Validate observations',
+    'Generate reference forecasts'
+])
+def test_add_job_role(app_cli_runner, user_id, role):
+    res = app_cli_runner.invoke(admincli.add_job_role,
+                                auth_args + [user_id, role])
+    assert res.exit_code == 0
+
+
+def test_add_job_role_bad_role(app_cli_runner, user_id):
+    res = app_cli_runner.invoke(admincli.add_job_role,
+                                auth_args + [user_id, 'Read all'])
+    assert res.exit_code != 0
+
+
+def test_add_job_role_multiple(app_cli_runner, user_id):
+    res = app_cli_runner.invoke(
+        admincli.add_job_role,
+        auth_args + [user_id, 'Create reports', 'Validate observations'])
+    assert res.exit_code == 0
+
+
+@pytest.mark.parametrize('role', [
+    'Create reports', 'Validate observations',
+    'Generate reference forecasts'
+])
+def test_add_job_role_already_present(app_cli_runner, user_id, role):
+    res = app_cli_runner.invoke(admincli.add_job_role,
+                                auth_args + [user_id, role])
+    assert res.exit_code == 0
+    res = app_cli_runner.invoke(admincli.add_job_role,
+                                auth_args + [user_id, role])
+    assert res.exit_code != 0
+
+
+@pytest.mark.parametrize('role', [
+    'Create reports', 'Validate observations',
+    'Generate reference forecasts'
+])
+def test_add_job_role_user_dne(app_cli_runner, missing_id, role):
+    res = app_cli_runner.invoke(admincli.add_job_role,
+                                auth_args + [missing_id, role])
+    assert res.exit_code != 0

--- a/sfa_api/utils/auth0_info.py
+++ b/sfa_api/utils/auth0_info.py
@@ -334,7 +334,7 @@ def get_refresh_token(email, password):
             }
     req = requests.post(
         current_app.config['AUTH0_BASE_URL'] + '/oauth/token',
-        data=body
+        json=body
     )
     req.raise_for_status()
     return req.json()['refresh_token']

--- a/sfa_api/utils/auth0_info.py
+++ b/sfa_api/utils/auth0_info.py
@@ -1,6 +1,8 @@
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 import logging
+import secrets
+import string
 
 
 from flask import current_app
@@ -249,3 +251,122 @@ def get_auth0_id_of_user(email):
                                  token_redis_connection(),
                                  auth0_token(),
                                  current_app.config)
+
+
+def random_password():
+    """
+    Generate a random password of letters, digits, punctuation, and whitespace
+    with a random length between 32 and 48 characters.
+    """
+    pass_len = secrets.choice(range(32, 49))
+    return ''.join(secrets.choice(string.printable)
+                   for _ in range(pass_len))
+
+
+def create_user(email, password, verified=False):
+    """
+    Create a new Auth0 user.
+
+    Parameters
+    ----------
+    email : str
+        The email address of the new user.
+    password : str
+        The password for the user.
+    verified : boolean, default False
+        Whether or not to set 'email_verified' with Auth0
+
+    Returns
+    -------
+    user_id : str
+        The Auth0 user id of the newly created user
+
+    Raises
+    ------
+    HTTPError
+        If the request to the Auth0 API fails
+    """
+    token = auth0_token()
+    config = current_app.config
+    body = {'email': email,
+            'password': password,
+            'email_verified': verified,
+            'connection': 'Username-Password-Authentication'}
+    headers = {'content-type': 'application/json',
+               'authorization': f'Bearer {token}'}
+    req = requests.post(
+        config['AUTH0_BASE_URL'] + '/api/v2/users',
+        json=body,
+        headers=headers)
+    req.raise_for_status()
+    user_id = req.json()['user_id']
+    return user_id
+
+
+def get_refresh_token(email, password):
+    """
+    Requests a refresh token from Auth0
+
+    Parameters
+    ----------
+    email : str
+        The email address of the new user.
+    password : str
+        The password for the user.
+
+    Returns
+    -------
+    refresh_token : str
+        The refresh token
+
+    Raises
+    ------
+    HTTPError
+        If the request to the Auth0 API fails
+    """
+    body = {'grant_type': 'password',
+            'username': email,
+            'password': password,
+            'client_id': current_app.config['AUTH0_CLIENT_ID'],
+            'client_secret': current_app.config['AUTH0_CLIENT_SECRET'],
+            'audience': current_app.config['AUTH0_AUDIENCE'],
+            'scope': 'offline_access'
+            }
+    req = requests.post(
+        current_app.config['AUTH0_BASE_URL'] + '/oauth/token',
+        data=body
+    )
+    req.raise_for_status()
+    return req.json()['refresh_token']
+
+
+def exchange_refresh_token(refresh_token):
+    """
+    Requests an access token from Auth0 from a refresh token
+
+    Parameters
+    ----------
+    refresh_token : str
+        The refresh token to use.
+
+    Returns
+    -------
+    access_token : str
+        The access token to be used to authenticate with the SFA API
+
+    Raises
+    ------
+    HTTPError
+        If the request to the Auth0 API fails
+    """
+    body = {'grant_type': 'refresh_token',
+            'client_id': current_app.config['AUTH0_CLIENT_ID'],
+            'client_secret': current_app.config['AUTH0_CLIENT_SECRET'],
+            'audience': current_app.config['AUTH0_AUDIENCE'],
+            'refresh_token': refresh_token
+            }
+    req = requests.post(
+        current_app.config['AUTH0_BASE_URL'] + '/oauth/token',
+        json=body)
+    req.raise_for_status()
+    return req.json()['access_token']


### PR DESCRIPTION
The idea is that each org will have a number of background jobs (daily data validation, automatic report generation, automatic forecast generation in trials), and these jobs require an authenticated user. So, we create a job user (in auth0 and the db) for each org and store an encrypted refresh token in the database to be used when a scheduled job runs. 