### PR TITLE
Define a schedule jobs framework

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,22 +53,25 @@ jobs:
   - script: |
       flake8 sfa_api
     displayName: 'flake8'
+    condition: always()
 
   - task: PublishTestResults@2
     inputs:
       testResultsFiles: '**/test-results.xml'
       testRunTitle: 'Python $(python.version)'
-    condition: succeededOrFailed()
+    condition: always()
 
   - task: PublishCodeCoverageResults@1
     inputs:
       codeCoverageTool: Cobertura
       summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
       reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
+    condition: always()
 
   - script: |
       bash <(curl https://codecov.io/bash) -t 8c76f562-08c0-4ad6-be35-026cceabcc1e -f coverage.xml -F adder -F subtractor
     displayName: 'codecov'
+    condition: always()
 
 - job: 'Publish'
   dependsOn: 'Test'

--- a/datastore/migrations/0027_aggregate_forecasts.down.sql
+++ b/datastore/migrations/0027_aggregate_forecasts.down.sql
@@ -1,4 +1,5 @@
 DELETE FROM arbiter_data.forecasts WHERE id = UUID_TO_BIN('39220780-76ae-4b11-bef1-7a75bdc784e3', 1);
+DELETE FROM arbiter_data.forecasts WHERE id = UUID_TO_BIN('49220780-76ae-4b11-bef1-7a75bdc784e3', 1);
 ALTER TABLE arbiter_data.forecasts DROP FOREIGN KEY forecasts_sites_fk,
     DROP FOREIGN KEY forecasts_aggregates_fk,
     ADD FOREIGN KEY forecasts_ibfk_2 (site_id) REFERENCES sites(id) ON DELETE RESTRICT ON UPDATE RESTRICT;

--- a/datastore/migrations/0027_aggregate_forecasts.up.sql
+++ b/datastore/migrations/0027_aggregate_forecasts.up.sql
@@ -125,9 +125,17 @@ INSERT INTO arbiter_data.forecasts (
     @orgid, @aggid,
     'GHI Aggregate FX', 'ghi', '06:00', 60, 'beginning', 5, 1440, 'interval_mean', '',
     TIMESTAMP('2019-03-01 11:55:37'), TIMESTAMP('2019-03-01 11:55:37')
-);
+),  (
+    UUID_TO_BIN('49220780-76ae-4b11-bef1-7a75bdc784e3', 1),
+    @orgid, @aggid,
+    'GHI Aggregate FX 60', 'ghi', '00:00', 0, 'beginning', 60, 1440, 'interval_mean', '',
+    TIMESTAMP('2019-03-01 11:55:37'), TIMESTAMP('2019-03-01 11:55:37')
+    );
 
 INSERT INTO arbiter_data.forecasts_values (id, timestamp, value) SELECT UUID_TO_BIN('39220780-76ae-4b11-bef1-7a75bdc784e3', 1), timestamp, value FROM arbiter_data.forecasts_values where id = UUID_TO_BIN('11c20780-76ae-4b11-bef1-7a75bdc784e3', 1);
+
+INSERT INTO arbiter_data.forecasts_values (id, timestamp, value) SELECT UUID_TO_BIN('49220780-76ae-4b11-bef1-7a75bdc784e3', 1), timestamp, value FROM arbiter_data.forecasts_values where id = UUID_TO_BIN('11c20780-76ae-4b11-bef1-7a75bdc784e3', 1) and MINUTE(timestamp) = 0;
+
 
 
 -- CDF Forecast modifications

--- a/datastore/migrations/0030_job_user.up.sql
+++ b/datastore/migrations/0030_job_user.up.sql
@@ -152,3 +152,6 @@ END;
 GRANT EXECUTE ON PROCEDURE arbiter_data.grant_job_role TO 'insert_rbac'@'localhost';
 GRANT SELECT(id, organization_id, name) ON arbiter_data.roles TO 'insert_rbac'@'localhost';
 GRANT EXECUTE ON PROCEDURE arbiter_data.grant_job_role TO 'frameworkadmin'@'%';
+
+
+INSERT INTO job_tokens (id, token) VALUES (UUID_TO_BIN('0c90950a-7cca-11e9-a81f-54bf64606445', 1), 'gAAAAABd1FW6XEIHNukUg459WHrP4wohBDuO7kA3idZu9G0nI8HYKR3GcnrwZM2jH5oI09ihmkOSO7ZJKThPtd2Nfs0w088qeQ==');

--- a/datastore/migrations/0030_job_user.up.sql
+++ b/datastore/migrations/0030_job_user.up.sql
@@ -65,7 +65,7 @@ BEGIN
      AND description IN (
        'Read all sites', 'Read all observations', 'Read all observation values', 'Read all forecasts',
        'Read all forecast values', 'Read all probabilistic forecasts', 'Read all probabilistic forecast values',
-       'Read all aggregates', 'Read all aggregate values', 'Read all reports', 'Read all report values'
+       'Read all aggregates', 'Read all aggregate values', 'Read all reports', 'Read all report values',
        'Create reports');
     SELECT BIN_TO_UUID(roleid, 1);
 END;

--- a/datastore/migrations/0030_job_user.up.sql
+++ b/datastore/migrations/0030_job_user.up.sql
@@ -65,7 +65,8 @@ BEGIN
      AND description IN (
        'Read all sites', 'Read all observations', 'Read all observation values', 'Read all forecasts',
        'Read all forecast values', 'Read all probabilistic forecasts', 'Read all probabilistic forecast values',
-       'Read all aggregates', 'Read all aggregate values', 'Create reports');
+       'Read all aggregates', 'Read all aggregate values', 'Read all reports', 'Read all report values'
+       'Create reports');
     SELECT BIN_TO_UUID(roleid, 1);
 END;
 

--- a/datastore/migrations/0031_jobs.down.sql
+++ b/datastore/migrations/0031_jobs.down.sql
@@ -1,0 +1,6 @@
+DROP PROCEDURE delete_job;
+DROP PROCEDURE list_jobs;
+DROP PROCEDURE store_job;
+DROP PROCEDURE fetch_token;
+DROP USER 'job_executor'@'%';
+DROP TABLE scheduled_jobs;

--- a/datastore/migrations/0031_jobs.up.sql
+++ b/datastore/migrations/0031_jobs.up.sql
@@ -57,22 +57,14 @@ GRANT EXECUTE ON PROCEDURE arbiter_data.store_job TO 'insert_objects'@'localhost
 GRANT EXECUTE ON PROCEDURE arbiter_data.store_job TO 'frameworkadmin'@'%';
 
 
-CREATE DEFINER = 'select_objects'@'localhost' PROCEDURE list_jobs (IN orgid CHAR(36))
+CREATE DEFINER = 'select_objects'@'localhost' PROCEDURE list_jobs ()
 COMMENT 'List the jobs of an organization'
 READS SQL DATA SQL SECURITY DEFINER
-BEGIN
-    DECLARE binid BINARY(16);
-    SET binid = UUID_TO_BIN(orgid, 1);
-    IF binid IS NULL THEN
-        SELECT BIN_TO_UUID(id, 1) as id, BIN_TO_UUID(organization_id, 1) as organization_id,
-          BIN_TO_UUID(user_id, 1) as user_id, name, job_type, parameters, schedule, version,
-          created_at, modified_at FROM arbiter_data.scheduled_jobs;
-    ELSE
-        SELECT BIN_TO_UUID(id, 1) as id, BIN_TO_UUID(organization_id, 1) as organization_id,
-          BIN_TO_UUID(user_id, 1) as user_id, name, job_type, parameters, schedule, version,
-          created_at, modified_at FROM arbiter_data.scheduled_jobs WHERE organization_id = binid;
-    END IF;
-END;
+SELECT BIN_TO_UUID(id, 1) as id, get_organization_name(organization_id) as organization_name,
+    BIN_TO_UUID(organization_id, 1) as organization_id,
+    BIN_TO_UUID(user_id, 1) as user_id, name, job_type, parameters, schedule, version,
+    created_at, modified_at FROM arbiter_data.scheduled_jobs;
+
 
 GRANT SELECT ON arbiter_data.scheduled_jobs TO 'select_objects'@'localhost';
 GRANT EXECUTE ON PROCEDURE arbiter_data.list_jobs TO 'select_objects'@'localhost';

