### PR TITLE
Add reference jobs to migrations

### DIFF
--- a/datastore/migrations/0028_update_after_create.up.sql
+++ b/datastore/migrations/0028_update_after_create.up.sql
@@ -121,6 +121,7 @@ BEGIN
         ) VALUES (
             binid, orgid, name, report_parameters);
         CALL add_object_permission_to_default_user_role(auth0id, orgid, binid, 'reports', 'update');
+        CALL add_object_permission_to_default_user_role(auth0id, orgid, binid, 'reports', 'write_values');
     ELSE
         SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "create reports"',
         MYSQL_ERRNO = 1142;

--- a/datastore/migrations/0030_job_user.down.sql
+++ b/datastore/migrations/0030_job_user.down.sql
@@ -1,7 +1,7 @@
 DROP PROCEDURE grant_job_role;
 DROP PROCEDURE create_forecast_generation_role;
 DROP PROCEDURE create_data_validation_role;
-DROP PROCEDURE create_report_creation_role;
+DROP PROCEDURE recompute_report_creation_role;
 DROP PROCEDURE create_job_user;
 DROP PROCEDURE store_token;
 DROP USER 'token_user'@'localhost';

--- a/datastore/migrations/0032_updated_reference_user.down.sql
+++ b/datastore/migrations/0032_updated_reference_user.down.sql
@@ -1,0 +1,4 @@
+SET @reforgid = (SELECT id FROM organizations WHERE name = 'Reference');
+DELETE FROM permissions WHERE organization_id = @reforgid AND description IN (
+'Create all reports', 'Update all reports', 'Create all report values',
+'Read all reports', 'Read all report values');

--- a/datastore/migrations/0032_updated_reference_user.up.sql
+++ b/datastore/migrations/0032_updated_reference_user.up.sql
@@ -1,0 +1,25 @@
+SET @reforgid = (SELECT id FROM organizations WHERE name = 'Reference');
+
+-- allow everyone to read reference reports
+SET @readrep = UUID_TO_BIN(UUID(), 1);
+SET @readrepval = UUID_TO_BIN(UUID(), 1);
+SET @readrole = (SELECT id from roles WHERE name = 'Read Reference Data' and organization_id = @reforgid);
+
+INSERT INTO permissions (id, description, organization_id, action, object_type, applies_to_all) VALUES (
+  @readrep, 'Read all reports', @reforgid, 'read', 'reports', TRUE), (
+  @readrepval, 'Read all report values', @reforgid, 'read_values', 'reports', TRUE);
+
+INSERT INTO role_permission_mapping (role_id, permission_id) VALUES (@readrole, @readrep), (@readrole, @readrepval);
+
+-- allow reference to create/update reports
+SET @createrep = UUID_TO_BIN(UUID(), 1);
+SET @updaterep = UUID_TO_BIN(UUID(), 1);
+SET @writerep = UUID_TO_BIN(UUID(), 1);
+SET @refrole = (SELECT id from roles WHERE name = 'Reference user role' and organization_id = @reforgid);
+
+INSERT INTO permissions (id, description, organization_id, action, object_type, applies_to_all) VALUES (
+  @createrep, 'Create all reports', @reforgid, 'create', 'reports', TRUE),(
+  @updaterep, 'Update all reports', @reforgid, 'update', 'reports', TRUE),(
+  @writerep, 'Create all report values', @reforgid, 'write_values', 'reports', TRUE);
+
+INSERT INTO role_permission_mapping (role_id, permission_id) VALUES (@refrole, @createrep), (@refrole, @updaterep), (@refrole, @writerep), (@refrole, @readrep), (@refrole, @readrepval);

