### PR TITLE
Validate path UUID

### DIFF
--- a/sfa_api/__init__.py
+++ b/sfa_api/__init__.py
@@ -16,6 +16,7 @@ from sentry_sdk.integrations.flask import FlaskIntegration  # NOQA
 from sfa_api.spec import spec  # NOQA
 from sfa_api.error_handlers import register_error_handlers  # NOQA
 from sfa_api.utils.auth import requires_auth  # NOQA
+from sfa_api.utils.url_converters import UUIDStringConverter  # NOQA
 
 
 ma = Marshmallow()
@@ -52,6 +53,7 @@ def create_app(config_name='ProductionConfig'):
                           'base-uri': "'none'"
                       },
                       content_security_policy_nonce_in=['script-src'])
+    app.url_map.converters['uuid_str'] = UUIDStringConverter
 
     from sfa_api.observations import obs_blp
     from sfa_api.forecasts import forecast_blp

--- a/sfa_api/aggregates.py
+++ b/sfa_api/aggregates.py
@@ -400,16 +400,16 @@ agg_blp = Blueprint(
 )
 agg_blp.add_url_rule('/', view_func=AllAggregatesView.as_view('all'))
 agg_blp.add_url_rule(
-    '/<uuid:aggregate_id>', view_func=AggregateView.as_view('single'))
+    '/<uuid_str:aggregate_id>', view_func=AggregateView.as_view('single'))
 agg_blp.add_url_rule(
-    '/<uuid:aggregate_id>/values',
+    '/<uuid_str:aggregate_id>/values',
     view_func=AggregateValuesView.as_view('values'))
 agg_blp.add_url_rule(
-    '/<uuid:aggregate_id>/metadata',
+    '/<uuid_str:aggregate_id>/metadata',
     view_func=AggregateMetadataView.as_view('metadata'))
 agg_blp.add_url_rule(
-    '/<uuid:aggregate_id>/forecasts/single',
+    '/<uuid_str:aggregate_id>/forecasts/single',
     view_func=AggregateForecasts.as_view('forecasts'))
 agg_blp.add_url_rule(
-    '/<uuid:aggregate_id>/forecasts/cdf',
+    '/<uuid_str:aggregate_id>/forecasts/cdf',
     view_func=AggregateCDFForecastGroups.as_view('cdf_forecasts'))