--- a/datastore/migrations/0031_jobs.up.sql
+++ b/datastore/migrations/0031_jobs.up.sql
@@ -1,0 +1,90 @@
+CREATE TABLE arbiter_data.scheduled_jobs (
+    id BINARY(16) NOT NULL DEFAULT (UUID_TO_BIN(UUID(), 1)),
+    organization_id BINARY(16) NOT NULL,
+    user_id BINARY(16) NOT NULL,
+    name VARCHAR(64) NOT NULL,
+    job_type VARCHAR(64) NOT NULL,
+    parameters JSON NOT NULL,
+    schedule JSON NOT NULL,
+    version TINYINT UNSIGNED NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    modified_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY primary_id (id),
+    UNIQUE name_org_unq (organization_id, name),
+    FOREIGN KEY job_user_fk (user_id)
+        REFERENCES users(id)
+        ON DELETE CASCADE ON UPDATE RESTRICT,
+    FOREIGN KEY job_org_fk (organization_id)
+        REFERENCES organizations(id)
+        ON DELETE CASCADE ON UPDATE RESTRICT
+) ENGINE=INNODB ENCRYPTION='Y' ROW_FORMAT=COMPRESSED;
+
+
+CREATE USER 'job_executor'@'%' IDENTIFIED BY 'thisisaterribleandpublicpassword';
+
+
+CREATE DEFINER = 'token_user'@'localhost' PROCEDURE fetch_token (IN user_id CHAR(36))
+COMMENT 'Fetch the refresh token for the user'
+READS SQL DATA SQL SECURITY DEFINER
+SELECT token FROM arbiter_data.job_tokens WHERE id = UUID_TO_BIN(user_id, 1);
+
+GRANT EXECUTE ON PROCEDURE arbiter_data.fetch_token TO 'token_user'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.fetch_token TO 'job_executor'@'%';
+
+
+CREATE DEFINER = 'insert_objects'@'localhost' PROCEDURE store_job (
+    IN strid CHAR(36), IN userstrid CHAR(36), IN name VARCHAR(32), IN job_type VARCHAR(16),
+    IN parameters JSON, IN schedule JSON, IN version TINYINT)
+COMMENT 'Create a scheduled job object'
+MODIFIES SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    DECLARE userid BINARY(16);
+    DECLARE orgid BINARY(16);
+    SET binid = UUID_TO_BIN(strid, 1);
+    SET userid = UUID_TO_BIN(userstrid, 1);
+    SET orgid = get_object_organization(userid, 'users');
+
+    INSERT INTO arbiter_data.scheduled_jobs (id, organization_id, user_id, name, job_type,
+        parameters, schedule, version) VALUES (binid, orgid, userid, name, job_type, parameters,
+        schedule, version);
+END;
+
+GRANT INSERT ON arbiter_data.scheduled_jobs TO 'insert_objects'@'localhost';
+GRANT EXECUTE ON FUNCTION get_object_organization TO 'insert_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.store_job TO 'insert_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.store_job TO 'frameworkadmin'@'%';
+
+
+CREATE DEFINER = 'select_objects'@'localhost' PROCEDURE list_jobs (IN orgid CHAR(36))
+COMMENT 'List the jobs of an organization'
+READS SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    SET binid = UUID_TO_BIN(orgid, 1);
+    IF binid IS NULL THEN
+        SELECT BIN_TO_UUID(id, 1) as id, BIN_TO_UUID(organization_id, 1) as organization_id,
+          BIN_TO_UUID(user_id, 1) as user_id, name, job_type, parameters, schedule, version,
+          created_at, modified_at FROM arbiter_data.scheduled_jobs;
+    ELSE
+        SELECT BIN_TO_UUID(id, 1) as id, BIN_TO_UUID(organization_id, 1) as organization_id,
+          BIN_TO_UUID(user_id, 1) as user_id, name, job_type, parameters, schedule, version,
+          created_at, modified_at FROM arbiter_data.scheduled_jobs WHERE organization_id = binid;
+    END IF;
+END;
+
+GRANT SELECT ON arbiter_data.scheduled_jobs TO 'select_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.list_jobs TO 'select_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.list_jobs TO 'frameworkadmin'@'%';
+GRANT EXECUTE ON PROCEDURE arbiter_data.list_jobs TO 'job_executor'@'%';
+
+
+CREATE DEFINER = 'delete_objects'@'localhost' PROCEDURE delete_job (IN jobid CHAR(36))
+COMMENT 'Delete a job'
+MODIFIES SQL DATA SQL SECURITY DEFINER
+DELETE FROM arbiter_data.scheduled_jobs WHERE id = UUID_TO_BIN(jobid, 1);
+
+GRANT DELETE, SELECT(id) ON arbiter_data.scheduled_jobs TO 'delete_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.delete_job TO 'delete_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.delete_job TO 'frameworkadmin'@'%';

--- a/datastore/migrations/0031_jobs.up.sql
+++ b/datastore/migrations/0031_jobs.up.sql
@@ -34,7 +34,7 @@ GRANT EXECUTE ON PROCEDURE arbiter_data.fetch_token TO 'job_executor'@'%';
 
 
 CREATE DEFINER = 'insert_objects'@'localhost' PROCEDURE store_job (
-    IN strid CHAR(36), IN userstrid CHAR(36), IN name VARCHAR(32), IN job_type VARCHAR(16),
+    IN strid CHAR(36), IN userstrid CHAR(36), IN name VARCHAR(64), IN job_type VARCHAR(64),
     IN parameters JSON, IN schedule JSON, IN version TINYINT)
 COMMENT 'Create a scheduled job object'
 MODIFIES SQL DATA SQL SECURITY DEFINER

--- a/datastore/migrations/0031_jobs.up.sql
+++ b/datastore/migrations/0031_jobs.up.sql
@@ -88,3 +88,13 @@ DELETE FROM arbiter_data.scheduled_jobs WHERE id = UUID_TO_BIN(jobid, 1);
 GRANT DELETE, SELECT(id) ON arbiter_data.scheduled_jobs TO 'delete_objects'@'localhost';
 GRANT EXECUTE ON PROCEDURE arbiter_data.delete_job TO 'delete_objects'@'localhost';
 GRANT EXECUTE ON PROCEDURE arbiter_data.delete_job TO 'frameworkadmin'@'%';
+
+
+INSERT INTO scheduled_jobs (id, organization_id, user_id, name, job_type, parameters, schedule, version) VALUES (
+   UUID_TO_BIN('907a9340-0b11-11ea-9e88-f4939feddd82', 1),
+   UUID_TO_BIN('b76ab62e-4fe1-11e9-9e44-64006a511e6f', 1),
+   UUID_TO_BIN('0c90950a-7cca-11e9-a81f-54bf64606445', 1),
+   'Test Job',
+   'daily_observation_validation', '{"start_td": "-1d", "end_td": "0h", "base_url": "http://localhost:5000"}',
+   '{"type": "cron", "cron_string": "0 0 * * *"}',
+   0);

--- a/datastore/tests/conftest.py
+++ b/datastore/tests/conftest.py
@@ -503,3 +503,26 @@ def default_user_role(cursor, valueset):
     cursor.execute('CALL create_default_user_role(%s, %s)',
                    (user['id'], org['id']))
     return user
+
+
+@pytest.fixture()
+def new_job(cursor, new_user):
+    def fnc(user=None, name='testjob'):
+        if user is None:
+            user = new_user()
+        out = OrderedDict(
+            id=newuuid(),
+            organization_id=user['organization_id'],
+            user_id=user['id'],
+            name=name,
+            job_type='daily_observation_validation',
+            parameters='{"start_td": "1h"}',
+            schedule='{"type": "cron", "cron_schedule": "* * * * *"}',
+            version=0
+        )
+        cursor.execute(
+            'INSERT INTO scheduled_jobs (id, organization_id, user_id, name, '
+            'job_type, parameters, schedule, version) VALUES'
+            ' (%s, %s, %s, %s, %s, %s, %s, %s)', list(out.values()))
+        return out
+    return fnc