--- a/datastore/migrations/0041_reference_jobs.down.sql
+++ b/datastore/migrations/0041_reference_jobs.down.sql
@@ -1,0 +1,28 @@
+SET @reforgid = (SELECT id FROM organizations WHERE name = 'Reference');
+DROP PROCEDURE doereport;
+DROP PROCEDURE makecvs;
+
+DELETE FROM reports WHERE organization_id = @reforgid;
+DELETE FROM observations WHERE organization_id = @reforgid AND name in (
+  'Albuquerque NM ac_power', 'Henderson NV ac_power', 'Williston VT ac_power', 'Cocoa FL ac_power');
+DELETE FROM cdf_forecasts_groups WHERE organization_id = @reforgid AND (
+  name like 'Albuquerque NM%ac_power'
+  OR name like 'Henderson NV%ac_power'
+  OR name like 'Williston VT%ac_power'
+  OR name like 'Cocoa FL%ac_power');
+DELETE FROM forecasts WHERE organization_id = @reforgid AND (
+  name like 'Albuquerque NM%ac_power'
+  OR name like 'Henderson NV%ac_power'
+  OR name like 'Williston VT%ac_power'
+  OR name like 'Cocoa FL%ac_power');
+DELETE FROM sites WHERE organization_id = @reforgid AND name in (
+  'DOE RTC Albuquerque NM', 'DOE RTC Henderson NV', 'DOE RTC Williston VT', 'DOE RTC Cocoa FL');
+DELETE FROM scheduled_jobs WHERE organization_id = @reforgid;
+INSERT INTO scheduled_jobs (id, organization_id, user_id, name, job_type, parameters, schedule, version) VALUES (
+    UUID_TO_BIN('907a9340-0b11-11ea-9e88-f4939feddd82', 1),
+    UUID_TO_BIN('b76ab62e-4fe1-11e9-9e44-64006a511e6f', 1),
+    UUID_TO_BIN('0c90950a-7cca-11e9-a81f-54bf64606445', 1),
+    'Test Job',
+    'daily_observation_validation', '{"start_td": "-1d", "end_td": "0h", "base_url": "http://localhost:5000"}',
+    '{"type": "cron", "cron_string": "0 0 * * *"}',
+    0);