--- a/sfa_api/aggregates.py
+++ b/sfa_api/aggregates.py
@@ -400,16 +400,16 @@ agg_blp = Blueprint(
 )
 agg_blp.add_url_rule('/', view_func=AllAggregatesView.as_view('all'))
 agg_blp.add_url_rule(
-    '/<aggregate_id>', view_func=AggregateView.as_view('single'))
+    '/<uuid:aggregate_id>', view_func=AggregateView.as_view('single'))
 agg_blp.add_url_rule(
-    '/<aggregate_id>/values',
+    '/<uuid:aggregate_id>/values',
     view_func=AggregateValuesView.as_view('values'))
 agg_blp.add_url_rule(
-    '/<aggregate_id>/metadata',
+    '/<uuid:aggregate_id>/metadata',
     view_func=AggregateMetadataView.as_view('metadata'))
 agg_blp.add_url_rule(
-    '/<aggregate_id>/forecasts/single',
+    '/<uuid:aggregate_id>/forecasts/single',
     view_func=AggregateForecasts.as_view('forecasts'))
 agg_blp.add_url_rule(
-    '/<aggregate_id>/forecasts/cdf',
+    '/<uuid:aggregate_id>/forecasts/cdf',
     view_func=AggregateCDFForecastGroups.as_view('cdf_forecasts'))

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -572,24 +572,24 @@ forecast_blp.add_url_rule(
     '/single/',
     view_func=AllForecastsView.as_view('all'))
 forecast_blp.add_url_rule(
-    '/single/<forecast_id>',
+    '/single/<uuid:forecast_id>',
     view_func=ForecastView.as_view('single'))
 forecast_blp.add_url_rule(
-    '/single/<forecast_id>/values',
+    '/single/<uuid:forecast_id>/values',
     view_func=ForecastValuesView.as_view('values'))
 forecast_blp.add_url_rule(
-    '/single/<forecast_id>/metadata',
+    '/single/<uuid:forecast_id>/metadata',
     view_func=ForecastMetadataView.as_view('metadata'))
 
 forecast_blp.add_url_rule(
     '/cdf/',
     view_func=AllCDFForecastGroupsView.as_view('all_cdf_groups'))
 forecast_blp.add_url_rule(
-    '/cdf/<forecast_id>',
+    '/cdf/<uuid:forecast_id>',
     view_func=CDFForecastGroupMetadataView.as_view('single_cdf_group'))
 forecast_blp.add_url_rule(
-    '/cdf/single/<forecast_id>',
+    '/cdf/single/<uuid:forecast_id>',
     view_func=CDFForecastMetadata.as_view('single_cdf_metadata'))
 forecast_blp.add_url_rule(
-    '/cdf/single/<forecast_id>/values',
+    '/cdf/single/<uuid:forecast_id>/values',
     view_func=CDFForecastValues.as_view('single_cdf_value'))

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -572,24 +572,24 @@ forecast_blp.add_url_rule(
     '/single/',
     view_func=AllForecastsView.as_view('all'))
 forecast_blp.add_url_rule(
-    '/single/<uuid:forecast_id>',
+    '/single/<uuid_str:forecast_id>',
     view_func=ForecastView.as_view('single'))
 forecast_blp.add_url_rule(
-    '/single/<uuid:forecast_id>/values',
+    '/single/<uuid_str:forecast_id>/values',
     view_func=ForecastValuesView.as_view('values'))
 forecast_blp.add_url_rule(
-    '/single/<uuid:forecast_id>/metadata',
+    '/single/<uuid_str:forecast_id>/metadata',
     view_func=ForecastMetadataView.as_view('metadata'))
 
 forecast_blp.add_url_rule(
     '/cdf/',
     view_func=AllCDFForecastGroupsView.as_view('all_cdf_groups'))
 forecast_blp.add_url_rule(
-    '/cdf/<uuid:forecast_id>',
+    '/cdf/<uuid_str:forecast_id>',
     view_func=CDFForecastGroupMetadataView.as_view('single_cdf_group'))
 forecast_blp.add_url_rule(
-    '/cdf/single/<uuid:forecast_id>',
+    '/cdf/single/<uuid_str:forecast_id>',
     view_func=CDFForecastMetadata.as_view('single_cdf_metadata'))
 forecast_blp.add_url_rule(
-    '/cdf/single/<uuid:forecast_id>/values',
+    '/cdf/single/<uuid_str:forecast_id>/values',
     view_func=CDFForecastValues.as_view('single_cdf_value'))

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -319,10 +319,10 @@ obs_blp = Blueprint(
 
 obs_blp.add_url_rule('/', view_func=AllObservationsView.as_view('all'))
 obs_blp.add_url_rule(
-    '/<uuid:observation_id>', view_func=ObservationView.as_view('single'))
+    '/<uuid_str:observation_id>', view_func=ObservationView.as_view('single'))
 obs_blp.add_url_rule(
-    '/<uuid:observation_id>/values',
+    '/<uuid_str:observation_id>/values',
     view_func=ObservationValuesView.as_view('values'))
 obs_blp.add_url_rule(
-    '/<uuid:observation_id>/metadata',
+    '/<uuid_str:observation_id>/metadata',
     view_func=ObservationMetadataView.as_view('metadata'))

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -319,10 +319,10 @@ obs_blp = Blueprint(
 
 obs_blp.add_url_rule('/', view_func=AllObservationsView.as_view('all'))
 obs_blp.add_url_rule(
-    '/<observation_id>', view_func=ObservationView.as_view('single'))
+    '/<uuid:observation_id>', view_func=ObservationView.as_view('single'))
 obs_blp.add_url_rule(
-    '/<observation_id>/values',
+    '/<uuid:observation_id>/values',
     view_func=ObservationValuesView.as_view('values'))
 obs_blp.add_url_rule(
-    '/<observation_id>/metadata',
+    '/<uuid:observation_id>/metadata',
     view_func=ObservationMetadataView.as_view('metadata'))

