### PR TITLE
Speed up value inserts

### DIFF
--- a/datastore/migrations/0034_faster_inserts.down.sql
+++ b/datastore/migrations/0034_faster_inserts.down.sql
@@ -1,0 +1,70 @@
+DROP PROCEDURE store_observation_values;
+CREATE DEFINER = 'insert_objects'@'localhost' PROCEDURE store_observation_values (
+    IN auth0id VARCHAR(32), IN strid CHAR(36), IN timestamp TIMESTAMP, IN value FLOAT,
+    IN quality_flag SMALLINT UNSIGNED)
+COMMENT 'Store a single time, value, quality_flag row into observation_values'
+MODIFIES SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+    SET binid = (SELECT UUID_TO_BIN(strid, 1));
+    SET allowed = (SELECT can_user_perform_action(auth0id, binid, 'write_values'));
+    IF allowed THEN
+        INSERT INTO arbiter_data.observations_values (id, timestamp, value, quality_flag) VALUES (
+            binid, timestamp, value, quality_flag) ON DUPLICATE KEY UPDATE value=value, quality_flag=quality_flag;
+    ELSE
+        SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "write observation values"',
+        MYSQL_ERRNO = 1142;
+    END IF;
+END;
+
+GRANT EXECUTE ON PROCEDURE arbiter_data.store_observation_values TO 'insert_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.store_observation_values TO 'apiuser'@'%';
+
+
+DROP PROCEDURE store_forecast_values;
+CREATE DEFINER = 'insert_objects'@'localhost' PROCEDURE store_forecast_values (
+    IN auth0id VARCHAR(32), IN strid CHAR(36), IN timestamp TIMESTAMP, IN value FLOAT)
+COMMENT 'Store a single time, value, quality_flag row into forecast_values'
+MODIFIES SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+    SET binid = (SELECT UUID_TO_BIN(strid, 1));
+    SET allowed = (SELECT can_user_perform_action(auth0id, binid, 'write_values'));
+    IF allowed THEN
+        INSERT INTO arbiter_data.forecasts_values (id, timestamp, value) VALUES (
+            binid, timestamp, value) ON DUPLICATE KEY UPDATE value=value;
+    ELSE
+        SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "write forecast values"',
+        MYSQL_ERRNO = 1142;
+    END IF;
+END;
+
+GRANT EXECUTE ON PROCEDURE arbiter_data.store_forecast_values TO 'insert_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.store_forecast_values TO 'apiuser'@'%';
+
+
+DROP PROCEDURE store_cdf_forecast_values;
+CREATE DEFINER = 'insert_objects'@'localhost' PROCEDURE store_cdf_forecast_values (
+    IN auth0id VARCHAR(32), IN strid CHAR(36), IN timestamp TIMESTAMP, IN value FLOAT)
+COMMENT 'Store a single time, value, quality_flag row into cdf_forecast_values'
+MODIFIES SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    DECLARE groupid BINARY(16);
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+    SET binid = UUID_TO_BIN(strid, 1);
+    SET groupid = (SELECT cdf_forecast_group_id FROM cdf_forecasts_singles WHERE id = binid);
+    SET allowed = (SELECT can_user_perform_action(auth0id, groupid, 'write_values'));
+    IF allowed THEN
+        INSERT INTO arbiter_data.cdf_forecasts_values (id, timestamp, value) VALUES (
+            binid, timestamp, value) ON DUPLICATE KEY UPDATE value=value;
+    ELSE
+        SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "write cdf forecast values"',
+        MYSQL_ERRNO = 1142;
+    END IF;
+END;
+
+GRANT EXECUTE ON PROCEDURE arbiter_data.store_cdf_forecast_values TO 'insert_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.store_cdf_forecast_values TO 'apiuser'@'%';

