### PR TITLE
Actions on object

### DIFF
--- a/datastore/migrations/0036_actions_on_object.down.sql
+++ b/datastore/migrations/0036_actions_on_object.down.sql
@@ -1,0 +1,1 @@
+DROP PROCEDURE get_user_actions_on_object;

--- a/datastore/migrations/0036_actions_on_object.up.sql
+++ b/datastore/migrations/0036_actions_on_object.up.sql
@@ -1,0 +1,24 @@
+CREATE DEFINER = 'select_rbac'@'localhost' PROCEDURE get_user_actions_on_object(
+    IN auth0id VARCHAR(32), IN strobjectid CHAR(36))
+COMMENT 'Get a list of all of the actions the user can take on an object.'
+READS SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE userid BINARY(16);
+    DECLARE objectid BINARY(16);
+    SET userid = (SELECT id FROM users WHERE auth0_id = auth0id);
+    SET objectid = UUID_TO_BIN(strobjectid, 1);
+    
+    SELECT perm.action from permissions as perm WHERE perm.id IN(
+        SELECT permission_id from permission_object_mapping
+            WHERE object_id = objectid AND permission_id IN (
+                SELECT permission_id FROM role_permission_mapping
+                    WHERE role_id IN(
+                        SELECT role_id FROM user_role_mapping
+                            WHERE user_id = userid
+                )
+        )
+    );
+END;
+
+GRANT EXECUTE ON PROCEDURE get_user_actions_on_object TO 'select_rbac'@'localhost';
+GRANT EXECUTE ON PROCEDURE get_user_actions_on_object TO 'apiuser'@'%';

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -430,6 +430,13 @@ def forecast_id():
     return '11c20780-76ae-4b11-bef1-7a75bdc784e3'
 
 
+# Forecast provided by 'Forecast Provider A', but test user does not
+# have access to it.
+@pytest.fixture()
+def inaccessible_forecast_id():
+    return 'd0dd64fc-8250-11e9-a81f-54bf64606445'
+
+
 @pytest.fixture()
 def site_id():
     return 'd2018f1d-82b1-422a-8ec4-4e8b3fe92a4a'

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -963,3 +963,9 @@ class AggregateValuesSchema(ObservationValuesPostSchema):
         },
         description="Contains a link to the values endpoint."
     )
+
+
+@spec.define_schema('ActionList')
+class ActionList(ma.Schema):
+    object_id = ma.UUID(title="Object UUID")
+    actions = ma.List(ma.String(), title="Actions allowed on the object.")

--- a/sfa_api/users.py
+++ b/sfa_api/users.py
@@ -338,7 +338,7 @@ user_blp.add_url_rule(
     '/<uuid_str:user_id>/email',
     view_func=UserIdToEmailView.as_view('user_email'))
 user_blp.add_url_rule(
-    '/actions-on/<uuid_str:object_id>/',
+    '/actions-on/<uuid_str:object_id>',
     view_func=UserActionsView.as_view('user_actions_on_object'))
 
 user_email_blp = Blueprint(

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -1883,3 +1883,23 @@ def create_job_user(username, passwd, org_id, encryption_key):
     _call_procedure('store_token', auth0_id, sec_token,
                     with_current_user=False)
     return user_id, auth0_id
+
+
+def get_user_actions_on_object(object_id):
+    """Read the list of actions that the user can perform on object.
+
+    Parameters
+    ----------
+    object_id: String
+        UUID of the observation to retrieve.
+
+    Returns
+    -------
+    list
+        The list of actions.
+    """
+    permissions = _call_procedure('get_user_actions_on_object', object_id)
+    if not permissions:
+        raise StorageAuthError()
+    actions = [perm['action'] for perm in permissions]
+    return actions

--- a/sfa_api/utils/tests/test_storage_interface.py
+++ b/sfa_api/utils/tests/test_storage_interface.py
@@ -1504,3 +1504,22 @@ def test_call_procedure_bad_json(
     with pytest.raises(storage_interface.BadAPIRequest):
         storage_interface._call_procedure('store_raw_report', reportid,
                                           '{"badnan": NaN}')
+
+
+def test_get_user_actions_on_object(
+        sql_app, user, nocommit_cursor, forecast_id):
+    actions = storage_interface.get_user_actions_on_object(forecast_id)
+    assert actions == ['read', 'read_values', 'delete', 'delete_values',
+                       'write_values']
+
+
+def test_get_user_actions_on_object_object_dne(
+        sql_app, user, nocommit_cursor, missing_id):
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.get_user_actions_on_object(missing_id)
+
+
+def test_get_user_actions_on_object_no_actions(
+        sql_app, user, nocommit_cursor, inaccessible_forecast_id):
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.get_user_actions_on_object(inaccessible_forecast_id)


### PR DESCRIPTION
Aimed at closing #151 . Doesn't have any testing yet, as I wanted to get some feedback on the design before investing the time. @alorenzo175 Can you take a look at this new endpoint? It lists the actions a user is allowed to take on an object. I'm foregoing the "allowed" check in sql and returning a 404 if the actions list is empty because it seems like you should be able to see your permitted actions if you have any( as opposed to say, having 'read_values' and 'write_values' and being disallowed because you don't have 'read'). This should make it such that someone can't spam requests to discover the existence of objects.