--- a/sfa_api/permissions.py
+++ b/sfa_api/permissions.py
@@ -203,8 +203,8 @@ permission_blp = Blueprint(
 )
 permission_blp.add_url_rule('/', view_func=AllPermissionsView.as_view('all'))
 permission_blp.add_url_rule(
-    '/<permission_id>',
+    '/<uuid:permission_id>',
     view_func=PermissionView.as_view('single'))
 permission_blp.add_url_rule(
-    '/<permission_id>/objects/<object_id>',
+    '/<uuid:permission_id>/objects/<uuid:object_id>',
     view_func=PermissionObjectManagementView.as_view('objects'))

--- a/sfa_api/permissions.py
+++ b/sfa_api/permissions.py
@@ -203,8 +203,8 @@ permission_blp = Blueprint(
 )
 permission_blp.add_url_rule('/', view_func=AllPermissionsView.as_view('all'))
 permission_blp.add_url_rule(
-    '/<uuid:permission_id>',
+    '/<uuid_str:permission_id>',
     view_func=PermissionView.as_view('single'))
 permission_blp.add_url_rule(
-    '/<uuid:permission_id>/objects/<uuid:object_id>',
+    '/<uuid_str:permission_id>/objects/<uuid_str:object_id>',
     view_func=PermissionObjectManagementView.as_view('objects'))

--- a/sfa_api/reports.py
+++ b/sfa_api/reports.py
@@ -284,18 +284,18 @@ reports_blp.add_url_rule(
     view_func=AllReportsView.as_view('all')
 )
 reports_blp.add_url_rule(
-        '/<uuid:report_id>',
+    '/<uuid_str:report_id>',
     view_func=ReportView.as_view('single')
 )
 reports_blp.add_url_rule(
-    '/<uuid:report_id>/status/<status>',
+    '/<uuid_str:report_id>/status/<status>',
     view_func=ReportStatusView.as_view('status')
 )
 reports_blp.add_url_rule(
-    '/<uuid:report_id>/raw',
+    '/<uuid_str:report_id>/raw',
     view_func=RawReportView.as_view('metrics')
 )
 reports_blp.add_url_rule(
-    '/<uuid:report_id>/values',
+    '/<uuid_str:report_id>/values',
     view_func=ReportValuesView.as_view('values')
 )

--- a/sfa_api/reports.py
+++ b/sfa_api/reports.py
@@ -284,18 +284,18 @@ reports_blp.add_url_rule(
     view_func=AllReportsView.as_view('all')
 )
 reports_blp.add_url_rule(
-    '/<report_id>',
+        '/<uuid:report_id>',
     view_func=ReportView.as_view('single')
 )
 reports_blp.add_url_rule(
-    '/<report_id>/status/<status>',
+    '/<uuid:report_id>/status/<status>',
     view_func=ReportStatusView.as_view('status')
 )
 reports_blp.add_url_rule(
-    '/<report_id>/raw',
+    '/<uuid:report_id>/raw',
     view_func=RawReportView.as_view('metrics')
 )
 reports_blp.add_url_rule(
-    '/<report_id>/values',
+    '/<uuid:report_id>/values',
     view_func=ReportValuesView.as_view('values')
 )

--- a/sfa_api/roles.py
+++ b/sfa_api/roles.py
@@ -187,8 +187,8 @@ role_blp = Blueprint(
     'roles', 'roles', url_prefix='/roles',
 )
 role_blp.add_url_rule('/', view_func=AllRolesView.as_view('all'))
-role_blp.add_url_rule('/<role_id>', view_func=RoleView.as_view('single'))
+role_blp.add_url_rule('/<uuid:role_id>', view_func=RoleView.as_view('single'))
 role_blp.add_url_rule(
-    '/<role_id>/permissions/<permission_id>',
+    '/<uuid:role_id>/permissions/<uuid:permission_id>',
     view_func=RolePermissionManagementView.as_view('permissions')
 )