--- a/datastore/migrations/0034_faster_inserts.up.sql
+++ b/datastore/migrations/0034_faster_inserts.up.sql
@@ -12,9 +12,9 @@ BEGIN
         INSERT INTO arbiter_data.observations_values (id, timestamp, value, quality_flag)
             SELECT binid, timestamp, value, quality_flag
             FROM JSON_TABLE(data, '$[*]' COLUMNS (
-                timestamp TIMESTAMP PATH '$.timestamp' ERROR ON EMPTY ERROR ON ERROR,
-                value FLOAT PATH '$.value' ERROR ON ERROR,
-                quality_flag SMALLINT UNSIGNED PATH '$.quality_flag' ERROR ON EMPTY ERROR ON ERROR)
+                timestamp TIMESTAMP PATH '$.ts' ERROR ON EMPTY ERROR ON ERROR,
+                value FLOAT PATH '$.v' NULL ON EMPTY ERROR ON ERROR,
+                quality_flag SMALLINT UNSIGNED PATH '$.qf' ERROR ON EMPTY ERROR ON ERROR)
             ) as jsonvals
         ON DUPLICATE KEY UPDATE value=jsonvals.value,
             quality_flag=jsonvals.quality_flag;
@@ -43,8 +43,8 @@ BEGIN
         INSERT INTO arbiter_data.forecasts_values (id, timestamp, value)
             SELECT binid, timestamp, value
             FROM JSON_TABLE(data, '$[*]' COLUMNS (
-               timestamp TIMESTAMP PATH '$.timestamp' ERROR ON EMPTY ERROR ON ERROR,
-               value FLOAT PATH '$.value' ERROR ON ERROR)
+               timestamp TIMESTAMP PATH '$.ts' ERROR ON EMPTY ERROR ON ERROR,
+               value FLOAT PATH '$.v' NULL ON EMPTY ERROR ON ERROR)
             ) as jsonvals
         ON DUPLICATE KEY UPDATE value=jsonvals.value;
     ELSE
@@ -73,8 +73,8 @@ BEGIN
         INSERT INTO arbiter_data.cdf_forecasts_values (id, timestamp, value)
             SELECT binid, timestamp, value
             FROM JSON_TABLE(data, '$[*]' COLUMNS (
-                timestamp TIMESTAMP PATH '$.timestamp' ERROR ON EMPTY ERROR ON ERROR,
-                value FLOAT PATH '$.value' ERROR ON ERROR)
+                timestamp TIMESTAMP PATH '$.ts' ERROR ON EMPTY ERROR ON ERROR,
+                value FLOAT PATH '$.v' NULL ON EMPTY ERROR ON ERROR)
             ) as jsonvals
         ON DUPLICATE KEY UPDATE value=jsonvals.value;
     ELSE

