### PR TITLE
Log errors when getting Auth0 token instead of raising

### DIFF
--- a/sfa_api/utils/auth0_info.py
+++ b/sfa_api/utils/auth0_info.py
@@ -97,13 +97,19 @@ def auth0_token():
 
     Returns
     -------
-    token : str
+    token : str or None
+        Returns None when could not retrieve a token to access the
+        Auth0 Management API
     """
     redis_conn = token_redis_connection()
     token = redis_conn.get('auth0_token')
     token_valid = check_if_token_is_valid(token)
     if token is None or not token_valid:
-        token = get_fresh_auth0_management_token()
+        try:
+            token = get_fresh_auth0_management_token()
+        except (ValueError, requests.HTTPError) as e:
+            logging.error('Failed to retrieve Auth0 token: %r', e)
+            return
         redis_conn.set('auth0_token', token)
     return token
 

--- a/sfa_api/utils/tests/test_auth0_info.py
+++ b/sfa_api/utils/tests/test_auth0_info.py
@@ -87,6 +87,18 @@ def test_auth0_token_not_in_redis(running_app, mocker):
     r.get('auth0_token') == 'atoken'
 
 
+@pytest.mark.parametrize('se', [ValueError, requests.HTTPError])
+def test_auth0_token_no_fresh(running_app, mocker, se):
+    log = mocker.patch('sfa_api.utils.auth0_info.logging.error')
+    mocker.patch(
+        'sfa_api.utils.auth0_info.get_fresh_auth0_management_token',
+        side_effect=se)
+    assert auth0_info.auth0_token() is None
+    r = auth0_info.token_redis_connection()
+    r.get('auth0_token') is None
+    assert log.called
+
+
 @pytest.mark.parametrize('val', [
     'no', 'auth0other',
     pytest.param('auth0|4882lxjlsd0', marks=pytest.mark.xfail)


### PR DESCRIPTION
So later functions can handle the API request error as appropriate
likely returning 'Unable to retrieve'