--- a/sfa_api/roles.py
+++ b/sfa_api/roles.py
@@ -187,8 +187,11 @@ role_blp = Blueprint(
     'roles', 'roles', url_prefix='/roles',
 )
 role_blp.add_url_rule('/', view_func=AllRolesView.as_view('all'))
-role_blp.add_url_rule('/<uuid:role_id>', view_func=RoleView.as_view('single'))
 role_blp.add_url_rule(
-    '/<uuid:role_id>/permissions/<uuid:permission_id>',
+    '/<uuid_str:role_id>',
+    view_func=RoleView.as_view('single')
+)
+role_blp.add_url_rule(
+    '/<uuid_str:role_id>/permissions/<uuid_str:permission_id>',
     view_func=RolePermissionManagementView.as_view('permissions')
 )

--- a/sfa_api/sites.py
+++ b/sfa_api/sites.py
@@ -243,10 +243,10 @@ site_blp = Blueprint(
 )
 site_blp.add_url_rule('/', view_func=AllSitesView.as_view('all'))
 site_blp.add_url_rule(
-    '/<uuid:site_id>', view_func=SiteView.as_view('single'))
-site_blp.add_url_rule('/<uuid:site_id>/observations',
+    '/<uuid_str:site_id>', view_func=SiteView.as_view('single'))
+site_blp.add_url_rule('/<uuid_str:site_id>/observations',
                       view_func=SiteObservations.as_view('observations'))