--- a/datastore/tests/test_admin_procedures.py
+++ b/datastore/tests/test_admin_procedures.py
@@ -687,14 +687,14 @@ def test_set_org_accepted_tou_org_dne(dictcursor):
 def test_store_token(dictcursor, new_user):
     user = new_user()
     dictcursor.callproc('store_token', (user['auth0_id'], 'testtoken'))
-    dictcursor.execute('SELECT * FROM job_tokens')
+    dictcursor.execute('SELECT * FROM job_tokens where id = %s', (user['id'],))
     out = dictcursor.fetchall()
     assert len(out) == 1
     assert out[0]['id'] == user['id']
     assert out[0]['token'] == 'testtoken'
 
     dictcursor.callproc('store_token', (user['auth0_id'], 'newtoken'))
-    dictcursor.execute('SELECT * FROM job_tokens')
+    dictcursor.execute('SELECT * FROM job_tokens where id = %s', (user['id'],))
     out = dictcursor.fetchall()
     assert len(out) == 1
     assert out[0]['id'] == user['id']
@@ -704,7 +704,7 @@ def test_store_token(dictcursor, new_user):
 def test_fetch_token(dictcursor, new_user):
     user = new_user()
     dictcursor.callproc('store_token', (user['auth0_id'], 'testtoken'))
-    dictcursor.execute('SELECT * FROM job_tokens')
+    dictcursor.execute('SELECT * FROM job_tokens where id = %s', (user['id'],))
     out = dictcursor.fetchall()
     assert len(out) == 1
     assert out[0]['id'] == user['id']

--- a/datastore/tests/test_admin_procedures.py
+++ b/datastore/tests/test_admin_procedures.py
@@ -760,7 +760,7 @@ def test_create_report_creation_role(dictcursor):
         'SELECT permission_id FROM role_permission_mapping WHERE role_id = %s',
         role_id)
     permission_ids = dictcursor.fetchall()
-    assert len(permission_ids) == 10
+    assert len(permission_ids) == 12
     perm_objects = []
     for permid in [p['permission_id'] for p in permission_ids]:
         dictcursor.execute('SELECT * FROM permissions WHERE id = %s', permid)
@@ -775,6 +775,7 @@ def test_create_report_creation_role(dictcursor):
             'Read all forecast values', 'Read all probabilistic forecasts',
             'Read all probabilistic forecast values',
             'Read all aggregates', 'Read all aggregate values',
+            'Read all reports', 'Read all report values',
             'Create reports'} == set(perms.keys())
 
 

--- a/datastore/tests/test_admin_procedures.py
+++ b/datastore/tests/test_admin_procedures.py
@@ -701,6 +701,21 @@ def test_store_token(dictcursor, new_user):
     assert out[0]['token'] == 'newtoken'
 
 
+def test_fetch_token(dictcursor, new_user):
+    user = new_user()
+    dictcursor.callproc('store_token', (user['auth0_id'], 'testtoken'))
+    dictcursor.execute('SELECT * FROM job_tokens')
+    out = dictcursor.fetchall()
+    assert len(out) == 1
+    assert out[0]['id'] == user['id']
+    assert out[0]['token'] == 'testtoken'
+
+    dictcursor.callproc('fetch_token', (bin_to_uuid(user['id']),))
+    out = dictcursor.fetchall()
+    assert len(out) == 1
+    assert out[0]['token'] == 'testtoken'
+
+
 def test_create_job_user(cursor, new_organization):
     org = new_organization()
     orgid = bin_to_uuid(org['id'])

--- a/datastore/tests/test_deletes.py
+++ b/datastore/tests/test_deletes.py
@@ -801,12 +801,12 @@ def test_remove_user_facing_permissions_and_default_roles(
 
 def test_delete_job(new_job, cursor):
     job = new_job()
-    cursor.execute('select id from scheduled_jobs')
+    cursor.execute('select id from scheduled_jobs where id = %s', (job['id'],))
     out = cursor.fetchall()
     assert len(out) == 1
     assert out[0][0] == job['id']
 
     cursor.callproc('delete_job', (bin_to_uuid(job['id']),))
-    cursor.execute('select id from scheduled_jobs')
+    cursor.execute('select id from scheduled_jobs where id = %s', (job['id'],))
     out = cursor.fetchall()
     assert len(out) == 0

--- a/datastore/tests/test_deletes.py
+++ b/datastore/tests/test_deletes.py
@@ -2,7 +2,7 @@ import pytest
 import pymysql
 
 
-from conftest import bin_to_uuid
+from conftest import bin_to_uuid, newuuid
 
 
 @pytest.fixture()
@@ -810,3 +810,10 @@ def test_delete_job(new_job, cursor):
     cursor.execute('select id from scheduled_jobs where id = %s', (job['id'],))
     out = cursor.fetchall()
     assert len(out) == 0
+
+
+def test_delete_job_job_dne(dictcursor):
+    with pytest.raises(pymysql.err.InternalError) as e:
+        dictcursor.callproc('delete_job', (str(bin_to_uuid(newuuid())),))
+    assert e.value.args[0] == 1305
+    assert e.value.args[1] == "Job does not exist"

--- a/datastore/tests/test_deletes.py
+++ b/datastore/tests/test_deletes.py
@@ -797,3 +797,16 @@ def test_remove_user_facing_permissions_and_default_roles(
          'description = CONCAT("DEFAULT Read User Role ", %s)'),
         str(bin_to_uuid(user['id'])))
     assert cursor.fetchone() is None
+
+
+def test_delete_job(new_job, cursor):
+    job = new_job()
+    cursor.execute('select id from scheduled_jobs')
+    out = cursor.fetchall()
+    assert len(out) == 1
+    assert out[0][0] == job['id']
+
+    cursor.callproc('delete_job', (bin_to_uuid(job['id']),))
+    cursor.execute('select id from scheduled_jobs')
+    out = cursor.fetchall()
+    assert len(out) == 0

--- a/datastore/tests/test_inserts.py
+++ b/datastore/tests/test_inserts.py
@@ -1388,7 +1388,8 @@ def test_store_job(dictcursor, new_user):
         version=0
     )
     dictcursor.callproc('store_job', list(args.values()))
-    dictcursor.execute('SELECT * from scheduled_jobs')
+    dictcursor.execute('SELECT * from scheduled_jobs where user_id = %s',
+                       (user['id'],))
     out = dictcursor.fetchone()
     for k, v in args.items():
         if k in ('user_id', 'id'):

--- a/datastore/tests/test_inserts.py
+++ b/datastore/tests/test_inserts.py
@@ -1374,3 +1374,28 @@ def test_create_user_if_not_exist(dictcursor, valueset_org):
     perm_role_ids = dictcursor.fetchall()
     assert len(perm_role_ids) == 1
     assert perm_role_ids[0]['object_id'] == default_role['id']
+
+
+def test_store_job(dictcursor, new_user):
+    user = new_user()
+    args = OrderedDict(
+        id=bin_to_uuid(newuuid()),
+        user_id=bin_to_uuid(user['id']),
+        name='testjob',
+        job_type='jobtype',
+        parameters='{"start_td": "1h"}',
+        schedule='{"type": "cron", "cron_schedule": "* * * * *"}',
+        version=0
+    )
+    dictcursor.callproc('store_job', list(args.values()))
+    dictcursor.execute('SELECT * from scheduled_jobs')
+    out = dictcursor.fetchone()
+    for k, v in args.items():
+        if k in ('user_id', 'id'):
+            assert bin_to_uuid(out[k]) == v
+        else:
+            assert out[k] == v
+
+    assert out['organization_id'] == user['organization_id']
+    assert 'created_at' in out
+    assert 'modified_at' in out

--- a/datastore/tests/test_list.py
+++ b/datastore/tests/test_list.py
@@ -224,3 +224,23 @@ def test_list_aggregates(dictcursor, twosets):
     assert ([str(bin_to_uuid(o['id'])) for a in agg for o in a['obs_list']] ==
             [b['observation_id'] for r in res for b in
              json.loads(r['observations'])])