--- a/datastore/migrations/0034_faster_inserts.up.sql
+++ b/datastore/migrations/0034_faster_inserts.up.sql
@@ -1,0 +1,87 @@
+DROP PROCEDURE store_observation_values;
+CREATE DEFINER = 'insert_objects'@'localhost' PROCEDURE store_observation_values (
+    IN auth0id VARCHAR(32), strid CHAR(36), IN data JSON)
+COMMENT 'Store a JSON object array with time, value, quality_flag keys into observation_values'
+MODIFIES SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+    SET binid = (SELECT UUID_TO_BIN(strid, 1));
+    SET allowed = (SELECT can_user_perform_action(auth0id, binid, 'write_values'));
+    IF allowed THEN
+        INSERT INTO arbiter_data.observations_values (id, timestamp, value, quality_flag)
+            SELECT binid, timestamp, value, quality_flag
+            FROM JSON_TABLE(data, '$[*]' COLUMNS (
+                timestamp TIMESTAMP PATH '$.timestamp' ERROR ON EMPTY ERROR ON ERROR,
+                value FLOAT PATH '$.value' ERROR ON ERROR,
+                quality_flag SMALLINT UNSIGNED PATH '$.quality_flag' ERROR ON EMPTY ERROR ON ERROR)
+            ) as jsonvals
+        ON DUPLICATE KEY UPDATE value=jsonvals.value,
+            quality_flag=jsonvals.quality_flag;
+    ELSE
+        SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "write observation values"',
+        MYSQL_ERRNO = 1142;
+    END IF;
+    select allowed;
+END;
+
+GRANT EXECUTE ON PROCEDURE store_observation_values TO 'insert_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE store_observation_values TO 'apiuser'@'%';
+
+
+DROP PROCEDURE store_forecast_values;
+CREATE DEFINER = 'insert_objects'@'localhost' PROCEDURE store_forecast_values (
+    IN auth0id VARCHAR(32), IN strid CHAR(36), IN data JSON)
+COMMENT 'Store a JSON object array with timestamp and value keys into forecast_values'
+MODIFIES SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+    SET binid = (SELECT UUID_TO_BIN(strid, 1));
+    SET allowed = (SELECT can_user_perform_action(auth0id, binid, 'write_values'));
+    IF allowed THEN
+        INSERT INTO arbiter_data.forecasts_values (id, timestamp, value)
+            SELECT binid, timestamp, value
+            FROM JSON_TABLE(data, '$[*]' COLUMNS (
+               timestamp TIMESTAMP PATH '$.timestamp' ERROR ON EMPTY ERROR ON ERROR,
+               value FLOAT PATH '$.value' ERROR ON ERROR)
+            ) as jsonvals
+        ON DUPLICATE KEY UPDATE value=jsonvals.value;
+    ELSE
+        SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "write forecast values"',
+        MYSQL_ERRNO = 1142;
+    END IF;
+END;
+
+GRANT EXECUTE ON PROCEDURE arbiter_data.store_forecast_values TO 'insert_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.store_forecast_values TO 'apiuser'@'%';
+
+
+DROP PROCEDURE store_cdf_forecast_values;
+CREATE DEFINER = 'insert_objects'@'localhost' PROCEDURE store_cdf_forecast_values (
+    IN auth0id VARCHAR(32), IN strid CHAR(36), IN data JSON)
+COMMENT 'Store a JSON object array with timestamp and value keys into cdf_forecast_values'
+MODIFIES SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    DECLARE groupid BINARY(16);
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+    SET binid = UUID_TO_BIN(strid, 1);
+    SET groupid = (SELECT cdf_forecast_group_id FROM cdf_forecasts_singles WHERE id = binid);
+    SET allowed = (SELECT can_user_perform_action(auth0id, groupid, 'write_values'));
+    IF allowed THEN
+        INSERT INTO arbiter_data.cdf_forecasts_values (id, timestamp, value)
+            SELECT binid, timestamp, value
+            FROM JSON_TABLE(data, '$[*]' COLUMNS (
+                timestamp TIMESTAMP PATH '$.timestamp' ERROR ON EMPTY ERROR ON ERROR,
+                value FLOAT PATH '$.value' ERROR ON ERROR)
+            ) as jsonvals
+        ON DUPLICATE KEY UPDATE value=jsonvals.value;
+    ELSE
+        SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "write cdf forecast values"',
+        MYSQL_ERRNO = 1142;
+    END IF;
+END;
+
+GRANT EXECUTE ON PROCEDURE arbiter_data.store_cdf_forecast_values TO 'insert_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.store_cdf_forecast_values TO 'apiuser'@'%';

