### PR TITLE
User info retry

### DIFF
--- a/sfa_api/utils/auth.py
+++ b/sfa_api/utils/auth.py
@@ -81,8 +81,7 @@ def request_user_info():
     adapter = requests.adapters.HTTPAdapter(max_retries=retries)
     session.mount(base_url, adapter)
 
-    info_request = session.get(
-        current_app.config['AUTH0_BASE_URL'] + '/userinfo', timeout=3.0)
+    info_request = session.get(base_url + '/userinfo', timeout=3.0)
 
     info_request.raise_for_status()
     user_info = info_request.json()

--- a/sfa_api/utils/auth.py
+++ b/sfa_api/utils/auth.py
@@ -76,7 +76,7 @@ def request_user_info(retries=5):
         if info_request.status_code == 401:
             # User is not authorized
             return {}
-        return request_user_info(retries-1)
+        return request_user_info(retries - 1)
     user_info = info_request.json()
     return user_info
 

--- a/sfa_api/utils/auth.py
+++ b/sfa_api/utils/auth.py
@@ -8,6 +8,7 @@ it is better documented and is not missing any JWT features.
 from json.decoder import JSONDecodeError
 from functools import wraps
 import requests
+from urllib3 import Retry
 
 
 from flask import (request, Response, current_app, render_template,
@@ -51,32 +52,39 @@ def verify_access_token():
         return validate_user_existence()
 
 
-def request_user_info(retries=5):
+def request_user_info():
     """Makes a user info request to check if the user exists
     and is verified.
     Returns
     -------
     unser_info: dict
-        Dict of user information provided by auth0 or empty dict on failure.
+        Dict of user information provided by auth0.
     Raises
     ------
     json.decoder.JSONDecodeError
         If the user info request returns some invalid json.
+
+    requests.exceptions.HTTPError
+        If the request fails after 5 retries.
     """
-    if retries < 0:
-        return {}
-    info_request = requests.get(
-        current_app.config['AUTH0_BASE_URL'] + '/userinfo',
-        headers={
-            'Authorization': f'Bearer {current_access_token}',
-        })
-    try:
-        info_request.raise_for_status()
-    except requests.exceptions.HTTPError:
-        if info_request.status_code == 401:
-            # User is not authorized
-            return {}
-        return request_user_info(retries - 1)
+    session = requests.Session()
+    session.headers = {
+        'Authorization': f'Bearer {current_access_token}',
+    }
+    retries = Retry(
+        total=5, connect=3, read=3, status=3,
+        status_forcelist=[408, 500, 502, 503, 504],
+        backoff_factor=0.2,
+        respect_retry_after_header=True,
+    )
+    base_url = current_app.config['AUTH0_BASE_URL']
+    adapter = requests.adapters.HTTPAdapter(max_retries=retries)
+    session.mount(base_url, adapter)
+
+    info_request = session.get(
+        current_app.config['AUTH0_BASE_URL'] + '/userinfo', timeout=3.0)
+
+    info_request.raise_for_status()
     user_info = info_request.json()
     return user_info
 
@@ -102,9 +110,7 @@ def validate_user_existence():
     if not storage.user_exists():
         try:
             info = request_user_info()
-        except JSONDecodeError:
-            # The user has been removed from auth0 but the
-            # token is still valid
+        except (requests.exceptions.HTTPError, JSONDecodeError):
             return False
         else:
             if not info.get('email_verified', False):

--- a/sfa_api/utils/tests/test_auth.py
+++ b/sfa_api/utils/tests/test_auth.py
@@ -1,6 +1,8 @@
 import pytest
 from json.decoder import JSONDecodeError
 
+from requests.exceptions import HTTPError
+
 from sfa_api.utils import auth
 
 
@@ -134,6 +136,6 @@ def test_request_user_info(sql_app, auth_token, user_id):
 def test_request_user_info_failure(sql_app, user_id):
     ctx = sql_app.test_request_context()
     ctx.push()
-    user_info = auth.request_user_info()
-    assert user_info == {}
+    with pytest.raises(HTTPError):
+        auth.request_user_info()
     ctx.pop()

--- a/sfa_api/utils/tests/test_auth.py
+++ b/sfa_api/utils/tests/test_auth.py
@@ -1,8 +1,6 @@
 import pytest
 from json.decoder import JSONDecodeError
 
-from requests.exceptions import HTTPError
-
 from sfa_api.utils import auth
 
 
@@ -133,28 +131,9 @@ def test_request_user_info(sql_app, auth_token, user_id):
     ctx.pop()
 
 
-def test_request_user_info_401_failure(sql_app, user_id):
+def test_request_user_info_failure(sql_app, user_id):
     ctx = sql_app.test_request_context()
     ctx.push()
     user_info = auth.request_user_info()
     assert user_info == {}
     ctx.pop()
-
-
-@pytest.mark.parametrize('status_code', [400, 404, 422, 500])
-def test_request_user_info_maximum_failures(
-        sql_app, user_id, mocker, status_code):
-    mocked_response = mocker.Mock()
-    mocked_response.status_code == status_code
-    raise_for_status = mocker.Mock()
-    raise_for_status.side_effect = HTTPError(response=mocked_response)
-    mocked_response.raise_for_status = raise_for_status
-    mocked_get = mocker.patch('sfa_api.utils.auth.requests.get',
-                              return_value=mocked_response)
-
-    ctx = sql_app.test_request_context()
-    ctx.push()
-    user_info = auth.request_user_info()
-    assert user_info == {}
-    ctx.pop()
-    assert mocked_get.call_count == 6

--- a/sfa_api/utils/tests/test_auth.py
+++ b/sfa_api/utils/tests/test_auth.py
@@ -142,7 +142,8 @@ def test_request_user_info_401_failure(sql_app, user_id):
 
 
 @pytest.mark.parametrize('status_code', [400, 404, 422, 500])
-def test_request_user_info_401_failure(sql_app, user_id, mocker, status_code):
+def test_request_user_info_maximum_failures(
+        sql_app, user_id, mocker, status_code):
     mocked_response = mocker.Mock()
     mocked_response.status_code == status_code
     raise_for_status = mocker.Mock()

--- a/sfa_api/utils/tests/test_auth.py
+++ b/sfa_api/utils/tests/test_auth.py
@@ -130,3 +130,11 @@ def test_request_user_info(sql_app, auth_token, user_id):
     assert user_info['name'] == 'testing@solarforecastarbiter.org'
     assert user_info['sub'] == 'auth0|5be343df7025406237820b85'
     ctx.pop()
+
+
+def test_request_user_info_failure(sql_app, user_id):
+    ctx = sql_app.test_request_context()
+    ctx.push()
+    user_info = auth.request_user_info()
+    assert user_info == {}
+    ctx.pop()


### PR DESCRIPTION
aims at closing #152 
This is admittedly a naive approach to retrying the auth0 /userinfo endpoint., but considering this code should only run when a new user logs in for the first time, I think it should be sufficient. Also added logic such that if a 401 is returned, it returns immediately. I'm not sure if we want to add a back off or anything.