+
+
+def test_list_jobs(dictcursor, new_job, new_user):
+    user = new_user()
+    job0 = new_job(user, 'job0')
+    job1 = new_job(user, 'job1')
+    job2 = new_job(user, 'job2')
+    job3 = new_job(None, 'job3')
+
+    dictcursor.callproc('list_jobs')
+    out = dictcursor.fetchall()
+    keys = {'id', 'organization_id', 'organization_name',
+            'user_id', 'name',
+            'job_type', 'parameters', 'schedule',
+            'version', 'created_at', 'modified_at'}
+    assert keys == set(out[0].keys())
+
+    out_job_ids = {o['id'] for o in out}
+    for j in (job0, job1, job2, job3):
+        assert bin_to_uuid(j['id']) in out_job_ids

--- a/datastore/tests/test_reads.py
+++ b/datastore/tests/test_reads.py
@@ -1480,30 +1480,3 @@ def test_read_auth0id_caller_unaffiliated(cursor, insertuser,
     with pytest.raises(pymysql.err.OperationalError) as e:
         cursor.callproc('read_auth0id', (u2['auth0_id'], bin_to_uuid(insertuser.user['id'])))
     assert e.value.args[0] == 1142
-
-
-def test_list_jobs(dictcursor, new_job, new_user):
-    user = new_user()
-    job0 = new_job(user, 'job0')
-    job1 = new_job(user, 'job1')
-    job2 = new_job(user, 'job2')
-    job3 = new_job(None, 'job3')
-
-    dictcursor.callproc('list_jobs', (None,))
-    out = dictcursor.fetchall()
-    keys = {'id', 'organization_id', 'user_id', 'name',
-            'job_type', 'parameters', 'schedule',
-            'version', 'created_at', 'modified_at'}
-    assert keys == set(out[0].keys())
-
-    out_job_ids = {o['id'] for o in out}
-    for j in (job0, job1, job2, job3):
-        assert bin_to_uuid(j['id']) in out_job_ids
-
-    dictcursor.callproc('list_jobs', (bin_to_uuid(user['organization_id']),))
-    out = dictcursor.fetchall()
-    out_job_ids = {o['id'] for o in out}
-    for j in (job0, job1, job2):
-        assert bin_to_uuid(j['id']) in out_job_ids
-
-    assert bin_to_uuid(job3['id']) not in out_job_ids

--- a/datastore/tests/test_reads.py
+++ b/datastore/tests/test_reads.py
@@ -1480,3 +1480,30 @@ def test_read_auth0id_caller_unaffiliated(cursor, insertuser,
     with pytest.raises(pymysql.err.OperationalError) as e:
         cursor.callproc('read_auth0id', (u2['auth0_id'], bin_to_uuid(insertuser.user['id'])))
     assert e.value.args[0] == 1142
+
+
+def test_list_jobs(dictcursor, new_job, new_user):
+    user = new_user()
+    job0 = new_job(user, 'job0')
+    job1 = new_job(user, 'job1')
+    job2 = new_job(user, 'job2')
+    job3 = new_job(None, 'job3')
+
+    dictcursor.callproc('list_jobs', (None,))
+    out = dictcursor.fetchall()
+    keys = {'id', 'organization_id', 'user_id', 'name',
+            'job_type', 'parameters', 'schedule',
+            'version', 'created_at', 'modified_at'}
+    assert keys == set(out[0].keys())
+
+    out_job_ids = {o['id'] for o in out}
+    for j in (job0, job1, job2, job3):
+        assert bin_to_uuid(j['id']) in out_job_ids
+
+    dictcursor.callproc('list_jobs', (bin_to_uuid(user['organization_id']),))
+    out = dictcursor.fetchall()
+    out_job_ids = {o['id'] for o in out}
+    for j in (job0, job1, job2):
+        assert bin_to_uuid(j['id']) in out_job_ids
+
+    assert bin_to_uuid(job3['id']) not in out_job_ids

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ pymysql
 sqlalchemy
 redis
 rq
+rq_scheduler
 fakeredis
 sentry_sdk
 blinker

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(path.abspath(path.dirname(__file__)), 'README.md')) as f:
 EXTRAS_REQUIRE = {
     'test': ['pytest', 'pytest-cov', 'pytest-mock', 'flake8'],
     'cli': ['click'],
-    'queue': ['rq', 'redis'],
+    'queue': ['rq', 'redis', 'rq_scheduler'],
     'metrics': ['prometheus-flask-exporter']
 }
 EXTRAS_REQUIRE['all'] = [

--- a/sfa_api/admincli.py
+++ b/sfa_api/admincli.py
@@ -65,7 +65,7 @@ def create_organization(organization_name, **kwargs):
     except pymysql.err.IntegrityError as e:
         if e.args[0] == 1062:
             fail(f'Organization {organization_name} already exists.')
-        else:
+        else:  # pragma: no cover
             raise
     else:
         click.echo(f'Created organization {organization_name}.')
@@ -90,7 +90,7 @@ def add_user_to_org(
     except pymysql.err.IntegrityError as e:
         if e.args[0] == 1452:
             fail('Organization does not exist')
-        else:
+        else:  # pragma: no cover
             raise
     except StorageAuthError as e:
         fail(e.args[0])
@@ -115,7 +115,7 @@ def promote_to_admin(user_id, organization_id, **kwargs):
     except pymysql.err.IntegrityError as e:
         if e.args[0] == 1062:
             fail('User already granted admin permissions.')
-        else:
+        else:  # pragma: no cover
             raise
     except StorageAuthError as e:
         click.echo(e.args[0])
@@ -202,7 +202,7 @@ def set_org_accepted_tou(organization_id, **kwargs):
     except pymysql.err.InternalError as e:
         if e.args[0] == 1305:
             fail(e.args[1])
-        else:
+        else:  # pragma: no cover
             raise
     else:
         click.echo(f'Organization {organization_id} has been marked '
@@ -224,7 +224,7 @@ def delete_user(user_id, **kwargs):
     except pymysql.err.InternalError as e:
         if e.args[0] == 1305:
             fail(e.args[1])
-        else:
+        else:  # pragma: no cover
             raise
     else:
         click.echo(f'User {user_id} deleted successfully.')
@@ -324,7 +324,7 @@ def delete_job(job_id, **kwargs):
     except pymysql.err.InternalError as e:
         if e.args[0] == 1305:
             fail(e.args[1])
-        else:
+        else:  # pragma: no cover
             raise
     else:
         click.echo(f'Job {job_id} deleted successfully.')

--- a/sfa_api/admincli.py
+++ b/sfa_api/admincli.py
@@ -78,7 +78,8 @@ def create_organization(organization_name, **kwargs):
 @click.argument('organization_name', required=True)
 def create_job_user(organization_name, encryption_key, **kwargs):
     """
-    Creates a new user in Auth0 to run background jobs for the organization
+    Creates a new user in Auth0 to run background jobs for the organization.
+    Make sure AUTH0_CLIENT_ID and AUTH0_CLIENT_SECRET are properly set.
     """
     from sfa_api.utils import auth0_info
     import sfa_api.utils.storage_interface as storage

--- a/sfa_api/admincli.py
+++ b/sfa_api/admincli.py
@@ -421,6 +421,6 @@ def periodic_report_job(name, user_id, cron_string, report_id,
     """
     from sfa_api.jobs import create_job
     id_ = create_job(
-        'reference_nwp', name, user_id, cron_string,
-        report_id=report_id, base_url=base_url)
+        'periodic_report', name, user_id, cron_string,
+        report_id=str(report_id), base_url=base_url)
     click.echo(f'Job created with id {id_}')

--- a/sfa_api/admincli.py
+++ b/sfa_api/admincli.py
@@ -144,19 +144,28 @@ def move_user_to_unaffiliated(user_id, **kwargs):
 def list_users(**kwargs):
     """
     Prints a table of user information including auth0 id, user id,
-    organization and organization id.
+    organization and organization id. AUTH0_CLIENT_ID and AUTH0_CLIENT_SECRET
+    must be properly set to retrieve emails.
     """
     import sfa_api.utils.storage_interface as storage
+    from sfa_api.utils.auth0_info import list_user_emails
+    import logging
+    logging.getLogger('sfa_api.utils.auth0_info').setLevel('CRITICAL')
     users = storage._call_procedure('list_all_users', with_current_user=False)
-    table_format = '{:<34}|{:<38}|{:<34}|{:<38}'
+    emails = list_user_emails([u['auth0_id'] for u in users])
+
+    table_format = '{:<34}|{:<38}|{:<44}|{:<34}|{:<38}'
     headers = table_format.format(
-        'auth0_id', 'User ID', 'Organization Name', 'Organization ID')
+        'auth0_id', 'User ID', 'User Email', 'Organization Name',
+        'Organization ID'
+    )
     click.echo(headers)
     click.echo('-' * len(headers))
     for user in users:
         click.echo(table_format.format(
-            user['auth0_id'], user['id'], user['organization_name'],
-            user['organization_id']))
+            user['auth0_id'], user['id'], emails[user['auth0_id']],
+            user['organization_name'], user['organization_id']))
+
 
 
 @admin_cli.command('list-organizations')

--- a/sfa_api/admincli.py
+++ b/sfa_api/admincli.py
@@ -71,7 +71,6 @@ def create_organization(organization_name, **kwargs):
         click.echo(f'Created organization {organization_name}.')
 
 
-
 @admin_cli.command('add-user-to-org')
 @with_default_options
 @click.argument('user_id', required=True, type=click.UUID)
@@ -165,7 +164,6 @@ def list_users(**kwargs):
         click.echo(table_format.format(
             user['auth0_id'], user['id'], emails[user['auth0_id']],
             user['organization_name'], user['organization_id']))
-
 
 
 @admin_cli.command('list-organizations')
@@ -402,7 +400,6 @@ def reference_nwp_job(name, user_id, cron_string, issue_time_buffer,
         'reference_nwp', name, user_id, cron_string,
         issue_time_buffer=issue_time_buffer, base_url=base_url)
     click.echo(f'Job created with id {id_}')
-
 
 
 @create_jobs.command('periodic-report')

--- a/sfa_api/cli.py
+++ b/sfa_api/cli.py
@@ -115,7 +115,6 @@ def scheduler(verbose, config_file, interval, burst):
     sentry_sdk.init(send_default_pii=False,
                     integrations=[RqIntegration()])
     from rq_scheduler import Scheduler
-    from rq_scheduler.utils import setup_loghandlers
     from rq.utils import ColorizingStreamHandler
     from sfa_api.jobs import make_job_app, UpdateMixin
     import solarforecastarbiter  # NOQA preload

--- a/sfa_api/config.py
+++ b/sfa_api/config.py
@@ -47,7 +47,7 @@ class TestingConfig(Config):
     AUTH0_CLIENT_SECRET = 'secret'
 
 
-class AdminTestConfig(Config):
+class AdminTestConfig(TestingConfig):
     MYSQL_USER = 'frameworkadmin'
     MYSQL_PASSWORD = 'thisisaterribleandpublicpassword'
     MYSQL_DATABASE = 'arbiter_data'

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -644,6 +644,23 @@ demo_forecasts = {
         "interval_value_type": "interval_mean",
         "created_at": pytz.utc.localize(dt.datetime(2019, 3, 1, 11, 55, 37)),
         "modified_at": pytz.utc.localize(dt.datetime(2019, 3, 1, 11, 55, 37))
+    },
+    '49220780-76ae-4b11-bef1-7a75bdc784e3': {
+        "extra_parameters": "",
+        "forecast_id": "49220780-76ae-4b11-bef1-7a75bdc784e3",
+        "name": "GHI Aggregate FX 60",
+        "provider": "Organization 1",
+        "site_id": None,
+        "aggregate_id": "458ffc27-df0b-11e9-b622-62adb5fd6af0",
+        "variable": "ghi",
+        "issue_time_of_day": "00:00",
+        "run_length": 1440,
+        "interval_length": 60,
+        "interval_label": "beginning",
+        "lead_time_to_start": 0,
+        "interval_value_type": "interval_mean",
+        "created_at": pytz.utc.localize(dt.datetime(2019, 3, 1, 11, 55, 37)),
+        "modified_at": pytz.utc.localize(dt.datetime(2019, 3, 1, 11, 55, 37))
     }
 }
 
@@ -898,9 +915,11 @@ def generate_randoms(freq):
     """
     if freq == 1:
         length = 4320
-    else:
-        # assume 5 minutes
+    elif freq == 5:
         length = 864
+    else:
+        # assume 60 min
+        length = 72
     index = pd.date_range(start=pd.Timestamp('20190414T07:00'),
                           periods=length, freq=f'{freq}min', tz='UTC')
     values = np.random.normal(50, 5, size=length)

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -375,8 +375,18 @@ def aggregate_id():
 
 
 @pytest.fixture()
-def test_orgid():
+def orgid():
     return 'b76ab62e-4fe1-11e9-9e44-64006a511e6f'
+
+
+@pytest.fixture()
+def userid():
+    return '0c90950a-7cca-11e9-a81f-54bf64606445'
+
+
+@pytest.fixture()
+def jobid():
+    return '907a9340-0b11-11ea-9e88-f4939feddd82'
 
 
 @pytest.fixture()

--- a/sfa_api/jobs.py
+++ b/sfa_api/jobs.py
@@ -1,0 +1,131 @@
+"""
+Required keys: TOKEN_ENCRYPTION_KEY, SCHEDULER_QUEUE, AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET, AUTH0_BASE_URL, AUTH0_AUDIENCE
+optional: REDIS_HOST, REDIS_PORT, REDIS_DB, REDIS_PASSWORD,
+REDIS_DECODE_RESPONSES, REDIS_SOCKET_CONNECT_TIMEOUT,
+REDIS_USE_SSL, REDIS_CA_CERTS, REDIS_CERT_REQS,
+LOG_LEVEL
+"""
+from contextlib import contextmanager
+import json
+import logging
+
+
+from crytography.fernet import Fernet
+from flask import current_app, Flask
+import pandas as pd
+from solarforecastarbiter.io import nwp
+from solarforecastarbiter.io.utils import HiddenToken
+import solarforecastarbiter.reference_forecasts.main as reference_forecasts
+from solarforecastarbiter.reports.main import compute_report
+from solarforecastarbiter.validation import tasks as validation_tasks
+
+
+from sfa_api.utils.auth0_info import exchange_refresh_token
+from sfa_api.utils.queuing import get_queue
+import sfa_api.utils.storage_interface as storage
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_access_token(user_id):
+    """requires app context"""
+    enc_token = storage._call_procedure_for_single(
+        'fetch_token', (user_id,), with_current_user=False,
+        )['token']
+    f = Fernet(current_app.config['TOKEN_ENCRYPTION_KEY'])
+    refresh_token = f.decrypt(enc_token)
+    access_token = exchange_refresh_token(refresh_token)
+    return HiddenToken(access_token)
+
+
+def utcnow():
+    return pd.Timestamp.now(tz='UTC')
+
+
+def execute_job(name, job_type, user_id, **kwargs):
+    logger.info('Running job %s', name)
+    token = get_access_token(user_id)
+    base_url = kwargs.get('base_url', None)
+    if job_type == 'daily_observation_validation':
+        start = utcnow() + pd.Timedelta(kwargs['start_td'])
+        end = utcnow() + pd.Timedelta(kwargs['end_td'])
+        return validation_tasks.daily_observation_validation(
+            token, start, end, base_url)
+    elif job_type == 'reference_nwp':
+        issue_buffer = pd.Timedelta(kwargs['issue_time_buffer'])
+        run_time = utcnow()
+        nwp.set_base_path(kwargs['nwp_directory'])
+        return reference_forecasts.make_latest_nwp_forecasts(
+            token, run_time, issue_buffer, base_url)
+    elif job_type == 'periodic_report':
+        return compute_report(token, kwargs['report_id'], base_url)
+    else:
+        raise ValueError(f'Job type {job_type} is not supported')
+
+
+def convert_sql_to_rq_job(sql_job, scheduler):
+    args = (sql_job[k] for k in ('name', 'job_type', 'user_id'))
+    kwargs = json.loads(sql_job['parameters'])
+    schedule = json.loads(sql_job['schedule'])
+    if schedule['type'] != 'cron':
+        raise NotImplementedError('Only cron job schedules are supported')
+    scheduler.cron(
+        schedule['cron_string'],
+        func=execute_job,
+        args=args,
+        kwargs=kwargs,
+        repeat=schedule.get('repeat', None),
+        id=sql_job['id'],
+        meta={'sql_job': sql_job['id'],
+              'job_name': sql_job['name'],
+              'org': sql_job['organization_id'],
+              'last_modified_in_sql': sql_job['modified_at']},
+        use_local_timezone=False
+    )
+
+
+def schedule_jobs(scheduler):
+    sql_jobs = storage._call_procedure('list_jobs',
+                                       with_current_user=False)
+    rq_jobs = scheduler.get_jobs()
+
+    sql_dict = {k['id']: k for k in sql_jobs}
+    rq_dict = {j.id: j for j in rq_jobs}
+
+    for to_cancel in set(rq_dict.keys()) - set(sql_dict.keys()):
+        scheduler.cancel(to_cancel)
+
+    for job_id, sql_job in sql_dict.items():
+        if job_id not in rq_dict:
+            convert_sql_to_rq_job(sql_job, scheduler)
+        elif (
+                sql_job['modified_at'] !=
+                rq_dict[job_id].meta['last_modified_in_sql']
+        ):
+            scheduler.cancel(job_id)
+            convert_sql_to_rq_job(sql_job, scheduler)
+
+
+@contextmanager
+def make_job_app(config_file):
+    app = Flask('scheduled_jobs')
+    app.config.from_pyfile(config_file)
+    with app.app_context():
+        queue = get_queue(app.config['SCHEDULER_QUEUE'])
+        yield app, queue
+
+
+def run_worker(queue, loglevel):
+    from rq import Worker
+
+    w = Worker(queue)
+    w.work(logging_level=loglevel)
+
+
+def run_scheduler(queue, interval, burst=False):
+    from rq_scheduler import Scheduler
+
+    scheduler = Scheduler(queue=queue, interval=interval)
+    schedule_jobs(scheduler)
+    scheduler.run(burst=burst)

--- a/sfa_api/jobs.py
+++ b/sfa_api/jobs.py
@@ -225,7 +225,7 @@ def schedule_jobs(scheduler):
                 logger.info('Removing job %s', sql_job['name'])
                 scheduler.cancel(job_id)
             else:
-                continue
+                continue  # pragma: no cover
         try:
             convert_sql_to_rq_job(sql_job, scheduler)
         except (ValueError, json.JSONDecodeError, KeyError) as e:

--- a/sfa_api/tests/test_admincli.py
+++ b/sfa_api/tests/test_admincli.py
@@ -1,3 +1,4 @@
+import click
 from cryptography.fernet import Fernet
 import pytest
 import pymysql
@@ -74,25 +75,25 @@ def test_create_org_name_too_long(mocker, app_cli_runner):
 
 
 def test_add_user_to_org(
-        app_cli_runner, unaffiliated_userid, test_orgid,
+        app_cli_runner, unaffiliated_userid, orgid,
         dict_cursor):
     result = app_cli_runner.invoke(
         admincli.add_user_to_org,
-        [unaffiliated_userid, test_orgid] + auth_args)
+        [unaffiliated_userid, orgid] + auth_args)
     assert (f'Added user {unaffiliated_userid} to organization '
-            f'{test_orgid}\n') == result.output
+            f'{orgid}\n') == result.output
     with dict_cursor as cursor:
         cursor.callproc('list_all_users')
         users = user_dict(cursor.fetchall())
         assert unaffiliated_userid in users
-        assert users[unaffiliated_userid]['organization_id'] == test_orgid
+        assert users[unaffiliated_userid]['organization_id'] == orgid
 
 
 def test_add_user_to_org_affiliated_user(
-        app_cli_runner, user_id, test_orgid):
+        app_cli_runner, user_id, orgid):
     result = app_cli_runner.invoke(
         admincli.add_user_to_org,
-        [user_id, test_orgid] + auth_args)
+        [user_id, orgid] + auth_args)
     assert 'Cannot add affiliated user to organization\n' == result.output
 
 
@@ -106,19 +107,19 @@ def test_add_user_to_org_invalid_orgid(
 
 
 def test_add_user_to_org_invalid_userid(
-        app_cli_runner, test_orgid):
+        app_cli_runner, orgid):
     result = app_cli_runner.invoke(
         admincli.add_user_to_org,
-        ['baduuid', test_orgid] + auth_args)
+        ['baduuid', orgid] + auth_args)
     assert ('Error: Invalid value for "USER_ID": baduuid is '
             'not a valid UUID value') in result.output
 
 
 def test_add_user_to_org_user_dne(
-        app_cli_runner, missing_id, test_orgid):
+        app_cli_runner, missing_id, orgid):
     result = app_cli_runner.invoke(
         admincli.add_user_to_org,
-        [missing_id, test_orgid] + auth_args)
+        [missing_id, orgid] + auth_args)
     assert 'Cannot add affiliated user to organization\n' == result.output
 
 