--- a/datastore/tests/test_inserts.py
+++ b/datastore/tests/test_inserts.py
@@ -338,6 +338,12 @@ def test_store_observation_values_null(cursor, allow_write_values,
     bad = '[{"ts": "2020-01-01T00:00:00", "qf": 0, "v": null}]'
     with pytest.raises(pymysql.err.InternalError):
         cursor.callproc('store_observation_values', (auth0id, obsid, bad))
+    with pytest.raises(pymysql.err.InternalError):
+        cursor.callproc('store_observation_values', (
+            auth0id, obsid, '[{"ts": "2020-01-01T00:00:00"}]'))
+    with pytest.raises(pymysql.err.InternalError):
+        cursor.callproc('store_observation_values', (
+            auth0id, obsid, '[{"qf": 0}]'))
 
 
 def test_store_observation_values_duplicates(cursor, allow_write_values,
@@ -426,6 +432,9 @@ def test_store_forecast_values_null(cursor, allow_write_values,
     bad = '[{"ts": "2020-01-01T00:00:00", "v": null}]'
     with pytest.raises(pymysql.err.InternalError):
         cursor.callproc('store_forecast_values', (auth0id, fxid, bad))
+    with pytest.raises(pymysql.err.InternalError):
+        cursor.callproc('store_forecast_values', (
+            auth0id, fxid, '[{"v": 1.0}]'))
 
 
 def test_store_forecast_values_duplicates(cursor, allow_write_values,
@@ -648,6 +657,9 @@ def test_store_cdf_forecast_values_null(cursor, allow_write_values,
     bad = '[{"ts": "2020-01-01T00:00:00", "v": null}]'
     with pytest.raises(pymysql.err.InternalError):
         cursor.callproc('store_cdf_forecast_values', (auth0id, fxid, bad))
+    with pytest.raises(pymysql.err.InternalError):
+        cursor.callproc('store_cdf_forecast_values', (
+            auth0id, fxid, '[{"v": 1.0}]'))
 
 
 def test_store_cdf_forecast_values_duplicates(

--- a/datastore/tests/test_inserts.py
+++ b/datastore/tests/test_inserts.py
@@ -295,26 +295,27 @@ def test_store_site_denied_cant_create(dictcursor, site_callargs):
 
 @pytest.fixture()
 def observation_values(insertuser):
-    def make(auth0id, obsid):
-        now = dt.datetime.utcnow().replace(microsecond=0)
-        for i in range(100):
-            now += dt.timedelta(minutes=5)
-            yield auth0id, obsid, now, float(random.randint(0, 100)), 0
-
     auth0id = insertuser[0]['auth0_id']
     obsid = insertuser[3]['strid']
     obsbinid = insertuser[3]['id']
-    testobs = make(auth0id, obsid)
-    return obsbinid, testobs
+    expected = []
+    now = dt.datetime.utcnow().replace(microsecond=0)
+    for i in range(100):
+        now += dt.timedelta(minutes=5)
+        expected.append(
+            (obsbinid, now, float(random.randint(0, 100)),
+             random.randint(0, 100)))
+    testobs = json.dumps(
+        [{'timestamp': r[1].strftime('%Y-%m-%dT%H:%M:%S'),
+          'value': r[2], 'quality_flag': r[3]}
+         for r in expected])
+    return auth0id, obsid, obsbinid, testobs, expected
 
 
 def test_store_observation_values(cursor, allow_write_values,
                                   observation_values):
-    obsbinid, testobs = observation_values
-    expected = []
-    for to in testobs:
-        expected.append((obsbinid, *to[-3:]))
-        cursor.callproc('store_observation_values', to)
+    auth0id, obsid, obsbinid, testobs, expected = observation_values
+    cursor.callproc('store_observation_values', (auth0id, obsid, testobs))
     cursor.execute(
         'SELECT * FROM arbiter_data.observations_values WHERE id = %s AND'
         ' timestamp > CURRENT_TIMESTAMP()',
@@ -325,64 +326,68 @@ def test_store_observation_values(cursor, allow_write_values,
 
 def test_store_observation_values_duplicates(cursor, allow_write_values,
                                              observation_values):
-    obsbinid, testobs = observation_values
-    testobs = list(testobs)
-    expected = []
+    auth0id, obsid, obsbinid, testobs, expected = observation_values
     # first insert
-    for to in testobs:
-        cursor.callproc('store_observation_values', to)
-    # second insert
-    for to in testobs:
-        to = list(to)
-        to[-1] = 1
-        to[-2] = to[-2] + 1
-        cursor.callproc('store_observation_values', to)
-        expected.append((obsbinid, *to[-3:]))
+    cursor.callproc('store_observation_values', (auth0id, obsid, testobs))
     cursor.execute(
         'SELECT * FROM arbiter_data.observations_values WHERE id = %s AND'
         ' timestamp > CURRENT_TIMESTAMP()',
         obsbinid)
     res = cursor.fetchall()
     assert res == tuple(expected)
+    # second insert
+    alt = []
+    for r in expected:
+        alt.append((r[0], r[1], r[2] + 0.9, r[3] + 1))
+    nextobs = json.dumps(
+        [{'timestamp': r[1].strftime('%Y-%m-%dT%H:%M:%S'),
+          'value': r[2], 'quality_flag': r[3]}
+         for r in alt])
+    cursor.callproc('store_observation_values', (auth0id, obsid, nextobs))
+    cursor.execute(
+        'SELECT * FROM arbiter_data.observations_values WHERE id = %s AND'
+        ' timestamp > CURRENT_TIMESTAMP()',
+        obsbinid)
+    res = cursor.fetchall()
+    assert res == tuple(alt)
 
 
 def test_store_observation_values_cant_write(cursor, observation_values):
-    obsbinid, testobs = observation_values
+    auth0id, obsid, obsbinid, testobs, expected = observation_values
     with pytest.raises(pymysql.err.OperationalError) as e:
-        cursor.callproc('store_observation_values', list(testobs)[0])
+        cursor.callproc('store_observation_values', (auth0id, obsid, testobs))
     assert e.value.args[0] == 1142
 
 
 def test_store_observation_values_cant_write_cant_delete(
         cursor, observation_values, allow_delete_values):
-    obsbinid, testobs = observation_values
+    auth0id, obsid, obsbinid, testobs, expected = observation_values
     with pytest.raises(pymysql.err.OperationalError) as e:
-        cursor.callproc('store_observation_values', list(testobs)[0])
+        cursor.callproc('store_observation_values', (auth0id, obsid, testobs))
     assert e.value.args[0] == 1142
 
 
 @pytest.fixture()
 def forecast_values(insertuser):
-    def make(auth0id, fxid):
-        now = dt.datetime.utcnow().replace(microsecond=0)
-        for i in range(100):
-            now += dt.timedelta(minutes=5)
-            yield auth0id, fxid, now, float(random.randint(0, 100))
-
     auth0id = insertuser[0]['auth0_id']
     fxid = insertuser[2]['strid']
     fxbinid = insertuser[2]['id']
-    testfx = make(auth0id, fxid)
-    return fxbinid, testfx
+    expected = []
+    now = dt.datetime.utcnow().replace(microsecond=0)
+    for i in range(100):
+        now += dt.timedelta(minutes=5)
+        expected.append(
+            (fxbinid, now, float(random.randint(0, 100))))
+    testfx = json.dumps(
+        [{'timestamp': r[1].strftime('%Y-%m-%dT%H:%M:%S'),
+          'value': r[2]} for r in expected])
+    return auth0id, fxid, fxbinid, testfx, expected
 
 
 def test_store_forecast_values(cursor, allow_write_values,
                                forecast_values):
-    fxbinid, testfx = forecast_values
-    expected = []
-    for tf in testfx:
-        expected.append((fxbinid, *tf[2:]))
-        cursor.callproc('store_forecast_values', tf)
+    auth0id, fxid, fxbinid, testfx, expected = forecast_values
+    cursor.callproc('store_forecast_values', (auth0id, fxid, testfx))
     cursor.execute(
         'SELECT * FROM arbiter_data.forecasts_values WHERE id = %s AND'
         ' timestamp > CURRENT_TIMESTAMP()',
@@ -393,18 +398,9 @@ def test_store_forecast_values(cursor, allow_write_values,
 
 def test_store_forecast_values_duplicates(cursor, allow_write_values,
                                           forecast_values):
-    fxbinid, testfx = forecast_values
-    testfx = list(testfx)
-    expected = []
+    auth0id, fxid, fxbinid, testfx, expected = forecast_values
     # first insert
-    for tf in testfx:
-        cursor.callproc('store_forecast_values', tf)
-    # second insert
-    for tf in testfx:
-        tf = list(tf)
-        tf[-1] = tf[-1] + 1
-        expected.append((fxbinid, *tf[2:]))
-        cursor.callproc('store_forecast_values', tf)
+    cursor.callproc('store_forecast_values', (auth0id, fxid, testfx))
     cursor.execute(
         'SELECT * FROM arbiter_data.forecasts_values WHERE id = %s AND'
         ' timestamp > CURRENT_TIMESTAMP()',
@@ -412,19 +408,34 @@ def test_store_forecast_values_duplicates(cursor, allow_write_values,
     res = cursor.fetchall()
     assert res == tuple(expected)
 
+    # second insert
+    alt = []
+    for r in expected:
+        alt.append((r[0], r[1], r[2] + 0.9))
+    nextfx = json.dumps(
+        [{'timestamp': r[1].strftime('%Y-%m-%dT%H:%M:%S'),
+          'value': r[2]} for r in alt])
+    cursor.callproc('store_forecast_values', (auth0id, fxid, nextfx))
+    cursor.execute(
+        'SELECT * FROM arbiter_data.forecasts_values WHERE id = %s AND'
+        ' timestamp > CURRENT_TIMESTAMP()',
+        fxbinid)
+    res = cursor.fetchall()
+    assert res == tuple(alt)
+
 
 def test_store_forecast_values_cant_write(cursor, forecast_values):
-    fxbinid, testfx = forecast_values
+    auth0id, fxid, fxbinid, testfx, expected = forecast_values
     with pytest.raises(pymysql.err.OperationalError) as e:
-        cursor.callproc('store_forecast_values', list(testfx)[0])
+        cursor.callproc('store_forecast_values', (auth0id, fxid, testfx))
     assert e.value.args[0] == 1142
 
 
 def test_store_forecast_values_cant_write_cant_delete(
         cursor, forecast_values, allow_delete_values):
-    fxbinid, testfx = forecast_values
+    auth0id, fxid, fxbinid, testfx, expected = forecast_values
     with pytest.raises(pymysql.err.OperationalError) as e:
-        cursor.callproc('store_forecast_values', list(testfx)[0])
+        cursor.callproc('store_forecast_values', (auth0id, fxid, testfx))
     assert e.value.args[0] == 1142
 
 
@@ -563,61 +574,66 @@ def test_store_cdf_forecast_single_denied_cant_update_group(
 
 @pytest.fixture(params=[0, 1, 2])
 def cdf_forecast_values(insertuser, request):
-    def make(auth0id, fxid):
-        now = dt.datetime.utcnow().replace(microsecond=0)
-        for i in range(100):
-            now += dt.timedelta(minutes=5)
-            yield auth0id, fxid, now, float(random.randint(0, 100))
-
     auth0id = insertuser[0]['auth0_id']
     fxid = list(insertuser[6]['constant_values'].keys())[request.param]
-    testfx = make(auth0id, fxid)
-    return fxid, testfx
+    fxbinid = uuid_to_bin(uuid.UUID(fxid))
+    expected = []
+    now = dt.datetime.utcnow().replace(microsecond=0)
+    for i in range(100):
+        now += dt.timedelta(minutes=5)
+        expected.append(
+            (fxbinid, now, float(random.randint(0, 100))))
+    testfx = json.dumps(
+        [{'timestamp': r[1].strftime('%Y-%m-%dT%H:%M:%S'),
+          'value': r[2]} for r in expected])
+    return auth0id, fxid, fxbinid, testfx, expected
 
 
 def test_store_cdf_forecast_values(
         cursor, allow_write_values, cdf_forecast_values):
-    fxid, testfx = cdf_forecast_values
-    expected = []
-    for tf in testfx:
-        expected.append((fxid, *tf[2:]))
-        cursor.callproc('store_cdf_forecast_values', tf)
+    auth0id, fxid, fxbinid, testfx, expected = cdf_forecast_values
+    cursor.callproc('store_cdf_forecast_values', (auth0id, fxid, testfx))
     cursor.execute(
-        'SELECT BIN_TO_UUID(id, 1) as id, timestamp, value '
-        'FROM arbiter_data.cdf_forecasts_values WHERE id = UUID_TO_BIN(%s, 1)'
+        'SELECT id, timestamp, value '
+        'FROM arbiter_data.cdf_forecasts_values WHERE id = %s'
         ' AND timestamp > CURRENT_TIMESTAMP()',
-        fxid)
+        fxbinid)
     res = cursor.fetchall()
     assert res == tuple(expected)
 
 
 def test_store_cdf_forecast_values_duplicates(
         cursor, allow_write_values, cdf_forecast_values):
-    fxid, testfx = cdf_forecast_values
-    testfx = list(testfx)
-    expected = []
-    # first
-    for tf in testfx:
-        cursor.callproc('store_cdf_forecast_values', tf)
-    # duplicate
-    for tf in testfx:
-        tf = list(tf)
-        tf[-1] = tf[-1] + 9
-        cursor.callproc('store_cdf_forecast_values', tf)
-        expected.append((fxid, *tf[2:]))
+    auth0id, fxid, fxbinid, testfx, expected = cdf_forecast_values
+    cursor.callproc('store_cdf_forecast_values', (auth0id, fxid, testfx))
     cursor.execute(
-        'SELECT BIN_TO_UUID(id, 1) as id, timestamp, value '
-        'FROM arbiter_data.cdf_forecasts_values WHERE id = UUID_TO_BIN(%s, 1)'
+        'SELECT id, timestamp, value '
+        'FROM arbiter_data.cdf_forecasts_values WHERE id = %s'
         ' AND timestamp > CURRENT_TIMESTAMP()',
-        fxid)
+        fxbinid)
     res = cursor.fetchall()
     assert res == tuple(expected)
+    # duplicate
+    alt = []
+    for r in expected[::-1]:
+        alt.append((r[0], r[1], r[2] + 9.9))
+    nextfx = json.dumps(
+        [{'timestamp': r[1].strftime('%Y-%m-%dT%H:%M:%S'),
+          'value': r[2]} for r in alt])
+    cursor.callproc('store_cdf_forecast_values', (auth0id, fxid, nextfx))
+    cursor.execute(
+        'SELECT id, timestamp, value '
+        'FROM arbiter_data.cdf_forecasts_values WHERE id = %s'
+        ' AND timestamp > CURRENT_TIMESTAMP()',
+        fxbinid)
+    res = cursor.fetchall()
+    assert res == tuple(alt[::-1])
 
 
 def test_store_cdf_forecast_values_cant_write(cursor, cdf_forecast_values):
-    fxid, testfx = cdf_forecast_values
+    auth0id, fxid, fxbinid, testfx, expected = cdf_forecast_values
     with pytest.raises(pymysql.err.OperationalError) as e:
-        cursor.callproc('store_cdf_forecast_values', list(testfx)[0])
+        cursor.callproc('store_cdf_forecast_values', (auth0id, fxid, testfx))
     assert e.value.args[0] == 1142
 
 

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -205,7 +205,10 @@ class ForecastValuesView(MethodView):
         """
         ---
         summary: Add Forecast data
-        description: Add new timeseries values to Forecast entry.
+        description: |
+          Add new timeseries values to Forecast entry.
+          Float values *will be rounded* to 8 decimal places before
+          storage.
         tags:
         - Forecasts
         parameters:
@@ -500,8 +503,10 @@ class CDFForecastValues(MethodView):
         """
         ---
         summary: Add Probabilistic Forecast data for one constant value.
-        description: >-
+        description: |
           Add timeseries values to a Probabilistic Forecast constant value.
+          Float values *will be rounded* to 8 decimal places before
+          storage.
         tags:
         - Probabilistic Forecasts
         parameters:

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -205,7 +205,10 @@ class ObservationValuesView(MethodView):
         """
         ---
         summary: Add Observation data.
-        description: Add new timeseries values to the Observation entry.
+        description: |
+          Add new timeseries values to the Observation entry.
+          Float values *will be rounded* to 8 decimal places before
+          storage.
         tags:
         - Observations
         parameters:

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -211,7 +211,13 @@ def _set_forecast_parameters(forecast_dict):
 def _process_df_into_json(df, rounding=8):
     """Processes a Dataframe with DatetimeIndex and 'value' column
     (with optional 'quality_flag' column) into a json string of the
-    form [{"ts": ..., "v": ...}, ...] for sending to MySQL
+    form [{"ts": ..., "v": ...}, ...] for sending to MySQL.
+
+    This numpy string processing to JSON is much faster than
+    using the json module and converting the dataframe to a list
+    of dicts. Also can't use the builtin pandas json exporter
+    because we need to leave out the value key completely when
+    the value is NaN (limitation of MySQL JSON_TABLE for json null).
     """
     timestr = np.char.add(
         '{"ts":"', df.index.values.astype('M8[s]').astype(str))


### PR DESCRIPTION
It can take seconds (at least locally) to write a few thousand datapoints using one of the store_*_values procedures. This is also probably leading to a ~10 reads for every row written. Now all the values are bundled into a json array instead of going through each individual value with at least a 10x to 100x speedup.

![Screenshot from 2020-02-09 21-23-25](https://user-images.githubusercontent.com/4625457/74121037-11397a80-4b83-11ea-86e2-a554a44709a1.png)