-site_blp.add_url_rule('/<uuid:site_id>/forecasts/single',
+site_blp.add_url_rule('/<uuid_str:site_id>/forecasts/single',
                       view_func=SiteForecasts.as_view('forecasts'))
-site_blp.add_url_rule('/<uuid:site_id>/forecasts/cdf',
+site_blp.add_url_rule('/<uuid_str:site_id>/forecasts/cdf',
                       view_func=SiteCDFForecastGroups.as_view('cdf_forecasts'))

--- a/sfa_api/sites.py
+++ b/sfa_api/sites.py
@@ -243,10 +243,10 @@ site_blp = Blueprint(
 )
 site_blp.add_url_rule('/', view_func=AllSitesView.as_view('all'))
 site_blp.add_url_rule(
-    '/<site_id>', view_func=SiteView.as_view('single'))
-site_blp.add_url_rule('/<site_id>/observations',
+    '/<uuid:site_id>', view_func=SiteView.as_view('single'))
+site_blp.add_url_rule('/<uuid:site_id>/observations',
                       view_func=SiteObservations.as_view('observations'))
-site_blp.add_url_rule('/<site_id>/forecasts/single',
+site_blp.add_url_rule('/<uuid:site_id>/forecasts/single',
                       view_func=SiteForecasts.as_view('forecasts'))
-site_blp.add_url_rule('/<site_id>/forecasts/cdf',
+site_blp.add_url_rule('/<uuid:site_id>/forecasts/cdf',
                       view_func=SiteCDFForecastGroups.as_view('cdf_forecasts'))

--- a/sfa_api/tests/test_api.py
+++ b/sfa_api/tests/test_api.py
@@ -488,7 +488,10 @@ def uuid_paths(sql_api):
     return paths_with_id
 
 
-@pytest.mark.parametrize('bad_id', ['56061aa6-4cf4-11ea-a21d-0a580a800331%'])
+@pytest.mark.parametrize('bad_id', [
+    '56061aa6-4cf4-11ea-a21d-0a580a800331%',
+    'not a real uuid',
+])
 def test_uuid_path_validation(sql_api, uuid_paths, auth_header, bad_id):
     for path in uuid_paths:
         req = sql_api.get(path.format(id=bad_id),

--- a/sfa_api/tests/test_reports.py
+++ b/sfa_api/tests/test_reports.py
@@ -166,7 +166,7 @@ categories_list = ", ".join(list(ALLOWED_CATEGORIES.keys()))
 
 
 @pytest.mark.parametrize('key,value,error', [
-    ('name', 'r'*70, '["Longer than maximum length 64."]'),
+    ('name', 'r' * 70, '["Longer than maximum length 64."]'),
     ('start', 'invalid_date',
      '["Not a valid datetime."]'),
     ('end', 'invalid_date',

--- a/sfa_api/users.py
+++ b/sfa_api/users.py
@@ -292,16 +292,16 @@ user_blp = Blueprint(
     'users', 'users', url_prefix='/users',
 )
 user_blp.add_url_rule('/', view_func=AllUsersView.as_view('all'))
-user_blp.add_url_rule('/<user_id>', view_func=UserView.as_view('single'))
+user_blp.add_url_rule('/<uuid:user_id>', view_func=UserView.as_view('single'))
 user_blp.add_url_rule(
-    '/<user_id>/roles/<role_id>',
+    '/<uuid:user_id>/roles/<uuid:role_id>',
     view_func=UserRolesManagementView.as_view('user_roles_management')
 )
 user_blp.add_url_rule(
     '/current',
     view_func=CurrentUserView.as_view('current_user'))
 user_blp.add_url_rule(
-    '/<user_id>/email',
+    '/<uuid:user_id>/email',
     view_func=UserIdToEmailView.as_view('user_email'))
 
 
@@ -311,6 +311,6 @@ user_email_blp = Blueprint(
 user_email_blp.add_url_rule(
     '/<email>', view_func=UserByEmailView.as_view('single'))
 user_email_blp.add_url_rule(
-    '/<email>/roles/<role_id>',
+    '/<email>/roles/<uuid:role_id>',
     view_func=UserRolesManagementByEmailView.as_view('user_roles_management')
 )

--- a/sfa_api/users.py
+++ b/sfa_api/users.py
@@ -292,16 +292,19 @@ user_blp = Blueprint(
     'users', 'users', url_prefix='/users',
 )
 user_blp.add_url_rule('/', view_func=AllUsersView.as_view('all'))
-user_blp.add_url_rule('/<uuid:user_id>', view_func=UserView.as_view('single'))
 user_blp.add_url_rule(
-    '/<uuid:user_id>/roles/<uuid:role_id>',
+    '/<uuid_str:user_id>',
+    view_func=UserView.as_view('single')
+)
+user_blp.add_url_rule(
+    '/<uuid_str:user_id>/roles/<uuid_str:role_id>',
     view_func=UserRolesManagementView.as_view('user_roles_management')
 )
 user_blp.add_url_rule(
     '/current',
     view_func=CurrentUserView.as_view('current_user'))
 user_blp.add_url_rule(
-    '/<uuid:user_id>/email',
+    '/<uuid_str:user_id>/email',
     view_func=UserIdToEmailView.as_view('user_email'))
 
 
@@ -311,6 +314,6 @@ user_email_blp = Blueprint(
 user_email_blp.add_url_rule(
     '/<email>', view_func=UserByEmailView.as_view('single'))
 user_email_blp.add_url_rule(
-    '/<email>/roles/<uuid:role_id>',
+    '/<email>/roles/<uuid_str:role_id>',
     view_func=UserRolesManagementByEmailView.as_view('user_roles_management')
 )

--- a/sfa_api/utils/url_converters.py
+++ b/sfa_api/utils/url_converters.py
@@ -1,0 +1,16 @@
+import uuid
+
+
+from flask import abort
+from werkzeug.routing import BaseConverter
+
+
+class UUIDStringConverter(BaseConverter):
+    def to_python(self, value):
+        try:
+            return str(uuid.UUID(value, version=1))
+        except ValueError:
+            abort(404)
+
+    def to_url(self, value):
+        return value

--- a/sfa_api/utils/url_converters.py
+++ b/sfa_api/utils/url_converters.py
@@ -8,7 +8,7 @@ from werkzeug.routing import BaseConverter
 class UUIDStringConverter(BaseConverter):
     def to_python(self, value):
         try:
-            return str(uuid.UUID(value, version=1))
+            return str(uuid.UUID(value))
         except ValueError:
             abort(404)
 


### PR DESCRIPTION
closes #215 
Created a custom url converter because the default uuid converter actually casts to a UUID object, here we only validate on the way in. Added tests to ensure that any path added to the api with the substring '_id' returns a 404 on an invalid uuid, instead of hitting the database and possibly throwing a 500.