@@ -398,3 +399,54 @@ def test_add_job_role_user_dne(app_cli_runner, missing_id, role):
     res = app_cli_runner.invoke(admincli.add_job_role,
                                 auth_args + [missing_id, role])
     assert res.exit_code != 0
+
+
+def test_list_jobs(app_cli_runner):
+    res = app_cli_runner.invoke(admincli.list_jobs,
+                                auth_args)
+    assert res.exit_code == 0
+
+
+def test_delete_job(app_cli_runner, jobid):
+    result = app_cli_runner.invoke(
+        admincli.delete_job,
+        [jobid] + auth_args)
+    assert result.output == (f'Job {jobid} deleted successfully.\n')
+
+
+def test_delete_job_job_dne(app_cli_runner, missing_id):
+    result = app_cli_runner.invoke(
+        admincli.delete_job,
+        [missing_id] + auth_args)
+    assert result.output == (f'Job does not exist\n')
+
+
+def test_TimeDeltaParam():
+    assert '1h' == admincli.TimeDeltaParam()('1h')
+    with pytest.raises(click.exceptions.BadParameter):
+        admincli.TimeDeltaParam()('what')
+
+
+def test_daily_validation_job(app_cli_runner, mocker, user_id):
+    mocker.patch('sfa_api.jobs.create_job', return_value='jobid')
+    result = app_cli_runner.invoke(
+        admincli.daily_validation_job,
+        ['Val Job', user_id, '* * * * *', '-1d', '0h'] + auth_args)
+    assert result.output == 'Job created with id jobid\n'
+
+
+def test_reference_nwp_job(app_cli_runner, mocker, user_id):
+    mocker.patch('sfa_api.jobs.create_job', return_value='jobid')
+    result = app_cli_runner.invoke(
+        admincli.reference_nwp_job,
+        ['Val Job', user_id, '* * * * *', '10min'] + auth_args)
+    assert result.output == 'Job created with id jobid\n'
+
+
+def test_periodic_report_job(app_cli_runner, mocker, user_id,
+                             missing_id):
+    mocker.patch('sfa_api.jobs.create_job', return_value='jobid')
+    result = app_cli_runner.invoke(
+        admincli.periodic_report_job,
+        ['Val Job', user_id, '* * * * *', missing_id] + auth_args)
+    assert result.output == 'Job created with id jobid\n'

