### PR TITLE
make a much faster procedure to read aggregate values

### DIFF
--- a/datastore/migrations/0035_faster_agg_values.down.sql
+++ b/datastore/migrations/0035_faster_agg_values.down.sql
@@ -1,0 +1,35 @@
+DROP PROCEDURE read_aggregate_values;
+
+CREATE DEFINER = 'select_objects'@'localhost' PROCEDURE read_aggregate_values (
+    IN auth0id VARCHAR(32), IN strid CHAR(36), IN start TIMESTAMP, IN end TIMESTAMP)
+COMMENT 'Read the observation values of the observations that make up the aggregate'
+READS SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+    DECLARE maxend TIMESTAMP DEFAULT TIMESTAMP('2038-01-19 03:14:07');
+    DECLARE minstart TIMESTAMP DEFAULT TIMESTAMP('1970-01-01 00:00:01');
+    SET binid = UUID_TO_BIN(strid, 1);
+    SET allowed = (SELECT can_user_perform_action(auth0id, binid, 'read_values'));
+    IF allowed THEN
+        -- In the future, this may be more complex, checking an aggregate_values table first
+        -- before retrieving the individual observation objects
+        WITH limits AS (
+            SELECT observation_id, IFNULL(effective_from, minstart) as obs_start,
+                LEAST(IFNULL(effective_until, maxend),
+                      IFNULL(observation_deleted_at, maxend)) as obs_end
+            FROM arbiter_data.aggregate_observation_mapping
+            WHERE aggregate_id = binid AND can_user_perform_action(auth0id, observation_id, 'read_values')
+        )
+        SELECT BIN_TO_UUID(id, 1) as observation_id, timestamp, value, quality_flag
+        FROM arbiter_data.observations_values JOIN limits
+        WHERE id = limits.observation_id AND timestamp BETWEEN GREATEST(limits.obs_start, start) AND LEAST(limits.obs_end, end)
+        GROUP BY id, timestamp ORDER BY id, timestamp;
+    ELSE
+        SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "read aggregate values"',
+        MYSQL_ERRNO = 1142;
+    END IF;
+END;
+
+GRANT EXECUTE ON PROCEDURE read_aggregate_values TO 'select_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE read_aggregate_values TO 'apiuser'@'%';

--- a/datastore/migrations/0035_faster_agg_values.up.sql
+++ b/datastore/migrations/0035_faster_agg_values.up.sql
@@ -1,0 +1,39 @@
+DROP PROCEDURE read_aggregate_values;
+
+CREATE DEFINER = 'select_objects'@'localhost' PROCEDURE read_aggregate_values (
+    IN auth0id VARCHAR(32), IN strid CHAR(36), IN start TIMESTAMP, IN end TIMESTAMP)
+COMMENT 'Read the observation values of the observations that make up the aggregate'
+READS SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+    DECLARE maxend TIMESTAMP DEFAULT TIMESTAMP('2038-01-19 03:14:07');
+    DECLARE minstart TIMESTAMP DEFAULT TIMESTAMP('1970-01-01 00:00:01');
+    DECLARE limits JSON;
+
+    SET binid = UUID_TO_BIN(strid, 1);
+    SET allowed = (SELECT can_user_perform_action(auth0id, binid, 'read_values'));
+    IF allowed THEN
+        -- faster than using a cursor as that would require a temporary table
+        SET limits = (SELECT JSON_ARRAYAGG(
+            JSON_OBJECT('obsid', BIN_TO_UUID(observation_id, 1),
+                        'obs_start', GREATEST(IFNULL(effective_from, minstart), start),
+                        'obs_end', LEAST(IFNULL(effective_until, maxend),
+                                         IFNULL(observation_deleted_at, maxend),
+                                         end)))
+            FROM arbiter_data.aggregate_observation_mapping
+            WHERE aggregate_id = binid AND can_user_perform_action(auth0id, observation_id, 'read_values'));
+
+         SELECT jt.obsid as observation_id, timestamp, value, quality_flag
+         FROM arbiter_data.observations_values, JSON_TABLE(limits, '$[*]' COLUMNS (
+             obsid char(36) PATH '$.obsid', obs_start TIMESTAMP PATH '$.obs_start',
+             obs_end TIMESTAMP PATH '$.obs_end')) as jt
+         WHERE id = UUID_TO_BIN(jt.obsid, 1) AND timestamp BETWEEN jt.obs_start AND jt.obs_end;
+    ELSE
+        SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "read aggregate values"',
+        MYSQL_ERRNO = 1142;
+    END IF;
+END ;
+
+GRANT EXECUTE ON PROCEDURE read_aggregate_values TO 'select_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE read_aggregate_values TO 'apiuser'@'%';

--- a/datastore/tests/test_reads.py
+++ b/datastore/tests/test_reads.py
@@ -991,7 +991,7 @@ def test_read_aggregate_values_removed_overlap(
     assert res == vals
     cursor.execute(
         "UPDATE aggregate_observation_mapping SET effective_until = TIMESTAMP('2019-01-30 12:30')"  # NOQA
-    )
+    )  # 12:28 and 12:29 extra
     cursor.execute(
         "INSERT INTO aggregate_observation_mapping "
         "(aggregate_id, observation_id, _incr, effective_from) VALUES"
@@ -1004,7 +1004,8 @@ def test_read_aggregate_values_removed_overlap(
             start, end)
     )
     res = cursor.fetchall()
-    assert res == vals
+    assert len(res) == len(vals) + 2
+    assert set(res) == set(vals)
 
 
 def test_read_aggregate_values_full_overlap(
@@ -1036,7 +1037,8 @@ def test_read_aggregate_values_full_overlap(
             start, end)
     )
     res = cursor.fetchall()
-    assert res == vals
+    assert len(res) == len(vals) + 1
+    assert set(res) == set(vals)
 
 
 def test_read_aggregate_values_deleted(

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -1757,8 +1757,8 @@ def read_aggregate_values(aggregate_id, start=None, end=None):
     ).groupby('observation_id')
     out = {}
     for obs_id, df in groups:
-        out[obs_id] = df.drop(columns='observation_id').set_index(
-            'timestamp')
+        out[obs_id] = df.drop(columns='observation_id').drop_duplicates(
+        ).set_index('timestamp').sort_index()
     return out
 
 


### PR DESCRIPTION
The procedure no long groups by id/timestamp or sorts, but it's probably best to keep that load off of mysql and let the python handle dedup and sorting.

and by faster, we're talking what may have taken 90 seconds before now takes a few seconds.