--- a/datastore/migrations/0041_reference_jobs.up.sql
+++ b/datastore/migrations/0041_reference_jobs.up.sql
@@ -1,0 +1,218 @@
+SET @reforgid = (SELECT id FROM organizations WHERE name = 'Reference');
+SET @refauth0 = 'auth0|5cc8aeff0ec8b510a4c7f2f1';
+SET @refid = (SELECT id FROM users WHERE auth0_id = @refauth0);
+SET @baseurl = 'https://dev-api.solarforecastarbiter.org';
+
+SET @abqsite = UUID_TO_BIN(UUID(), 1);
+SET @nvsite = UUID_TO_BIN(UUID(), 1);
+SET @vtsite = UUID_TO_BIN(UUID(), 1);
+SET @flsite = UUID_TO_BIN(UUID(), 1);
+
+INSERT INTO sites (id, organization_id, name, latitude, longitude,
+    elevation, timezone, extra_parameters, ac_capacity, dc_capacity,
+    temperature_coefficient, tracking_type, surface_tilt,
+    surface_azimuth, axis_tilt, axis_azimuth, ground_coverage_ratio,
+    backtrack, max_rotation_angle, dc_loss_factor, ac_loss_factor )
+VALUES (
+    @abqsite, @reforgid, 'DOE RTC Albuquerque NM' , 35.050000 ,
+    -106.530000 , 1657.00 , 'America/Denver' , '{"network": "DOE RTC",
+    "network_api_id": "Albuquerque", "network_api_abbreviation": "",
+    "observation_interval_length": 1, "attribution": "", "module":
+    "Suniva 270W"}' , 0.003240 , 0.003240 , -0.00420 , 'fixed' , 35.00 ,
+    180.00 , NULL , NULL , NULL , NULL , NULL , 0.00 , 0.00
+),(
+    @nvsite, @reforgid, 'DOE RTC Henderson NV' , 36.040000 , -114.920000 , 538.00 ,
+    'America/Los_Angeles' , '{"network": "DOE RTC", "network_api_id":
+    "Henderson", "network_api_abbreviation": "",
+    "observation_interval_length": 1, "attribution": "", "module":
+    "Suniva 270W"}' , 0.003240 , 0.003240 , -0.00420 , 'fixed' , 35.00 ,
+    180.00 , NULL , NULL , NULL , NULL , NULL , 0.00 , 0.00
+),(
+    @vtsite, @reforgid, 'DOE RTC Williston VT' , 44.500000 , -73.100000 , 184.00 ,
+    'America/New_York' , '{"network": "DOE RTC", "network_api_id":
+    "Williston", "network_api_abbreviation": "",
+    "observation_interval_length": 1, "attribution": "", "module":
+    "Suniva 270W"}' , 0.003240 , 0.003240 , -0.00420 , 'fixed' , 35.00 ,
+    180.00 , NULL , NULL , NULL , NULL , NULL , 0.00 , 0.00
+),(
+    @flsite, @reforgid, 'DOE RTC Cocoa FL' , 28.400000 , -80.770000 , 11.00 , 'America/New_York' ,
+    '{"network": "DOE RTC", "network_api_id": "Cocoa",
+    "network_api_abbreviation": "", "observation_interval_length": 1,
+    "attribution": "", "module": "Suniva 270W"}' , 0.003240 , 0.003240
+    , -0.00420 , 'fixed' , 35.00 , 180.00 , NULL , NULL , NULL , NULL ,
+    NULL , 0.00 , 0.00
+);
+
+INSERT INTO forecasts (organization_id, site_id, name, variable, issue_time_of_day,
+ lead_time_to_start, interval_label, interval_length, run_length,
+ interval_value_type, extra_parameters
+) VALUES(
+ @reforgid, @abqsite, 'Albuquerque NM Day Ahead GFS ac_power' , 'ac_power' , '07:00' , 1440 , 'ending' , 60 ,
+ 1440 , 'interval_mean' , '{"is_reference_forecast": true, "model": "gfs_quarter_deg_hourly_to_hourly_mean"}'
+),(@reforgid, @abqsite, 'Albuquerque NM Intraday HRRR ac_power', 'ac_power' , '00:00', 60 , 'ending' , 60 ,
+ 360 , 'interval_mean' , '{"is_reference_forecast": true, "model": "hrrr_subhourly_to_hourly_mean"}'
+),(@reforgid, @abqsite, 'Albuquerque NM Intraday RAP ac_power', 'ac_power' , '00:00' , 60 , 'ending' , 60 , 360 ,
+ 'interval_mean' , '{"is_reference_forecast": true, "model": "rap_cloud_cover_to_hourly_mean"}'
+),(@reforgid, @abqsite, 'Albuquerque NM Current Day NAM ac_power', 'ac_power' , '06:00' , 60 , 'ending' , 60 , 1440 ,
+ 'interval_mean' , '{"is_reference_forecast": true, "model": "nam_12km_cloud_cover_to_hourly_mean"}'
+),(@reforgid, @nvsite, 'Henderson NV Day Ahead GFS ac_power', 'ac_power' , '08:00' , 1440 , 'ending' , 60 , 1440 ,
+ 'interval_mean' , '{"is_reference_forecast": true, "model": "gfs_quarter_deg_hourly_to_hourly_mean"}'
+),(@reforgid, @nvsite, 'Henderson NV Intraday HRRR ac_power', 'ac_power' , '01:00' , 60 , 'ending' , 60 , 360 ,
+ 'interval_mean' , '{"is_reference_forecast": true, "model": "hrrr_subhourly_to_hourly_mean"}'
+),(@reforgid, @nvsite, 'Henderson NV Intraday RAP ac_power', 'ac_power' , '01:00' , 60 , 'ending' , 60 , 360 ,
+ 'interval_mean' , '{"is_reference_forecast": true, "model": "rap_cloud_cover_to_hourly_mean"}'
+),(@reforgid, @nvsite, 'Henderson NV Current Day NAM ac_power', 'ac_power' , '07:00' , 60 , 'ending' , 60 , 1440 ,
+ 'interval_mean' , '{"is_reference_forecast": true, "model": "nam_12km_cloud_cover_to_hourly_mean"}'
+),(@reforgid, @vtsite, 'Williston VT Day Ahead GFS ac_power', 'ac_power' , '05:00' , 1440 , 'ending' , 60 , 1440 ,
+ 'interval_mean' , '{"is_reference_forecast": true, "model": "gfs_quarter_deg_hourly_to_hourly_mean"}'
+),(@reforgid, @vtsite, 'Williston VT Intraday HRRR ac_power', 'ac_power' , '04:00' , 60 , 'ending' , 60 , 360 ,
+ 'interval_mean' , '{"is_reference_forecast": true, "model": "hrrr_subhourly_to_hourly_mean"}'
+),(@reforgid, @vtsite, 'Williston VT Intraday RAP ac_power', 'ac_power' , '04:00' , 60 , 'ending' , 60 , 360 ,
+ 'interval_mean' , '{"is_reference_forecast": true, "model": "rap_cloud_cover_to_hourly_mean"}'
+),(@reforgid, @vtsite, 'Williston VT Current Day NAM ac_power', 'ac_power' , '04:00' , 60 , 'ending' , 60 , 1440 ,
+ 'interval_mean' , '{"is_reference_forecast": true, "model": "nam_12km_cloud_cover_to_hourly_mean"}'
+),(@reforgid, @flsite, 'Cocoa FL Day Ahead GFS ac_power', 'ac_power' , '05:00' , 1440 , 'ending' , 60 , 1440 ,
+ 'interval_mean' , '{"is_reference_forecast": true, "model": "gfs_quarter_deg_hourly_to_hourly_mean"}'
+),(@reforgid, @flsite, 'Cocoa FL Intraday HRRR ac_power', 'ac_power' , '04:00' , 60 , 'ending' , 60 , 360 ,
+ 'interval_mean' , '{"is_reference_forecast": true, "model": "hrrr_subhourly_to_hourly_mean"}'
+),(@reforgid, @flsite, 'Cocoa FL Intraday RAP ac_power' , 'ac_power' , '04:00' , 60 , 'ending' , 60 , 360 ,
+ 'interval_mean' , '{"is_reference_forecast": true, "model": "rap_cloud_cover_to_hourly_mean"}'
+),(@reforgid, @flsite, 'Cocoa FL Current Day NAM ac_power', 'ac_power' , '04:00' , 60 , 'ending' , 60 , 1440 ,
+ 'interval_mean' , '{"is_reference_forecast": true, "model": "nam_12km_cloud_cover_to_hourly_mean"}'
+);
+
+
+SET @abqcg = UUID_TO_BIN(UUID(), 1);
+SET @nvcg = UUID_TO_BIN(UUID(), 1);
+SET @vtcg = UUID_TO_BIN(UUID(), 1);
+SET @flcg = UUID_TO_BIN(UUID(), 1);
+INSERT INTO cdf_forecasts_groups (id, site_id, organization_id, name, variable, issue_time_of_day, lead_time_to_start, interval_label, interval_length, run_length, interval_value_type, extra_parameters, axis
+) VALUES (
+  @abqcg, @abqsite, @reforgid, 'Albuquerque NM Day Ahead GEFS ac_power', 'ac_power', '07:00', 1440, 'ending', 60, 1440, 'interval_mean', '{"is_reference_forecast": true, "model": "gefs_half_deg_to_hourly_mean"}', 'y'), (
+  @nvcg, @nvsite, @reforgid, 'Henderson NV Day Ahead GEFS ac_power', 'ac_power', '08:00', 1440, 'ending', 60, 1440, 'interval_mean', '{"is_reference_forecast": true, "model": "gefs_half_deg_to_hourly_mean"}', 'y'), (
+  @vtcg, @vtsite, @reforgid, 'Williston VT Day Ahead GEFS ac_power', 'ac_power', '05:00', 1440, 'ending', 60, 1440, 'interval_mean', '{"is_reference_forecast": true, "model": "gefs_half_deg_to_hourly_mean"}', 'y'), (
+  @flcg, @flsite, @reforgid, 'Cocoa FL Day Ahead GEFS ac_power', 'ac_power', '05:00', 1440, 'ending', 60, 1440, 'interval_mean', '{"is_reference_forecast": true, "model": "gefs_half_deg_to_hourly_mean"}', 'y'
+);
+
+CREATE PROCEDURE makecvs(IN gid BINARY(16))
+BEGIN
+   DECLARE cv float DEFAULT 0.0;
+
+   WHILE cv < 101 DO
+       INSERT INTO cdf_forecasts_singles (cdf_forecast_group_id, constant_value) VALUES (gid, cv);
+       SET cv = cv + 5;
+   END WHILE;
+END;
+
+CALL makecvs(@abqcg);
+CALL makecvs(@nvcg);
+CALL makecvs(@vtcg);
+CALL makecvs(@flcg);
+
+
+INSERT INTO observations (organization_id, site_id, name, variable, interval_label, interval_length, interval_value_type, uncertainty, extra_parameters
+) VALUES (
+  @reforgid, @abqsite, 'Albuquerque NM ac_power', 'ac_power', 'ending', 1, 'interval_mean', 0, '{"network": "DOE RTC", "network_api_id": "Albuquerque", "network_api_abbreviation": "", "observation_interval_length": 1, "attribution": "", "module": "Suniva 270W"}'
+), (
+  @reforgid, @nvsite, 'Henderson NV ac_power', 'ac_power', 'ending', 1, 'interval_mean', 0, '{"network": "DOE RTC", "network_api_id": "Henderson", "network_api_abbreviation": "", "observation_interval_length": 1, "attribution": "", "module": "Suniva 270W"}'
+), (
+  @reforgid, @vtsite, 'Williston VT ac_power', 'ac_power', 'ending', 1, 'interval_mean', 0, '{"network": "DOE RTC", "network_api_id": "Williston", "network_api_abbreviation": "", "observation_interval_length": 1, "attribution": "", "module": "Suniva 270W"}'
+), (
+  @reforgid, @flsite, 'Cocoa FL ac_power', 'ac_power', 'ending', 1, 'interval_mean', 0, '{"network": "DOE RTC", "network_api_id": "Cocoa", "network_api_abbreviation": "", "observation_interval_length": 1, "attribution": "", "module": "Suniva 270W"}'
+);
+
+
+CREATE PROCEDURE doereport(IN name VARCHAR(64), IN siteid BINARY(16), IN reportid BINARY(16))
+BEGIN
+    DECLARE done INT DEFAULT FALSE;
+    DECLARE orgid BINARY(16);
+    DECLARE baseparams JSON;
+    DECLARE fxid CHAR(36);
+    DECLARE obsid CHAR(36);
+    DECLARE cur CURSOR FOR SELECT BIN_TO_UUID(id, 1) as id FROM forecasts WHERE site_id = siteid;
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+
+    SET baseparams = JSON_OBJECT('start', '2019-01-01T00:00Z', 'end', '2020-01-01T00:00Z', 'metrics', JSON_ARRAY('mae', 'rmse', 'mbe'), 'object_pairs', JSON_ARRAY());
+    SET orgid = (SELECT organization_id FROM sites WHERE id = siteid);
+    SET obsid = (SELECT BIN_TO_UUID(id, 1) FROM observations where site_id = siteid);
+
+    OPEN cur;
+    read_loop: LOOP
+      FETCH cur INTO fxid;
+      IF done THEN
+        LEAVE read_loop;
+      END IF;
+      SET baseparams = JSON_ARRAY_APPEND(baseparams, '$.object_pairs', JSON_OBJECT('forecast', fxid, 'observation', obsid));
+   END LOOP;
+   CLOSE cur;
+   INSERT INTO reports (id, organization_id, name, report_parameters) VALUES (reportid, orgid, name, baseparams);
+END;
+
+
+SET @abqrep = UUID_TO_BIN(UUID(), 1);
+SET @nvrep = UUID_TO_BIN(UUID(), 1);
+SET @vtrep = UUID_TO_BIN(UUID(), 1);
+SET @flrep = UUID_TO_BIN(UUID(), 1);
+
+CALL doereport('Albuquerque NM AC Power 2019 Report', @abqsite, @abqrep);
+CALL doereport('Henderson NV AC Power 2019 Report', @nvsite, @nvrep);
+CALL doereport('Williston VT AC Power 2019 Report', @vtsite, @vtrep);
+CALL doereport('Cocoa FL AC Power 2019 Report', @flsite, @flrep);
+
+
+DELETE FROM scheduled_jobs WHERE id = UUID_TO_BIN('907a9340-0b11-11ea-9e88-f4939feddd82', 1);
+INSERT INTO scheduled_jobs (id, organization_id, user_id, name, job_type, parameters, schedule, version) VALUES (
+    UUID_TO_BIN(UUID(), 1),
+    @reforgid,
+    @refid,
+    'Reference data daily validation',
+    'daily_observation_validation',
+    JSON_OBJECT('start_td', '-28h', 'end_td', '0h', 'base_url', @baseurl),
+    '{"type": "cron", "cron_string": "0 4 * * *"}',
+    0
+), (
+    UUID_TO_BIN(UUID(), 1),
+    @reforgid,
+    @refid,
+    'Reference NWP generation',
+    'reference_nwp',
+    JSON_OBJECT('issue_time_buffer', '10min', 'base_url', @baseurl),
+    '{"type": "cron", "cron_string": "50 * * * *"}',
+    0
+), (
+    UUID_TO_BIN(UUID(), 1),
+    @reforgid,
+    @refid,
+    'ABQ 2019 report',
+    'periodic_report',
+    JSON_OBJECT('report_id', BIN_TO_UUID(@abqrep, 1), 'base_url', @baseurl),
+    '{"type": "cron", "cron_string": "0 7 * * *"}',
+    0
+), (
+    UUID_TO_BIN(UUID(), 1),
+    @reforgid,
+    @refid,
+    'Henderson 2019 report',
+    'periodic_report',
+    JSON_OBJECT('report_id', BIN_TO_UUID(@nvrep, 1), 'base_url', @baseurl),
+    '{"type": "cron", "cron_string": "0 8 * * *"}',
+    0
+), (
+    UUID_TO_BIN(UUID(), 1),
+    @reforgid,
+    @refid,
+    'Williston 2019 report',
+    'periodic_report',
+    JSON_OBJECT('report_id', BIN_TO_UUID(@vtrep, 1), 'base_url', @baseurl),
+    '{"type": "cron", "cron_string": "0 5 * * *"}',
+    0
+), (
+    UUID_TO_BIN(UUID(), 1),
+    @reforgid,
+    @refid,
+    'Cocoa 2019 report',
+    'periodic_report',
+    JSON_OBJECT('report_id', BIN_TO_UUID(@flrep, 1), 'base_url', @baseurl),
+    '{"type": "cron", "cron_string": "0 5 * * *"}',
+    0
+);