--- a/sfa_api/tests/test_aggregates.py
+++ b/sfa_api/tests/test_aggregates.py
@@ -369,8 +369,7 @@ def test_get_aggregate_forecasts(api, aggregate_id):
     agg_forecasts = res.get_json()
     assert len(agg_forecasts) == 2
     agg_fx = agg_forecasts[0]
-    expected = list(demo_forecasts.values())[-1]
-    assert agg_fx['forecast_id'] == expected['forecast_id']
+    assert agg_fx['forecast_id'] in demo_forecasts
     assert agg_fx['aggregate_id'] == aggregate_id
 
 

--- a/sfa_api/tests/test_aggregates.py
+++ b/sfa_api/tests/test_aggregates.py
@@ -367,7 +367,7 @@ def test_get_aggregate_forecasts(api, aggregate_id):
     assert res.status_code == 200
     assert isinstance(res.get_json(), list)
     agg_forecasts = res.get_json()
-    assert len(agg_forecasts) == 1
+    assert len(agg_forecasts) == 2
     agg_fx = agg_forecasts[0]
     expected = list(demo_forecasts.values())[-1]
     assert agg_fx['forecast_id'] == expected['forecast_id']

--- a/sfa_api/tests/test_cli.py
+++ b/sfa_api/tests/test_cli.py
@@ -30,3 +30,26 @@ def test_devserver(mocker):
     r = runner.invoke(cli.cli, ['devserver'])
     assert r.exit_code == 0
     app.assert_called
