### PR TITLE
handle integrity checks for dual column keys, closes #197

### DIFF
--- a/sfa_api/tests/rbac/test_permissions.py
+++ b/sfa_api/tests/rbac/test_permissions.py
@@ -102,6 +102,20 @@ def test_add_object_to_permission(api, new_perm, new_observation):
     assert new_obs in objects_on_perm.keys()
 
 
+def test_add_object_to_permission_already_exists(
+        api, new_perm, new_observation):
+    perm_id = new_perm()
+    new_obs = new_observation()
+    add_to_perm = api.post(f'/permissions/{perm_id}/objects/{new_obs}',
+                           BASE_URL)
+    assert add_to_perm.status_code == 204
+    add_to_perm_failure = api.post(f'/permissions/{perm_id}/objects/{new_obs}',
+                                   BASE_URL)
+    assert add_to_perm_failure.status_code == 400
+    response = add_to_perm_failure.json['errors']
+    assert response['permission'] == ['Permission already acts upon object.']
+
+
 @pytest.mark.parametrize('action,object_type', [
     ('update', 'permissions'),
     ('read', 'observations'),

--- a/sfa_api/tests/rbac/test_permissions.py
+++ b/sfa_api/tests/rbac/test_permissions.py
@@ -102,7 +102,7 @@ def test_add_object_to_permission(api, new_perm, new_observation):
     assert new_obs in objects_on_perm.keys()
 
 
-def test_add_object_to_permission_already_exists(
+def test_add_object_to_permission_object_already_exists(
         api, new_perm, new_observation):
     perm_id = new_perm()
     new_obs = new_observation()
@@ -114,6 +114,19 @@ def test_add_object_to_permission_already_exists(
     assert add_to_perm_failure.status_code == 400
     response = add_to_perm_failure.json['errors']
     assert response['permission'] == ['Permission already acts upon object.']
+
+
+def test_add_object_to_permission_no_permission_object_already_exists(
+        api, new_perm, new_observation, remove_perms):
+    perm_id = new_perm()
+    new_obs = new_observation()
+    add_to_perm = api.post(f'/permissions/{perm_id}/objects/{new_obs}',
+                           BASE_URL)
+    assert add_to_perm.status_code == 204
+    remove_perms('update', 'permissions')
+    add_to_perm_failure = api.post(f'/permissions/{perm_id}/objects/{new_obs}',
+                                   BASE_URL)
+    assert add_to_perm_failure.status_code == 404
 
 
 @pytest.mark.parametrize('action,object_type', [

--- a/sfa_api/tests/rbac/test_roles.py
+++ b/sfa_api/tests/rbac/test_roles.py
@@ -56,6 +56,15 @@ def test_create_delete_role(api):
     assert role_dne.status_code == 404
 
 
+def test_create_role_name_exists(api):
+    new_role_id = api.post('/roles/', BASE_URL, json=ROLE)
+    assert new_role_id.status_code == 201
+    role_failure = api.post('/roles/', BASE_URL, json=ROLE)
+    assert role_failure.status_code == 400
+    response = role_failure.json['errors']
+    assert response['role'] == ["Role 'test created role' already exists."]
+
+
 @pytest.mark.parametrize('role,error', [
     ({'name': 'brad'}, '{"description":["Missing data for required field."]}'),
     ({'description': 'brad role'},

--- a/sfa_api/tests/rbac/test_roles.py
+++ b/sfa_api/tests/rbac/test_roles.py
@@ -65,6 +65,14 @@ def test_create_role_name_exists(api):
     assert response['role'] == ["Role 'test created role' already exists."]
 
 
+def test_create_role_name_exists_no_permissions(api, remove_perms):
+    new_role_id = api.post('/roles/', BASE_URL, json=ROLE)
+    assert new_role_id.status_code == 201
+    remove_perms('create', 'roles')
+    role_failure = api.post('/roles/', BASE_URL, json=ROLE)
+    assert role_failure.status_code == 404
+
+
 @pytest.mark.parametrize('role,error', [
     ({'name': 'brad'}, '{"description":["Missing data for required field."]}'),
     ({'description': 'brad role'},


### PR DESCRIPTION
Adds try/except for a couple of cases where tables contain a two-column primary key and attempts to add a duplicate key lead to an uncaught Integrity Error.