--- a/sfa_api/admincli.py
+++ b/sfa_api/admincli.py
@@ -280,7 +280,7 @@ def create_job_user(organization_name, encryption_key, **kwargs):
 @with_default_options
 @click.argument('user_id', required=True, type=click.UUID)
 @click.argument('role_name', nargs=-1, type=click.Choice(
-    ['Create reports', 'Validate observations',
+    ['Recompute reports', 'Validate observations',
      'Generate reference forecasts']))
 def add_job_role(user_id, role_name, **kwargs):
     """

--- a/sfa_api/tests/test_admincli.py
+++ b/sfa_api/tests/test_admincli.py
@@ -361,7 +361,7 @@ def test_create_job_user_no_org(app_cli_runner, mocker):
 
 
 @pytest.mark.parametrize('role', [
-    'Create reports', 'Validate observations',
+    'Recompute reports', 'Validate observations',
     'Generate reference forecasts'
 ])
 def test_add_job_role(app_cli_runner, user_id, role):
@@ -379,12 +379,12 @@ def test_add_job_role_bad_role(app_cli_runner, user_id):
 def test_add_job_role_multiple(app_cli_runner, user_id):
     res = app_cli_runner.invoke(
         admincli.add_job_role,
-        auth_args + [user_id, 'Create reports', 'Validate observations'])
+        auth_args + [user_id, 'Recompute reports', 'Validate observations'])
     assert res.exit_code == 0
 
 
 @pytest.mark.parametrize('role', [
-    'Create reports', 'Validate observations',
+    'Recompute reports', 'Validate observations',
     'Generate reference forecasts'
 ])
 def test_add_job_role_already_present(app_cli_runner, user_id, role):
@@ -397,7 +397,7 @@ def test_add_job_role_already_present(app_cli_runner, user_id, role):
 
 
 @pytest.mark.parametrize('role', [
-    'Create reports', 'Validate observations',
+    'Recompute reports', 'Validate observations',
     'Generate reference forecasts'
 ])
 def test_add_job_role_user_dne(app_cli_runner, missing_id, role):


### PR DESCRIPTION
For DOE RTC sites, including creating the sites/fx/obs/prob. fx, reports, and jobs for daily validation, reference nwp forecast generation, and periodic report generation. This should act as a continuous test of the job framework. This only applies to dev as we won't run this migration for prod. I'll add separate reports for prod, probably to the core repo.

Also change the 'Create reports' role to 'Recompute reports' and update permissions accordingly.