+
+
+def test_scheduled_worker(mocker):
+    w = mocker.patch('rq.Worker')
+    runner = CliRunner()
+    with tempfile.NamedTemporaryFile('w') as f:
+        f.write('SCHEDULER_QUEUE = "scheduled"')
+        f.flush()
+        r = runner.invoke(cli.cli, ['scheduled-worker', f.name])
+    assert r.exit_code == 0
+    w.assert_called
+
+
+def test_scheduler(mocker):
+    run = mocker.patch('rq_scheduler.Scheduler.run')
+    runner = CliRunner()
+    with tempfile.NamedTemporaryFile('w') as f:
+        f.write('USE_FAKE_REDIS = True\n')
+        f.write('SCHEDULER_QUEUE = "scheduled"')
+        f.flush()
+        r = runner.invoke(cli.cli, ['scheduler', f.name])
+    assert r.exit_code == 0
+    run.assert_called

--- a/sfa_api/tests/test_jobs.py
+++ b/sfa_api/tests/test_jobs.py
@@ -1,0 +1,196 @@
+import datetime as dt
+import tempfile
+
+
+import pytest
+from rq import SimpleWorker
+from rq_scheduler import Scheduler
+
+
+from sfa_api import jobs
+from sfa_api.utils.queuing import get_queue
+from sfa_api.conftest import _make_sql_app, _make_nocommit_cursor
+
+
+@pytest.fixture()
+def app(mocker):
+    with _make_sql_app() as app:
+        app.config.update(
+            TOKEN_ENCRYPTION_KEY=b'eKfeo832hn8nQ_3K69YDniBbHqbqpIxUNRstrv225c8=',  # NOQA
+            SCHEDULER_QUEUE='scheduler',
+            MYSQL_USER='job_executor',
+            MYSQL_PASSWORD='thisisaterribleandpublicpassword'
+        )
+        with _make_nocommit_cursor(mocker):
+            yield app
+
+
+@pytest.fixture()
+def queue(app):
+    return get_queue(app.config['SCHEDULER_QUEUE'])
+
+
+@pytest.fixture()
+def orgid():
+    return 'b76ab62e-4fe1-11e9-9e44-64006a511e6f'
+
+@pytest.fixture()
+def userid():
+    return '0c90950a-7cca-11e9-a81f-54bf64606445'
+
+
+@pytest.fixture()
+def jobid():
+    return '907a9340-0b11-11ea-9e88-f4939feddd82'
+
+
+def test_get_access_token(mocker, app, userid):
+    exchange = mocker.patch('sfa_api.jobs.exchange_refresh_token',
+                            return_value='access')
+    out = jobs.get_access_token(userid)
+    assert out.token == 'access'
+    assert exchange.called_with('token')
+
+
+def test_get_access_token_dne(app):
+    with pytest.raises(KeyError):
+        jobs.get_access_token('1190950a-7cca-11e9-a81f-54bf64606445')
+
+
+def test_make_job_app(mocker):
+    with tempfile.NamedTemporaryFile(mode='w') as f:
+        f.write('SCHEDULER_QUEUE = "scheduled_jobsq"')
+        f.flush()
+
+        with jobs.make_job_app(f.name) as (app, queue):
+            assert queue.name == 'scheduled_jobsq'
+
+
+def test_schedule_jobs(mocker, queue, jobid):
+    sch = Scheduler(queue=queue, connection=queue.connection)
+    jobs.schedule_jobs(sch)
+    assert jobid in sch
+    assert len(list(sch.get_jobs())) == 1
+    # running again should have no effect
+    jobs.schedule_jobs(sch)
+    assert jobid in sch
+    assert len(list(sch.get_jobs())) == 1
+
+
+def noop():
+    pass
+
+
+def test_schedule_jobs_bad_current(mocker, queue, jobid):
+    sch = Scheduler(queue=queue, connection=queue.connection)
+    id0 = 'jobid0'
+    sch.cron(
+        '* * * * *',
+        func=noop,
+        id=id0,
+        meta={}
+    )
+    jobs.schedule_jobs(sch)
+    assert jobid in sch
+    assert id0 not in sch
+    assert len(list(sch.get_jobs())) == 1
+
+
+@pytest.fixture()
+def sql_job(userid, orgid, jobid):
+    return {
+        'id': jobid,
+        'user_id': userid,
+        'organization_id': orgid,
+        'name': 'Test job',
+        'job_type': 'daily_observation_validation',
+        'parameters': '{"start_td": "-1d", "end_td": "0h", "base_url": "http://localhost:5000"}',  # NOQA
+        'schedule': '{"type": "cron", "cron_string": "0 0 * * *"}',
+        'version': 0,
+        'created_at': dt.datetime(2019, 1, 1, 12, tzinfo=dt.timezone.utc),
+        'modified_at': dt.datetime(2019, 1, 1, 12, tzinfo=dt.timezone.utc)
+    }
+
+
+def test_schedule_jobs_modified(mocker, queue, sql_job):
+    mocker.patch('sfa_api.jobs.storage._call_procedure',
+                 return_value=[sql_job])
+    sch = Scheduler(queue=queue, connection=queue.connection)
+    jobs.schedule_jobs(sch)
+    assert list(sch.get_jobs())[0].meta[
+        'last_modified_in_sql'] == dt.datetime(2019, 1, 1, 12,
+                                               tzinfo=dt.timezone.utc)
+    njob = sql_job.copy()
+    njob['modified_at'] = dt.datetime(2019, 2, 1, tzinfo=dt.timezone.utc)
+    mocker.patch('sfa_api.jobs.storage._call_procedure',
+                 return_value=[njob])
+    jobs.schedule_jobs(sch)
+    assert list(sch.get_jobs())[0].meta[
+        'last_modified_in_sql'] == dt.datetime(
+            2019, 2, 1, tzinfo=dt.timezone.utc)
+
+
+def test_schedule_jobs_err(mocker, queue, sql_job):
+    job = sql_job.copy()
+    job['schedule'] = '{}'
+    mocker.patch('sfa_api.jobs.storage._call_procedure',
+                 return_value=[job])
+    log = mocker.patch('sfa_api.jobs.logger')
+    sch = Scheduler(queue=queue, connection=queue.connection)
+    jobs.schedule_jobs(sch)
+    assert log.error.called
+
+
+def test_convert_sql_job_to_rq_job(sql_job, mocker):
+    scheduler = mocker.MagicMock()
+    jobs.convert_sql_to_rq_job(sql_job, scheduler)
+    assert scheduler.cron.called
+    assert scheduler.cron.call_args[0] == ('0 0 * * *',)
+
+
+def test_convert_sql_job_to_rq_job_not_cron(sql_job, mocker):
+    job = sql_job.copy()
+    job['schedule'] = '{"type": "enqueue_at"}'
+    scheduler = mocker.MagicMock()
+    with pytest.raises(ValueError):
+        jobs.convert_sql_to_rq_job(job, scheduler)
+
+
+@pytest.mark.parametrize('jtype,params,func', [
+    ('daily_observation_validation',
+     {'start_td': '-1h', 'end_td': '0h'},
+     'sfa_api.jobs.daily_observation_validation'),
+    ('reference_nwp',
+     {'issue_time_buffer': '10min',
+      'nwp_directory': '.'},
+     'sfa_api.jobs.make_latest_nwp_forecasts'),
+    ('periodic_report',
+     {'report_id': 'blah'},
+     'sfa_api.jobs.compute_report'),
+    pytest.param(
+        'other_job', {}, 'sfa_api.app',
+        marks=pytest.mark.xfail(strict=True, raises=ValueError))
+])
+def test_execute_job_daily_obs(jtype, params, func, mocker, userid):
+    mocker.patch('sfa_api.jobs.get_access_token',
+                 return_value='token')
+    ret = mocker.patch(func)
+    jobs.execute_job('test', jtype, userid, **params)
+    assert ret.called
+
+
+def test_full_run_through(app, queue, mocker):
+    mocker.patch('sfa_api.jobs.get_access_token', return_value='token')
+    validate = mocker.patch('sfa_api.jobs.daily_observation_validation')
+    gjq = mocker.patch('rq_scheduler.Scheduler.get_jobs_to_queue')
+    sch = Scheduler(queue=queue, connection=queue.connection)
+    jobs.schedule_jobs(sch)
+    (job, exc_time) = list(sch.get_jobs(with_times=True))[0]
+    assert exc_time == dt.datetime.utcnow().replace(
+        hour=0, minute=0, second=0, microsecond=0) + dt.timedelta(days=1)
+    gjq.return_value = [job]
+    sch.run(burst=True)
+    assert job in queue.jobs
+    w = SimpleWorker([queue], connection=queue.connection)
+    w.work(burst=True)
+    assert validate.called

--- a/sfa_api/tests/test_jobs.py
+++ b/sfa_api/tests/test_jobs.py
@@ -183,7 +183,11 @@ def test_full_run_through(app, queue, mocker):
     mocker.patch('sfa_api.jobs.get_access_token', return_value='token')
     validate = mocker.patch('sfa_api.jobs.daily_observation_validation')
     gjq = mocker.patch('rq_scheduler.Scheduler.get_jobs_to_queue')
-    sch = Scheduler(queue=queue, connection=queue.connection)
+
+    class US(jobs.UpdateMixin, Scheduler):
+        pass
+
+    sch = US(queue=queue, connection=queue.connection)
     jobs.schedule_jobs(sch)
     (job, exc_time) = list(sch.get_jobs(with_times=True))[0]
     assert exc_time == dt.datetime.utcnow().replace(

--- a/sfa_api/tests/test_jobs.py
+++ b/sfa_api/tests/test_jobs.py
@@ -30,20 +30,6 @@ def queue(app):
     return get_queue(app.config['SCHEDULER_QUEUE'])
 
 
-@pytest.fixture()
-def orgid():
-    return 'b76ab62e-4fe1-11e9-9e44-64006a511e6f'
-
-@pytest.fixture()
-def userid():
-    return '0c90950a-7cca-11e9-a81f-54bf64606445'
-
-
-@pytest.fixture()
-def jobid():
-    return '907a9340-0b11-11ea-9e88-f4939feddd82'
-
-
 def test_get_access_token(mocker, app, userid):
     exchange = mocker.patch('sfa_api.jobs.exchange_refresh_token',
                             return_value='access')

--- a/sfa_api/utils/auth0_info.py
+++ b/sfa_api/utils/auth0_info.py
@@ -13,6 +13,9 @@ import requests
 from sfa_api.utils.queuing import make_redis_connection
 
 
+logger = logging.getLogger(__name__)
+
+
 def token_redis_connection():
     """Make a connection to Redis and the database specified by
     config['AUTH0_REDIS_DB']. The connection is stored on the
@@ -110,7 +113,7 @@ def auth0_token():
         try:
             token = get_fresh_auth0_management_token()
         except (ValueError, requests.HTTPError) as e:
-            logging.error('Failed to retrieve Auth0 token: %r', e)
+            logger.error('Failed to retrieve Auth0 token: %r', e)
             return
         redis_conn.set('auth0_token', token)
     return token
@@ -138,8 +141,8 @@ def _get_email_of_user(auth0_id, redis_conn, token,
             # expire in 1 day
             redis_conn.set(auth0_id, email, ex=86400)
         else:
-            logging.error('Failed to retrieve email from Auth0: %s %s',
-                          req.status_code, req.text)
+            logger.error('Failed to retrieve email from Auth0: %s %s',
+                         req.status_code, req.text)
             email = 'Unable to retrieve'
     return email
 
@@ -225,8 +228,8 @@ def _get_auth0_id_of_user(email, redis_conn, token,
                 # expire in 1 day
                 redis_conn.set(email, user_id, ex=86400)
         else:
-            logging.error('Failed to retrieve user_id from Auth0: %s %s',
-                          req.status_code, req.text)
+            logger.error('Failed to retrieve user_id from Auth0: %s %s',
+                         req.status_code, req.text)
             user_id = 'Unable to retrieve'
     return user_id
 

--- a/sfa_api/utils/request_handling.py
+++ b/sfa_api/utils/request_handling.py
@@ -7,7 +7,7 @@ import re
 from flask import request
 import numpy as np
 import pandas as pd
-from solarforecastarbiter.datamodel import Forecast
+from solarforecastarbiter.datamodel import Forecast, Site
 from solarforecastarbiter.reference_forecasts import utils as fx_utils
 
 
@@ -422,7 +422,7 @@ def restrict_forecast_upload_window(extra_parameters, get_forecast,
         raise NotFoundException(errors={
             '404': 'Cannot read forecast or forecast does not exist'})
     # we don't care about the axis or constant values for probabilistic
-    fx_dict['site'] = ''
+    fx_dict['site'] = Site('name', 0, 0, 0, 'UTC')
     fx = Forecast.from_dict(fx_dict)
     next_issue_time = fx_utils.get_next_issue_time(
         fx, _current_utc_timestamp())

--- a/sfa_api/utils/tests/test_auth0_info.py
+++ b/sfa_api/utils/tests/test_auth0_info.py
@@ -89,7 +89,7 @@ def test_auth0_token_not_in_redis(running_app, mocker):
 
 @pytest.mark.parametrize('se', [ValueError, requests.HTTPError])
 def test_auth0_token_no_fresh(running_app, mocker, se):
-    log = mocker.patch('sfa_api.utils.auth0_info.logging.error')
+    log = mocker.patch('sfa_api.utils.auth0_info.logger.error')
     mocker.patch(
         'sfa_api.utils.auth0_info.get_fresh_auth0_management_token',
         side_effect=se)

--- a/sfa_api/utils/tests/test_storage_interface.py
+++ b/sfa_api/utils/tests/test_storage_interface.py
@@ -19,6 +19,7 @@ from sfa_api.utils import storage_interface
 TESTINDICES = {
     1: generate_randoms(1)[0].to_series(keep_tz=True),
     5: generate_randoms(5)[0].to_series(keep_tz=True),
+    60: generate_randoms(60)[0].to_series(keep_tz=True),
 }
 
 


### PR DESCRIPTION
With a new scheduled jobs table in MySQL that gets translated into jobs handled by rq_scheduler. Right now, daily observation validation, reference nwp forecast generation, and recomputing a report are supported.

Also adds another aggregate forecast with 60 minute interval.

### Motivation 
Trials will require creating reference forecasts for the trial and periodic report generation. Adding background jobs that are unique to each organization/trial supports this and has the added benefit of giving org. admins more control over data access. For example, we could create a user that had read/write access to all observations in the arbiter in order to perform daily validation. Instead the user executing the validation as a job for an organization only has access to observations within that org. Admins are also free to restrict the job user from accessing certain observations.

The complexity of the job code is higher than creating a few cronjobs, but this approach is more flexible, better documents jobs by storing them in MySQL (vs hunting them down in openshift), and is somewhat more scalable since we can adjust the number of workers running jobs. Later we may also decide that each organization is allocated a certain amount of compute for these background jobs which can likely be accomplished with separate queues for each org.