### PR TITLE
add /values/latest and /values/timerange endpoints

### DIFF
--- a/datastore/migrations/0037_latest_value.down.sql
+++ b/datastore/migrations/0037_latest_value.down.sql
@@ -1,3 +1,6 @@
 DROP PROCEDURE read_latest_observation_value;
 DROP PROCEDURE read_latest_forecast_value;
 DROP PROCEDURE read_latest_cdf_forecast_value;
+DROP PROCEDURE read_observation_time_range;
+DROP PROCEDURE read_forecast_time_range;
+DROP PROCEDURE read_cdf_forecast_time_range;

--- a/datastore/migrations/0037_latest_value.down.sql
+++ b/datastore/migrations/0037_latest_value.down.sql
@@ -1,0 +1,3 @@
+DROP PROCEDURE read_latest_observation_value;
+DROP PROCEDURE read_latest_forecast_value;
+DROP PROCEDURE read_latest_cdf_forecast_value;

--- a/datastore/migrations/0037_latest_value.down.sql
+++ b/datastore/migrations/0037_latest_value.down.sql
@@ -4,3 +4,6 @@ DROP PROCEDURE read_latest_cdf_forecast_value;
 DROP PROCEDURE read_observation_time_range;
 DROP PROCEDURE read_forecast_time_range;
 DROP PROCEDURE read_cdf_forecast_time_range;
+DROP FUNCTION is_read_observation_values_allowed;
+DROP FUNCTION is_read_forecast_values_allowed;
+DROP FUNCTION is_read_cdf_forecast_values_allowed;

--- a/datastore/migrations/0037_latest_value.up.sql
+++ b/datastore/migrations/0037_latest_value.up.sql
@@ -1,0 +1,70 @@
+CREATE DEFINER = 'select_objects'@'localhost' PROCEDURE read_latest_observation_value (
+IN auth0id VARCHAR(32), IN strid CHAR(36))
+COMMENT 'Read latest observation value'
+READS SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+    DECLARE lasttime TIMESTAMP;
+    SET binid = (SELECT UUID_TO_BIN(strid, 1));
+    SET allowed = (SELECT can_user_perform_action(auth0id, binid, 'read_values'));
+    IF allowed THEN
+        /* more efficient to set the max time then select one row w/ full index
+           vs doing a sort by timestamp desc which has to do a reverse index scan */
+        SET lasttime = (SELECT MAX(timestamp) from arbiter_data.observations_values WHERE id = binid);
+        SELECT BIN_TO_UUID(id, 1) as observation_id, timestamp, value, quality_flag
+        FROM arbiter_data.observations_values WHERE id = binid AND timestamp = lasttime;
+    ELSE
+        SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "read latest observation value"',
+        MYSQL_ERRNO = 1142;
+    END IF;
+END;
+
+CREATE DEFINER = 'select_objects'@'localhost' PROCEDURE read_latest_forecast_value (
+IN auth0id VARCHAR(32), IN strid CHAR(36))
+COMMENT 'Read latest forecast value'
+READS SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+    DECLARE lasttime TIMESTAMP;
+    SET binid = (SELECT UUID_TO_BIN(strid, 1));
+    SET allowed = (SELECT can_user_perform_action(auth0id, binid, 'read_values'));
+    IF allowed THEN
+        SET lasttime = (SELECT MAX(timestamp) from arbiter_data.forecasts_values WHERE id = binid);
+        SELECT BIN_TO_UUID(id, 1) as forecast_id, timestamp, value
+        FROM arbiter_data.forecasts_values WHERE id = binid AND timestamp = lasttime;
+    ELSE
+        SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "read latest forecast value"',
+        MYSQL_ERRNO = 1142;
+    END IF;
+END;
+
+CREATE DEFINER = 'select_objects'@'localhost' PROCEDURE read_latest_cdf_forecast_value (
+IN auth0id VARCHAR(32), IN strid CHAR(36))
+COMMENT 'Read latest cdf forecast value'
+READS SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    DECLARE lasttime TIMESTAMP;
+    DECLARE groupid BINARY(16);
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+    SET binid = UUID_TO_BIN(strid, 1);
+    SET groupid = (SELECT cdf_forecast_group_id FROM cdf_forecasts_singles WHERE id = binid);
+    SET allowed = (SELECT can_user_perform_action(auth0id, groupid, 'read_values'));   IF allowed THEN
+        SET lasttime = (SELECT MAX(timestamp) from arbiter_data.cdf_forecasts_values WHERE id = binid);
+        SELECT BIN_TO_UUID(id, 1) as forecast_id, timestamp, value
+        FROM arbiter_data.cdf_forecasts_values WHERE id = binid AND timestamp = lasttime;
+    ELSE
+        SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "read latest cdf forecast value"',
+        MYSQL_ERRNO = 1142;
+    END IF;
+END;
+
+
+GRANT EXECUTE ON PROCEDURE arbiter_data.read_latest_observation_value TO 'select_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.read_latest_forecast_value TO 'select_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.read_latest_cdf_forecast_value TO 'select_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE arbiter_data.read_latest_observation_value TO 'apiuser'@'%';
+GRANT EXECUTE ON PROCEDURE arbiter_data.read_latest_forecast_value TO 'apiuser'@'%';
+GRANT EXECUTE ON PROCEDURE arbiter_data.read_latest_cdf_forecast_value TO 'apiuser'@'%';

--- a/datastore/tests/conftest.py
+++ b/datastore/tests/conftest.py
@@ -217,7 +217,7 @@ def new_forecast(cursor, new_site):
         # add some  test data too
         cursor.execute(
             'INSERT INTO forecasts_values (id, timestamp, value) VALUES '
-            '(%s, CURRENT_TIMESTAMP(), RAND())', (out['id'], ))
+            '(%s, TIMESTAMP(\'2020-01-01 11:03\'), RAND())', (out['id'], ))
         return out
     return fcn
 
@@ -259,7 +259,8 @@ def new_cdf_forecast(cursor, new_site):
             # add some  test data too
             cursor.execute(
                 'INSERT INTO cdf_forecasts_values (id, timestamp, value) '
-                'VALUES (%s, CURRENT_TIMESTAMP(), RAND())', (single['id'], ))
+                'VALUES (%s, TIMESTAMP(\'2020-01-03 18:01\'), RAND())',
+                (single['id'], ))
             out['constant_values'][str(id)] = float(i)
         return out
     return fcn
@@ -279,7 +280,7 @@ def new_observation(cursor, new_site):
         insert_dict(cursor, 'observations', out)
         cursor.execute(
             'INSERT INTO observations_values (id, timestamp, value, '
-            'quality_flag) VALUES (%s, CURRENT_TIMESTAMP(), RAND(), 0)',
+            'quality_flag) VALUES (%s, TIMESTAMP(\'2020-01-03 10:00\'), RAND(), 0)',
             (out['id'], ))
         return out
     return fcn

--- a/datastore/tests/test_reads.py
+++ b/datastore/tests/test_reads.py
@@ -908,15 +908,15 @@ def test_read_aggregate_values(
 
 
 @pytest.mark.parametrize('start,end,theslice', [
-    (dt.datetime(2019, 1, 30, 12, 20), dt.datetime(2019, 2, 10, 12, 20),
+    (dt.datetime(2020, 1, 30, 12, 20), dt.datetime(2020, 2, 10, 12, 20),
      slice(10)),
-    (dt.datetime(2019, 1, 30, 12, 30), dt.datetime(2019, 1, 30, 12, 40),
+    (dt.datetime(2020, 1, 30, 12, 30), dt.datetime(2020, 1, 30, 12, 40),
      slice(2, 10)),
-    (dt.datetime(2019, 1, 30, 12, 30), dt.datetime(2019, 1, 30, 12, 30),
+    (dt.datetime(2020, 1, 30, 12, 30), dt.datetime(2020, 1, 30, 12, 30),
      slice(0)),
-    (dt.datetime(2019, 1, 30, 12, 30), dt.datetime(2019, 1, 29, 12, 30),
+    (dt.datetime(2020, 1, 30, 12, 30), dt.datetime(2020, 1, 29, 12, 30),
      slice(0)),
-    (dt.datetime(2019, 1, 30, 12, 30), dt.datetime(2019, 1, 30, 12, 35),
+    (dt.datetime(2020, 1, 30, 12, 30), dt.datetime(2020, 1, 30, 12, 35),
      slice(2, 7)),
 ])
 def test_read_aggregate_values_time_limits(
@@ -951,7 +951,7 @@ def test_read_aggregate_values_removed(
     res = cursor.fetchall()
     assert res == vals
     cursor.execute(
-        "UPDATE aggregate_observation_mapping SET effective_until = TIMESTAMP('2019-01-30 12:30')"  # NOQA
+        "UPDATE aggregate_observation_mapping SET effective_until = TIMESTAMP('2020-01-30 12:30')"  # NOQA
     )
     cursor.callproc(
         'read_aggregate_values', (
@@ -964,7 +964,7 @@ def test_read_aggregate_values_removed(
     cursor.execute(
         "INSERT INTO aggregate_observation_mapping "
         "(aggregate_id, observation_id, _incr, effective_from) VALUES"
-        " (%s, %s, 1, TIMESTAMP('2019-01-30 12:35'))",
+        " (%s, %s, 1, TIMESTAMP('2020-01-30 12:35'))",
         (agg['id'], obs['id'])
     )
     cursor.callproc(
@@ -991,12 +991,12 @@ def test_read_aggregate_values_removed_overlap(
     res = cursor.fetchall()
     assert res == vals
     cursor.execute(
-        "UPDATE aggregate_observation_mapping SET effective_until = TIMESTAMP('2019-01-30 12:30')"  # NOQA
+        "UPDATE aggregate_observation_mapping SET effective_until = TIMESTAMP('2020-01-30 12:30')"  # NOQA
     )  # 12:28 and 12:29 extra
     cursor.execute(
         "INSERT INTO aggregate_observation_mapping "
         "(aggregate_id, observation_id, _incr, effective_from) VALUES"
-        " (%s, %s, 1, TIMESTAMP('2019-01-30 11:00'))",
+        " (%s, %s, 1, TIMESTAMP('2020-01-30 11:00'))",
         (agg['id'], obs['id'])
     )
     cursor.callproc(
@@ -1024,7 +1024,7 @@ def test_read_aggregate_values_full_overlap(
     res = cursor.fetchall()
     assert res == vals
     cursor.execute(
-        "UPDATE aggregate_observation_mapping SET effective_from = TIMESTAMP('2019-01-30 12:29'), effective_until = TIMESTAMP('2019-01-30 12:30')"  # NOQA
+        "UPDATE aggregate_observation_mapping SET effective_from = TIMESTAMP('2020-01-30 12:29'), effective_until = TIMESTAMP('2020-01-30 12:30')"  # NOQA
     )
     cursor.execute(
         "INSERT INTO aggregate_observation_mapping "
@@ -1057,14 +1057,14 @@ def test_read_aggregate_values_deleted(
     res = cursor.fetchall()
     assert res == vals
     cursor.execute(
-        "UPDATE aggregate_observation_mapping SET observation_deleted_at = TIMESTAMP('2019-01-30 12:30')"  # NOQA
+        "UPDATE aggregate_observation_mapping SET observation_deleted_at = TIMESTAMP('2020-01-30 12:30')"  # NOQA
     )
     obs1 = new_observation(org=org)
     _, _, v2, *_ = obs_values(str(bin_to_uuid(obs1['id'])))
     cursor.execute(
         "INSERT INTO aggregate_observation_mapping "
         "(aggregate_id, observation_id, _incr, created_at) VALUES"
-        " (%s, %s, 1, TIMESTAMP('2019-01-30 12:20'))",
+        " (%s, %s, 1, TIMESTAMP('2020-01-30 12:20'))",
         (agg['id'], obs1['id'])
     )
     cursor.callproc(
@@ -1278,6 +1278,7 @@ def test_read_metadata_for_value_write_fx(
     assert isinstance(res['interval_length'], int)
     assert res['previous_time'] == time_
     assert isinstance(res['extra_parameters'], str)
+
 
 def test_read_metadata_for_value_write_fx_before(
         dictcursor, insertuser, allow_write_values):
@@ -1684,3 +1685,140 @@ def test_read_latest_cdf_forecast_values_denied_can_read_meta(
                         (auth0id, cdf_fxid))
     assert e.value.args[0] == 1142
 
+
+def test_read_observation_range(
+        cursor, obs_values, insertuser, allow_read_observation_values):
+    auth0id, obsid, vals, *_ = obs_values(insertuser[3]['strid'])
+    cursor.callproc('read_observation_time_range', (auth0id, obsid))
+    res = cursor.fetchall()
+    assert len(res) == 1
+    assert res[0] == (dt.datetime(2020, 1, 3, 10), vals[-1][1])
+    early = dt.datetime(1989, 3, 2, 12, 22)
+    time_ = dt.datetime.now().replace(microsecond=0)
+    cursor.executemany(
+        'INSERT INTO observations_values (id, timestamp, value, quality_flag)'
+        ' VALUES (UUID_TO_BIN(%s, 1), %s, %s, %s)', (
+            (obsid, early, 0, 0), (obsid, time_, 0, 0)))
+    cursor.callproc('read_observation_time_range', (auth0id, obsid))
+    res = cursor.fetchall()
+    assert res[0] == (early, time_)
+
+
+def test_read_observation_range_no_data(
+        cursor, obs_values, insertuser, allow_read_observation_values):
+    auth0id, obsid, vals, *_ = obs_values(insertuser[3]['strid'])
+    cursor.execute(
+        'DELETE from observations_values where id = UUID_TO_BIN(%s, 1)',
+        (obsid,))
+    cursor.callproc('read_observation_time_range', (auth0id, obsid))
+    res = cursor.fetchall()
+    assert len(res) == 1
+    assert res[0] == (None, None)
+
+
+def test_read_observation_time_range_denied(cursor, obs_values, insertuser):
+    auth0id, obsid, vals, start, end = obs_values(insertuser[3]['strid'])
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('read_observation_time_range', (auth0id, obsid))
+    assert e.value.args[0] == 1142
+
+
+def test_read_observation_time_range_denied_can_read_meta(
+        cursor, obs_values, allow_read_observations, insertuser):
+    auth0id, obsid, vals, start, end = obs_values(insertuser[3]['strid'])
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('read_observation_time_range', (auth0id, obsid))
+    assert e.value.args[0] == 1142
+
+
+def test_read_cdf_forecast_range(
+        cursor, cdf_fx_values, insertuser, allow_read_cdf_forecast_values):
+    auth0id, cdf_fxid, vals, *_ = cdf_fx_values
+    cursor.callproc('read_cdf_forecast_time_range', (auth0id, cdf_fxid))
+    res = cursor.fetchall()
+    assert len(res) == 1
+    assert res[0] == (dt.datetime(2020, 1, 3, 18, 1), vals[-1][1])
+    early = dt.datetime(1989, 3, 2, 12, 22)
+    time_ = dt.datetime.now().replace(microsecond=0)
+    cursor.executemany(
+        'INSERT INTO cdf_forecasts_values (id, timestamp, value)'
+        ' VALUES (UUID_TO_BIN(%s, 1), %s, %s)', (
+            (cdf_fxid, early, 0), (cdf_fxid, time_, 0)))
+    cursor.callproc('read_cdf_forecast_time_range', (auth0id, cdf_fxid))
+    res = cursor.fetchall()
+    assert res[0] == (early, time_)
+
+
+def test_read_cdf_forecast_range_no_data(
+        cursor, cdf_fx_values, insertuser, allow_read_cdf_forecast_values):
+    auth0id, cdf_fxid, vals, *_ = cdf_fx_values
+    cursor.execute(
+        'DELETE from cdf_forecasts_values where id = UUID_TO_BIN(%s, 1)',
+        (cdf_fxid,))
+    cursor.callproc('read_cdf_forecast_time_range', (auth0id, cdf_fxid))
+    res = cursor.fetchall()
+    assert len(res) == 1
+    assert res[0] == (None, None)
+
+
+def test_read_cdf_forecast_time_range_denied(
+        cursor, cdf_fx_values, insertuser):
+    auth0id, cdf_fxid, vals, start, end = cdf_fx_values
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('read_cdf_forecast_time_range', (auth0id, cdf_fxid))
+    assert e.value.args[0] == 1142
+
+
+def test_read_cdf_forecast_time_range_denied_can_read_meta(
+        cursor, cdf_fx_values, allow_read_cdf_forecasts, insertuser):
+    auth0id, cdf_fxid, vals, start, end = cdf_fx_values
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('read_cdf_forecast_time_range', (auth0id, cdf_fxid))
+    assert e.value.args[0] == 1142
+
+    
+def test_read_forecast_range(
+        cursor, fx_values, insertuser, allow_read_forecast_values):
+    auth0id, fxid, vals, *_ = fx_values
+    cursor.callproc('read_forecast_time_range', (auth0id, fxid))
+    res = cursor.fetchall()
+    assert len(res) == 1
+    assert res[0] == (dt.datetime(2020, 1, 1, 11, 3), vals[-1][1])
+    early = dt.datetime(1989, 3, 2, 12, 22)
+    time_ = dt.datetime.now().replace(microsecond=0)
+    cursor.executemany(
+        'INSERT INTO forecasts_values (id, timestamp, value)'
+        ' VALUES (UUID_TO_BIN(%s, 1), %s, %s)', (
+            (fxid, early, 0), (fxid, time_, 0)))
+    cursor.callproc('read_forecast_time_range', (auth0id, fxid))
+    res = cursor.fetchall()
+    assert res[0] == (early, time_)
+
+
+def test_read_forecast_range_no_data(
+        cursor, fx_values, insertuser, allow_read_forecast_values):
+    auth0id, fxid, vals, *_ = fx_values
+    cursor.execute(
+        'DELETE from forecasts_values where id = UUID_TO_BIN(%s, 1)',
+        (fxid,))
+    cursor.callproc('read_forecast_time_range', (auth0id, fxid))
+    res = cursor.fetchall()
+    assert len(res) == 1
+    assert res[0] == (None, None)
+
+
+def test_read_forecast_time_range_denied(
+        cursor, fx_values, insertuser):
+    auth0id, fxid, vals, start, end = fx_values
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('read_forecast_time_range', (auth0id, fxid))
+    assert e.value.args[0] == 1142
+
+
+def test_read_forecast_time_range_denied_can_read_meta(
+        cursor, fx_values, allow_read_forecasts, insertuser):
+    auth0id, fxid, vals, start, end = fx_values
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('read_forecast_time_range', (auth0id, fxid))
+    assert e.value.args[0] == 1142
+    

--- a/datastore/tests/test_reads.py
+++ b/datastore/tests/test_reads.py
@@ -197,7 +197,7 @@ def obs_values(cursor, insertuser):
     auth0id = insertuser[0]['auth0_id']
 
     def insert(obsid):
-        start = dt.datetime(2019, 1, 30, 12, 28, 20)
+        start = dt.datetime(2020, 1, 30, 12, 28, 20)
         vals = tuple([
             (obsid, start + dt.timedelta(minutes=i),
              float(random.randint(0, 100)), 0) for i in range(10)])
@@ -205,8 +205,8 @@ def obs_values(cursor, insertuser):
             'INSERT INTO observations_values (id, timestamp, value, '
             'quality_flag) VALUES (UUID_TO_BIN(%s, 1), %s, %s, %s)',
             vals)
-        start = dt.datetime(2019, 1, 30, 12, 20)
-        end = dt.datetime(2019, 1, 30, 12, 40)
+        start = dt.datetime(2020, 1, 30, 12, 20)
+        end = dt.datetime(2020, 1, 30, 12, 40)
         return auth0id, obsid, vals, start, end
     return insert
 
@@ -220,15 +220,15 @@ def test_read_observation_values(cursor, obs_values, insertuser,
 
 
 @pytest.mark.parametrize('start,end,theslice', [
-    (dt.datetime(2019, 1, 30, 12, 20), dt.datetime(2019, 2, 10, 12, 20),
+    (dt.datetime(2020, 1, 30, 12, 20), dt.datetime(2020, 2, 10, 12, 20),
      slice(10)),
-    (dt.datetime(2019, 1, 30, 12, 30), dt.datetime(2019, 1, 30, 12, 40),
+    (dt.datetime(2020, 1, 30, 12, 30), dt.datetime(2020, 1, 30, 12, 40),
      slice(2, 10)),
-    (dt.datetime(2019, 1, 30, 12, 30), dt.datetime(2019, 1, 30, 12, 30),
+    (dt.datetime(2020, 1, 30, 12, 30), dt.datetime(2020, 1, 30, 12, 30),
      slice(0)),
-    (dt.datetime(2019, 1, 30, 12, 30), dt.datetime(2019, 1, 29, 12, 30),
+    (dt.datetime(2020, 1, 30, 12, 30), dt.datetime(2020, 1, 29, 12, 30),
      slice(0)),
-    (dt.datetime(2019, 1, 30, 12, 30), dt.datetime(2019, 1, 30, 12, 35),
+    (dt.datetime(2020, 1, 30, 12, 30), dt.datetime(2020, 1, 30, 12, 35),
      slice(2, 7)),
 ])
 def test_read_observation_values_time_limits(
@@ -261,15 +261,15 @@ def test_read_observation_values_denied_can_read_meta(
 def fx_values(cursor, insertuser):
     auth0id = insertuser[0]['auth0_id']
     fxid = insertuser[2]['strid']
-    start = dt.datetime(2019, 1, 30, 12, 28, 20)
+    start = dt.datetime(2020, 1, 30, 12, 28, 20)
     vals = tuple([
         (fxid, start + dt.timedelta(minutes=i),
          float(random.randint(0, 100))) for i in range(10)])
     cursor.executemany(
         'INSERT INTO forecasts_values (id, timestamp, value) '
         'VALUES (UUID_TO_BIN(%s, 1), %s, %s)', vals)
-    start = dt.datetime(2019, 1, 30, 12, 20)
-    end = dt.datetime(2019, 1, 30, 12, 40)
+    start = dt.datetime(2020, 1, 30, 12, 20)
+    end = dt.datetime(2020, 1, 30, 12, 40)
     return auth0id, fxid, vals, start, end
 
 
@@ -282,15 +282,15 @@ def test_read_forecast_values(cursor, fx_values,
 
 
 @pytest.mark.parametrize('start,end,theslice', [
-    (dt.datetime(2019, 1, 30, 12, 20), dt.datetime(2019, 2, 10, 12, 20),
+    (dt.datetime(2020, 1, 30, 12, 20), dt.datetime(2020, 2, 10, 12, 20),
      slice(10)),
-    (dt.datetime(2019, 1, 30, 12, 30), dt.datetime(2019, 1, 30, 12, 40),
+    (dt.datetime(2020, 1, 30, 12, 30), dt.datetime(2020, 1, 30, 12, 40),
      slice(2, 10)),
-    (dt.datetime(2019, 1, 30, 12, 30), dt.datetime(2019, 1, 30, 12, 30),
+    (dt.datetime(2020, 1, 30, 12, 30), dt.datetime(2020, 1, 30, 12, 30),
      slice(0)),
-    (dt.datetime(2019, 1, 30, 12, 30), dt.datetime(2019, 1, 29, 12, 30),
+    (dt.datetime(2020, 1, 30, 12, 30), dt.datetime(2020, 1, 29, 12, 30),
      slice(0)),
-    (dt.datetime(2019, 1, 30, 12, 30), dt.datetime(2019, 1, 30, 12, 35),
+    (dt.datetime(2020, 1, 30, 12, 30), dt.datetime(2020, 1, 30, 12, 35),
      slice(2, 7)),
 ])
 def test_read_forecast_values_time_limits(
@@ -410,15 +410,15 @@ def cdf_fx_values(cursor, insertuser, request):
     auth0id = insertuser[0]['auth0_id']
     forecast = insertuser[6]
     strid = list(forecast['constant_values'].keys())[request.param]
-    start = dt.datetime(2019, 1, 30, 12, 28, 20)
+    start = dt.datetime(2020, 1, 30, 12, 28, 20)
     vals = tuple([
         (strid, start + dt.timedelta(minutes=i),
          float(random.randint(0, 100))) for i in range(10)])
     cursor.executemany(
         'INSERT INTO cdf_forecasts_values (id, timestamp, value) '
         'VALUES (UUID_TO_BIN(%s, 1), %s, %s)', vals)
-    start = dt.datetime(2019, 1, 30, 12, 20)
-    end = dt.datetime(2019, 1, 30, 12, 40)
+    start = dt.datetime(2020, 1, 30, 12, 20)
+    end = dt.datetime(2020, 1, 30, 12, 40)
     return auth0id, strid, vals, start, end
 
 
@@ -431,15 +431,15 @@ def test_read_cdf_forecast_values(cursor, cdf_fx_values,
 
 
 @pytest.mark.parametrize('start,end,theslice', [
-    (dt.datetime(2019, 1, 30, 12, 20), dt.datetime(2019, 2, 10, 12, 20),
+    (dt.datetime(2020, 1, 30, 12, 20), dt.datetime(2020, 2, 10, 12, 20),
      slice(10)),
-    (dt.datetime(2019, 1, 30, 12, 30), dt.datetime(2019, 1, 30, 12, 40),
+    (dt.datetime(2020, 1, 30, 12, 30), dt.datetime(2020, 1, 30, 12, 40),
      slice(2, 10)),
-    (dt.datetime(2019, 1, 30, 12, 30), dt.datetime(2019, 1, 30, 12, 30),
+    (dt.datetime(2020, 1, 30, 12, 30), dt.datetime(2020, 1, 30, 12, 30),
      slice(0)),
-    (dt.datetime(2019, 1, 30, 12, 30), dt.datetime(2019, 1, 29, 12, 30),
+    (dt.datetime(2020, 1, 30, 12, 30), dt.datetime(2020, 1, 29, 12, 30),
      slice(0)),
-    (dt.datetime(2019, 1, 30, 12, 30), dt.datetime(2019, 1, 30, 12, 35),
+    (dt.datetime(2020, 1, 30, 12, 30), dt.datetime(2020, 1, 30, 12, 35),
      slice(2, 7)),
 ])
 def test_read_cdf_forecast_values_time_limits(
@@ -1520,6 +1520,7 @@ def test_get_user_actions_on_object_no_permissions(
     actions = dictcursor.fetchall()
     assert not actions
 
+    
 @pytest.fixture()
 def remove_perm(cursor):
     def fcn(action, what):
@@ -1527,6 +1528,7 @@ def remove_perm(cursor):
             'DELETE FROM permissions WHERE action=%s and object_type=%s',
             (action, what))
     return fcn
+
 
 def test_get_user_actions_on_object_after_removal(
         dictcursor, user_org_role, new_role, add_perm, remove_perm):
@@ -1548,3 +1550,137 @@ def test_get_user_actions_on_object_after_removal(
         dictcursor.callproc('get_user_actions_on_object', (auth0id, role_id))
         actions = dictcursor.fetchall()
         assert action not in [x['action'] for x in actions]
+
+
+def test_read_latest_observation_values(cursor, obs_values, insertuser,
+                                        allow_read_observation_values):
+    auth0id, obsid, vals, *_ = obs_values(insertuser[3]['strid'])
+    cursor.callproc('read_latest_observation_value', (auth0id, obsid))
+    res = cursor.fetchall()
+    assert len(res) == 1
+    assert res[0] == vals[-1]
+    time_ = dt.datetime.now().replace(microsecond=0)
+    cursor.execute(
+        'INSERT INTO observations_values (id, timestamp, value, quality_flag)'
+        ' VALUES (UUID_TO_BIN(%s, 1), %s, %s, %s)', (obsid, time_, 0, 0))
+    cursor.callproc('read_latest_observation_value', (auth0id, obsid))
+    res = cursor.fetchall()
+    assert res[0] == (obsid, time_, 0, 0)
+
+
+def test_read_latest_observation_values_no_data(
+        cursor, obs_values, insertuser, allow_read_observation_values):
+    auth0id, obsid, vals, *_ = obs_values(insertuser[3]['strid'])
+    cursor.execute(
+        'DELETE from observations_values where id = UUID_TO_BIN(%s, 1)',
+        (obsid,))
+    cursor.callproc('read_latest_observation_value', (auth0id, obsid))
+    res = cursor.fetchall()
+    assert len(res) == 0
+
+
+def test_read_latest_observation_values_denied(cursor, obs_values, insertuser):
+    auth0id, obsid, vals, start, end = obs_values(insertuser[3]['strid'])
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('read_latest_observation_value',
+                        (auth0id, obsid))
+    assert e.value.args[0] == 1142
+
+
+def test_read_latest_observation_values_denied_can_read_meta(
+        cursor, obs_values, allow_read_observations, insertuser):
+    auth0id, obsid, vals, start, end = obs_values(insertuser[3]['strid'])
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('read_latest_observation_value',
+                        (auth0id, obsid))
+    assert e.value.args[0] == 1142
+
+
+def test_read_latest_forecast_values(cursor, fx_values, insertuser,
+                                     allow_read_forecast_values):
+    auth0id, fxid, vals, *_ = fx_values
+    cursor.callproc('read_latest_forecast_value', (auth0id, fxid))
+    res = cursor.fetchall()
+    assert len(res) == 1
+    assert res[0] == vals[-1]
+    time_ = dt.datetime.now().replace(microsecond=0)
+    cursor.execute(
+        'INSERT INTO forecasts_values (id, timestamp, value)'
+        ' VALUES (UUID_TO_BIN(%s, 1), %s, %s)', (fxid, time_, 1.8))
+    cursor.callproc('read_latest_forecast_value', (auth0id, fxid))
+    res = cursor.fetchall()
+    assert res[0] == (fxid, time_, 1.8)
+
+
+def test_read_latest_forecast_values_no_data(
+        cursor, fx_values, insertuser, allow_read_forecast_values):
+    auth0id, fxid, vals, *_ = fx_values
+    cursor.execute(
+        'DELETE from forecasts_values where id = UUID_TO_BIN(%s, 1)',
+        (fxid,))
+    cursor.callproc('read_latest_forecast_value', (auth0id, fxid))
+    res = cursor.fetchall()
+    assert len(res) == 0
+
+
+def test_read_latest_forecast_values_denied(cursor, fx_values, insertuser):
+    auth0id, fxid, vals, start, end = fx_values
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('read_latest_forecast_value',
+                        (auth0id, fxid))
+    assert e.value.args[0] == 1142
+
+
+def test_read_latest_forecast_values_denied_can_read_meta(
+        cursor, fx_values, allow_read_forecasts, insertuser):
+    auth0id, fxid, vals, start, end = fx_values
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('read_latest_forecast_value',
+                        (auth0id, fxid))
+    assert e.value.args[0] == 1142
+
+
+def test_read_latest_cdf_forecast_values(
+        cursor, cdf_fx_values, insertuser, allow_read_cdf_forecast_values):
+    auth0id, cdf_fxid, vals, *_ = cdf_fx_values
+    cursor.callproc('read_latest_cdf_forecast_value', (auth0id, cdf_fxid))
+    res = cursor.fetchall()
+    assert len(res) == 1
+    assert res[0] == vals[-1]
+    time_ = dt.datetime.now().replace(microsecond=0)
+    cursor.execute(
+        'INSERT INTO cdf_forecasts_values (id, timestamp, value)'
+        ' VALUES (UUID_TO_BIN(%s, 1), %s, %s)', (cdf_fxid, time_, 1.8))
+    cursor.callproc('read_latest_cdf_forecast_value', (auth0id, cdf_fxid))
+    res = cursor.fetchall()
+    assert res[0] == (cdf_fxid, time_, 1.8)
+
+
+def test_read_latest_cdf_forecast_values_no_data(
+        cursor, cdf_fx_values, insertuser, allow_read_cdf_forecast_values):
+    auth0id, cdf_fxid, vals, *_ = cdf_fx_values
+    cursor.execute(
+        'DELETE from cdf_forecasts_values where id = UUID_TO_BIN(%s, 1)',
+        (cdf_fxid,))
+    cursor.callproc('read_latest_cdf_forecast_value', (auth0id, cdf_fxid))
+    res = cursor.fetchall()
+    assert len(res) == 0
+
+
+def test_read_latest_cdf_forecast_values_denied(
+        cursor, cdf_fx_values, insertuser):
+    auth0id, cdf_fxid, vals, start, end = cdf_fx_values
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('read_latest_cdf_forecast_value',
+                        (auth0id, cdf_fxid))
+    assert e.value.args[0] == 1142
+
+
+def test_read_latest_cdf_forecast_values_denied_can_read_meta(
+        cursor, cdf_fx_values, allow_read_cdf_forecasts, insertuser):
+    auth0id, cdf_fxid, vals, start, end = cdf_fx_values
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('read_latest_cdf_forecast_value',
+                        (auth0id, cdf_fxid))
+    assert e.value.args[0] == 1142
+

--- a/datastore/tests/test_reads.py
+++ b/datastore/tests/test_reads.py
@@ -1588,6 +1588,17 @@ def test_read_latest_observation_values_denied(cursor, obs_values, insertuser):
     assert e.value.args[0] == 1142
 
 
+    
+def test_read_observation_latest_fxid(cursor, obs_values, insertuser,
+                                      allow_read_observation_values,
+                                      allow_read_forecast_values):
+    auth0id, obsid, vals, start, end = obs_values(insertuser[3]['strid'])
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('read_latest_observation_value',
+                        (auth0id, insertuser.fx['strid']))
+    assert e.value.args[0] == 1142
+
+    
 def test_read_latest_observation_values_denied_can_read_meta(
         cursor, obs_values, allow_read_observations, insertuser):
     auth0id, obsid, vals, start, end = obs_values(insertuser[3]['strid'])
@@ -1629,6 +1640,16 @@ def test_read_latest_forecast_values_denied(cursor, fx_values, insertuser):
     with pytest.raises(pymysql.err.OperationalError) as e:
         cursor.callproc('read_latest_forecast_value',
                         (auth0id, fxid))
+    assert e.value.args[0] == 1142
+
+
+def test_read_latest_forecast_values_obsid(cursor, fx_values, insertuser,
+                                           allow_read_forecast_values,
+                                           allow_read_observation_values):
+    auth0id, fxid, vals, start, end = fx_values
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('read_latest_forecast_value',
+                        (auth0id, insertuser.obs['strid']))
     assert e.value.args[0] == 1142
 
 
@@ -1674,6 +1695,17 @@ def test_read_latest_cdf_forecast_values_denied(
     with pytest.raises(pymysql.err.OperationalError) as e:
         cursor.callproc('read_latest_cdf_forecast_value',
                         (auth0id, cdf_fxid))
+    assert e.value.args[0] == 1142
+
+    
+def test_read_latest_cdf_forecast_values_obsid(
+        cursor, cdf_fx_values, insertuser,
+        allow_read_cdf_forecast_values,
+        allow_read_observation_values):
+    auth0id, fxid, vals, start, end = cdf_fx_values
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('read_latest_cdf_forecast_value',
+                        (auth0id, insertuser.obs['strid']))
     assert e.value.args[0] == 1142
 
 
@@ -1723,6 +1755,16 @@ def test_read_observation_time_range_denied(cursor, obs_values, insertuser):
     assert e.value.args[0] == 1142
 
 
+def test_read_observation_time_range_fxid(cursor, obs_values, insertuser,
+                                          allow_read_observation_values,
+                                          allow_read_forecast_values):
+    auth0id, obsid, vals, start, end = obs_values(insertuser[3]['strid'])
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('read_observation_time_range',
+                        (auth0id, insertuser.fx['strid']))
+    assert e.value.args[0] == 1142
+
+
 def test_read_observation_time_range_denied_can_read_meta(
         cursor, obs_values, allow_read_observations, insertuser):
     auth0id, obsid, vals, start, end = obs_values(insertuser[3]['strid'])
@@ -1769,6 +1811,16 @@ def test_read_cdf_forecast_time_range_denied(
     assert e.value.args[0] == 1142
 
 
+def test_read_cdf_forecast_time_range_obs_id(
+        cursor, cdf_fx_values, insertuser, allow_read_cdf_forecast_values,
+        allow_read_observation_values):
+    auth0id, *_ = cdf_fx_values
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('read_cdf_forecast_time_range',
+                        (auth0id, insertuser.obs['strid']))
+    assert e.value.args[0] == 1142
+    
+
 def test_read_cdf_forecast_time_range_denied_can_read_meta(
         cursor, cdf_fx_values, allow_read_cdf_forecasts, insertuser):
     auth0id, cdf_fxid, vals, start, end = cdf_fx_values
@@ -1814,6 +1866,16 @@ def test_read_forecast_time_range_denied(
         cursor.callproc('read_forecast_time_range', (auth0id, fxid))
     assert e.value.args[0] == 1142
 
+
+def test_read_forecast_time_range_obs_id(
+        cursor, fx_values, insertuser, allow_read_forecast_values,
+        allow_read_observation_values):
+    auth0id, *_ = fx_values
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('read_forecast_time_range',
+                        (auth0id, insertuser.obs['strid']))
+    assert e.value.args[0] == 1142
+    
 
 def test_read_forecast_time_range_denied_can_read_meta(
         cursor, fx_values, allow_read_forecasts, insertuser):

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -1938,6 +1938,16 @@ def new_observation(api):
 
 
 @pytest.fixture
+def new_forecast(api):
+    def fn():
+        fx = api.post(f'/forecasts/single/', BASE_URL,
+                      json=VALID_FORECAST_JSON)
+        fx_id = fx.data.decode('utf-8')
+        return fx_id
+    return fn
+
+
+@pytest.fixture
 def new_perm(api):
     def fn(**kwargs):
         perm_json = PERMISSION.copy()

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -166,7 +166,7 @@ class ForecastValuesView(MethodView):
         responses:
           200:
             content:
-              applciation/json:
+              application/json:
                 schema:
                   $ref: '#/components/schemas/ForecastValues'
               text/csv:
@@ -525,7 +525,7 @@ class CDFForecastValues(MethodView):
         responses:
           200:
             content:
-              applciation/json:
+              application/json:
                 schema:
                   $ref: '#/components/schemas/CDFForecastValues'
               text/csv:
@@ -709,10 +709,10 @@ forecast_blp.add_url_rule(
     '/single/<uuid_str:forecast_id>/values',
     view_func=ForecastValuesView.as_view('values'))
 forecast_blp.add_url_rule(
-    '/<uuid_str:forecast_id>/values/latest',
+    '/single/<uuid_str:forecast_id>/values/latest',
     view_func=ForecastLatestView.as_view('latest_value'))
 forecast_blp.add_url_rule(
-    '/<uuid_str:forecast_id>/values/timerange',
+    '/single/<uuid_str:forecast_id>/values/timerange',
     view_func=ForecastTimeRangeView.as_view('time_range'))
 forecast_blp.add_url_rule(
     '/single/<uuid_str:forecast_id>/metadata',

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -278,6 +278,26 @@ class ObservationValuesSchema(ObservationValuesPostSchema):
     )
 
 
+@spec.define_schema('ObservationTimeRange')
+class ObservationTimeRangeSchema(ma.Schema):
+    class Meta:
+        strict = True
+        ordered = True
+    observation_id = ma.UUID(
+        title='Obs ID',
+        description="UUID of the Observation associated with this data.")
+    min_timestamp = ISODateTime(
+        title="Minimum Timestamp",
+        description=("The minimum timestamp in the observation value series as"
+                     " an ISO 8601 datetime."),
+    )
+    max_timestamp = ISODateTime(
+        title="Maximum Timestamp",
+        description=("The maximum timestamp in the observation value series as"
+                     " an ISO 8601 datetime."),
+    )
+
+
 @spec.define_schema('ObservationDefinition')
 class ObservationPostSchema(ma.Schema):
     class Meta:

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -278,24 +278,27 @@ class ObservationValuesSchema(ObservationValuesPostSchema):
     )
 
 
-@spec.define_schema('ObservationTimeRange')
-class ObservationTimeRangeSchema(ma.Schema):
+class TimeRangeSchema(ma.Schema):
     class Meta:
         strict = True
         ordered = True
-    observation_id = ma.UUID(
-        title='Obs ID',
-        description="UUID of the Observation associated with this data.")
     min_timestamp = ISODateTime(
         title="Minimum Timestamp",
-        description=("The minimum timestamp in the observation value series as"
+        description=("The minimum timestamp in the value series as"
                      " an ISO 8601 datetime."),
     )
     max_timestamp = ISODateTime(
         title="Maximum Timestamp",
-        description=("The maximum timestamp in the observation value series as"
+        description=("The maximum timestamp in the value series as"
                      " an ISO 8601 datetime."),
     )
+
+
+@spec.define_schema('ObservationTimeRange')
+class ObservationTimeRangeSchema(TimeRangeSchema):
+    observation_id = ma.UUID(
+        title='Obs ID',
+        description="UUID of the Observation associated with this data.")
 
 
 @spec.define_schema('ObservationDefinition')
@@ -408,6 +411,21 @@ class ForecastValuesSchema(ForecastValuesPostSchema):
         },
         description="Contains a link to the metadata endpoint."
     )
+
+
+@spec.define_schema('ForecastTimeRange')
+class ForecastTimeRangeSchema(TimeRangeSchema):
+    forecast_id = ma.UUID(
+        title='Forecast ID',
+        description="UUID of the forecast associated with this data.")
+
+
+@spec.define_schema('CDFForecastTimeRange')
+class CDFForecastTimeRangeSchema(TimeRangeSchema):
+    forecast_id = ma.UUID(
+        title='Forecast ID',
+        description=(
+            "UUID of the probabilistic forecast associated with this data."))
 
 
 @spec.define_schema('ForecastDefinition')

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -274,7 +274,7 @@ class ObservationValuesSchema(ObservationValuesPostSchema):
             'metadata': ma.AbsoluteURLFor('observations.metadata',
                                           observation_id='<observation_id>'),
             'timerange': ma.AbsoluteURLFor('observations.time_range',
-                                            observation_id='<observation_id>'),
+                                           observation_id='<observation_id>'),
         },
         description="Contains a link to the values endpoint."
     )
@@ -359,7 +359,7 @@ class ObservationLinksSchema(ma.Schema):
             'values': ma.AbsoluteURLFor('observations.values',
                                         observation_id='<observation_id>'),
             'timerange': ma.AbsoluteURLFor('observations.time_range',
-                                            observation_id='<observation_id>'),
+                                           observation_id='<observation_id>'),
         },
         description="Contains links to the values and metadata endpoints."
     )
@@ -399,7 +399,7 @@ class CDFForecastValuesSchema(ForecastValuesPostSchema):
             'metadata': ma.AbsoluteURLFor('forecasts.single_cdf_metadata',
                                           forecast_id='<forecast_id>'),
             'timerange': ma.AbsoluteURLFor('forecasts.cdf_time_range',
-                                            forecast_id='<forecast_id>'),
+                                           forecast_id='<forecast_id>'),
         },
         description="Contains a link to the metadata endpoint."
     )
@@ -415,7 +415,7 @@ class ForecastValuesSchema(ForecastValuesPostSchema):
             'metadata': ma.AbsoluteURLFor('forecasts.metadata',
                                           forecast_id='<forecast_id>'),
             'timerange': ma.AbsoluteURLFor('forecasts.time_range',
-                                            forecast_id='<forecast_id>'),
+                                           forecast_id='<forecast_id>'),
         },
         description="Contains a link to the metadata endpoint."
     )
@@ -538,7 +538,7 @@ class ForecastLinksSchema(ma.Schema):
             'values': ma.AbsoluteURLFor('forecasts.values',
                                         forecast_id='<forecast_id>'),
             'timerange': ma.AbsoluteURLFor('forecasts.time_range',
-                                            forecast_id='<forecast_id>'),
+                                           forecast_id='<forecast_id>'),
         },
         description="Contains links to the values and metadata endpoints."
     )
@@ -605,7 +605,7 @@ class CDFForecastSingleSchema(ma.Schema):
             'values': ma.AbsoluteURLFor('forecasts.single_cdf_value',
                                         forecast_id='<forecast_id>'),
             'timerange': ma.AbsoluteURLFor('forecasts.cdf_time_range',
-                                            forecast_id='<forecast_id>'),
+                                           forecast_id='<forecast_id>'),
         },
         description="Contains a link to the values endpoint."
     )

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -273,6 +273,8 @@ class ObservationValuesSchema(ObservationValuesPostSchema):
         {
             'metadata': ma.AbsoluteURLFor('observations.metadata',
                                           observation_id='<observation_id>'),
+            'timerange': ma.AbsoluteURLFor('observations.time_range',
+                                            observation_id='<observation_id>'),
         },
         description="Contains a link to the values endpoint."
     )
@@ -355,7 +357,9 @@ class ObservationLinksSchema(ma.Schema):
             'metadata': ma.AbsoluteURLFor('observations.metadata',
                                           observation_id='<observation_id>'),
             'values': ma.AbsoluteURLFor('observations.values',
-                                        observation_id='<observation_id>')
+                                        observation_id='<observation_id>'),
+            'timerange': ma.AbsoluteURLFor('observations.time_range',
+                                            observation_id='<observation_id>'),
         },
         description="Contains links to the values and metadata endpoints."
     )
@@ -394,6 +398,8 @@ class CDFForecastValuesSchema(ForecastValuesPostSchema):
         {
             'metadata': ma.AbsoluteURLFor('forecasts.single_cdf_metadata',
                                           forecast_id='<forecast_id>'),
+            'timerange': ma.AbsoluteURLFor('forecasts.cdf_time_range',
+                                            forecast_id='<forecast_id>'),
         },
         description="Contains a link to the metadata endpoint."
     )
@@ -408,6 +414,8 @@ class ForecastValuesSchema(ForecastValuesPostSchema):
         {
             'metadata': ma.AbsoluteURLFor('forecasts.metadata',
                                           forecast_id='<forecast_id>'),
+            'timerange': ma.AbsoluteURLFor('forecasts.time_range',
+                                            forecast_id='<forecast_id>'),
         },
         description="Contains a link to the metadata endpoint."
     )
@@ -528,7 +536,9 @@ class ForecastLinksSchema(ma.Schema):
             'metadata': ma.AbsoluteURLFor('forecasts.metadata',
                                           forecast_id='<forecast_id>'),
             'values': ma.AbsoluteURLFor('forecasts.values',
-                                        forecast_id='<forecast_id>')
+                                        forecast_id='<forecast_id>'),
+            'timerange': ma.AbsoluteURLFor('forecasts.time_range',
+                                            forecast_id='<forecast_id>'),
         },
         description="Contains links to the values and metadata endpoints."
     )
@@ -568,7 +578,10 @@ class CDFForecastSchema(ForecastSchema):
                 forecast_id='<parent>'),
             'values': ma.AbsoluteURLFor(
                 'forecasts.single_cdf_value',
-                forecast_id='<forecast_id>')
+                forecast_id='<forecast_id>'),
+            'timerange': ma.AbsoluteURLFor(
+                'forecasts.cdf_time_range',
+                forecast_id='<forecast_id>'),
         },
         description=("Contains a link to the associated Probabilistic "
                      "Forecast Group."),
@@ -590,7 +603,9 @@ class CDFForecastSingleSchema(ma.Schema):
     _links = ma.Hyperlinks(
         {
             'values': ma.AbsoluteURLFor('forecasts.single_cdf_value',
-                                        forecast_id='<forecast_id>')
+                                        forecast_id='<forecast_id>'),
+            'timerange': ma.AbsoluteURLFor('forecasts.cdf_time_range',
+                                            forecast_id='<forecast_id>'),
         },
         description="Contains a link to the values endpoint."
     )

--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -307,3 +307,49 @@ def test_post_and_get_values_csv(api, cdf_forecast_id, mock_previous):
                 query_string={'start': start, 'end': end})
     posted_data = r.data
     assert VALID_CDF_VALUE_CSV == posted_data.decode('utf-8')
+
+
+def test_get_latest_cdf_forecast_value_200(api, cdf_forecast_id, fx_vals):
+    r = api.get(f'/forecasts/cdf/single/{cdf_forecast_id}/values/latest',
+                base_url=BASE_URL)
+    assert r.status_code == 200
+    assert r.mimetype == 'application/json'
+    data = r.get_json()
+    assert data['forecast_id'] == cdf_forecast_id
+    assert len(data['values']) == 1
+    assert data['values'][0]['timestamp'] == fx_vals.index[-1].isoformat()
+
+
+def test_get_latest_cdf_forecast_value_404(api, missing_id):
+    r = api.get(f'/forecasts/cdf/single/{missing_id}/values/latest',
+                base_url=BASE_URL)
+    assert r.status_code == 404
+
+
+def test_get_latest_cdf_forecast_value_404_obsid(api, observation_id):
+    r = api.get(f'/forecasts/cdf/single/{observation_id}/values/latest',
+                base_url=BASE_URL)
+    assert r.status_code == 404
+
+
+def test_get_cdf_forecast_timerange_200(api, cdf_forecast_id, fx_vals):
+    r = api.get(f'/forecasts/cdf/single/{cdf_forecast_id}/values/timerange',
+                base_url=BASE_URL)
+    assert r.status_code == 200
+    assert r.mimetype == 'application/json'
+    data = r.get_json()
+    assert data['forecast_id'] == cdf_forecast_id
+    assert data['max_timestamp'] == fx_vals.index[-1].isoformat()
+    assert data['min_timestamp'] == fx_vals.index[0].isoformat()
+
+
+def test_get_cdf_forecast_timerange_404(api, missing_id):
+    r = api.get(f'/forecasts/cdf/single/{missing_id}/values/timerange',
+                base_url=BASE_URL)
+    assert r.status_code == 404
+
+
+def test_get_cdf_forecast_timerange_404_obsid(api, observation_id):
+    r = api.get(f'/forecasts/cdf/single/{observation_id}/values/timerange',
+                base_url=BASE_URL)
+    assert r.status_code == 404

--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -348,3 +348,73 @@ def test_post_and_get_values_csv(api, forecast_id, mock_previous):
                 query_string={'start': start, 'end': end})
     posted_data = r.data
     assert VALID_FX_VALUE_CSV == posted_data.decode('utf-8')
+
+
+def test_get_latest_forecast_value_200(api, forecast_id, fx_vals):
+    r = api.get(f'/forecasts/single/{forecast_id}/values/latest',
+                base_url=BASE_URL)
+    assert r.status_code == 200
+    assert r.mimetype == 'application/json'
+    data = r.get_json()
+    assert data['forecast_id'] == forecast_id
+    assert len(data['values']) == 1
+    assert data['values'][0]['timestamp'] == fx_vals.index[-1].isoformat()
+
+
+def test_get_latest_forecast_value_new(api, new_forecast):
+    forecast_id = new_forecast()
+    r = api.get(f'/forecasts/single/{forecast_id}/values/latest',
+                base_url=BASE_URL)
+    assert r.status_code == 200
+    assert r.mimetype == 'application/json'
+    data = r.get_json()
+    assert data['forecast_id'] == forecast_id
+    assert len(data['values']) == 0
+
+
+def test_get_latest_forecast_value_404(api, inaccessible_forecast_id):
+    r = api.get(f'/forecasts/single/{inaccessible_forecast_id}/values/latest',
+                base_url=BASE_URL)
+    assert r.status_code == 404
+
+
+def test_get_latest_forecast_value_404_obsid(api, observation_id):
+    r = api.get(f'/forecasts/single/{observation_id}/values/latest',
+                base_url=BASE_URL)
+    assert r.status_code == 404
+
+
+def test_get_forecast_timerange_200(api, forecast_id, fx_vals):
+    r = api.get(f'/forecasts/single/{forecast_id}/values/timerange',
+                base_url=BASE_URL)
+    assert r.status_code == 200
+    assert r.mimetype == 'application/json'
+    data = r.get_json()
+    assert data['forecast_id'] == forecast_id
+    assert data['max_timestamp'] == fx_vals.index[-1].isoformat()
+    assert data['min_timestamp'] == fx_vals.index[0].isoformat()
+
+
+def test_get_forecast_timerange_new(api, new_forecast):
+    forecast_id = new_forecast()
+    r = api.get(f'/forecasts/single/{forecast_id}/values/timerange',
+                base_url=BASE_URL)
+    assert r.status_code == 200
+    assert r.mimetype == 'application/json'
+    data = r.get_json()
+    assert data['forecast_id'] == forecast_id
+    assert data['min_timestamp'] is None
+    assert data['max_timestamp'] is None
+
+
+def test_get_forecast_timerange_404(api, inaccessible_forecast_id):
+    r = api.get(
+        f'/forecasts/single/{inaccessible_forecast_id}/values/timerange',
+        base_url=BASE_URL)
+    assert r.status_code == 404
+
+
+def test_get_forecast_timerange_404_obsid(api, observation_id):
+    r = api.get(f'/forecasts/single/{observation_id}/values/timerange',
+                base_url=BASE_URL)
+    assert r.status_code == 404

--- a/sfa_api/tests/test_observations.py
+++ b/sfa_api/tests/test_observations.py
@@ -375,3 +375,68 @@ def test_post_file_invalid_mimetype(api, observation_id):
     assert file_post.status_code == 400
     expected = '{"errors":{"error":["Unsupported Content-Type or MIME type."]}}\n' # noqa
     assert file_post.get_data(as_text=True) == expected
+
+
+def test_get_latest_observation_values_200(api, observation_id, ghi_obs_vals):
+    r = api.get(f'/observations/{observation_id}/values/latest',
+                base_url=BASE_URL)
+    assert r.status_code == 200
+    assert r.mimetype == 'application/json'
+    data = r.get_json()
+    assert data['observation_id'] == observation_id
+    assert len(data['values']) == 1
+    assert data['values'][0]['timestamp'] == ghi_obs_vals.index[-1].isoformat()
+
+
+def test_get_latest_observation_values_404_fxid(api, forecast_id):
+    r = api.get(f'/observations/{forecast_id}/values/latest',
+                base_url=BASE_URL)
+    assert r.status_code == 404
+
+
+def test_get_latest_observation_values_404(api, missing_id):
+    r = api.get(f'/observations/{missing_id}/values/latest',
+                base_url=BASE_URL)
+    assert r.status_code == 404
+
+
+def test_get_latest_observation_values_new(api, new_observation):
+    obs_id = new_observation()
+    r = api.get(f'/observations/{obs_id}/values/latest',
+                base_url=BASE_URL)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert len(data['values']) == 0
+
+
+def test_get_observation_timerange_200(api, observation_id, ghi_obs_vals):
+    r = api.get(f'/observations/{observation_id}/values/timerange',
+                base_url=BASE_URL)
+    assert r.status_code == 200
+    assert r.mimetype == 'application/json'
+    data = r.get_json()
+    assert data['observation_id'] == observation_id
+    assert data['max_timestamp'] == ghi_obs_vals.index[-1].isoformat()
+    assert data['min_timestamp'] == ghi_obs_vals.index[0].isoformat()
+
+
+def test_get_observation_timerange_404_fxid(api, forecast_id):
+    r = api.get(f'/observations/{forecast_id}/values/timerange',
+                base_url=BASE_URL)
+    assert r.status_code == 404
+
+
+def test_get_observation_timerange_404(api, missing_id):
+    r = api.get(f'/observations/{missing_id}/values/timerange',
+                base_url=BASE_URL)
+    assert r.status_code == 404
+
+
+def test_get_observation_timerange_new(api, new_observation):
+    obs_id = new_observation()
+    r = api.get(f'/observations/{obs_id}/values/timerange',
+                base_url=BASE_URL)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data['min_timestamp'] is None
+    assert data['max_timestamp'] is None

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -340,6 +340,46 @@ def read_observation_values(observation_id, start=None, end=None):
     return df
 
 
+def read_latest_observation_value(observation_id):
+    """Read the most recent observation value.
+
+    Parameters
+    ----------
+    observation_id: string
+        UUID of associated observation.
+
+    Returns
+    -------
+    pandas.DataFrame
+        With a value column and datetime index and only one row
+    """
+    obs_vals = _call_procedure('read_latest_observation_value', observation_id,
+                               cursor_type='standard')
+    df = pd.DataFrame.from_records(
+        list(obs_vals), columns=[
+            'observation_id', 'timestamp', 'value', 'quality_flag']
+    ).drop(columns='observation_id').set_index('timestamp')
+    return df
+
+
+def read_observation_time_range(observation_id):
+    """Get the time range of values for a observation.
+
+    Parameters
+    ----------
+    observation_id: string
+        UUID of associated observation.
+
+    Returns
+    -------
+    dict
+        With `min_timestamp` and `max_timestamp` keys that are either
+        dt.datetime objects or None
+    """
+    return _call_procedure_for_single(
+        'read_observation_time_range', observation_id)
+
+
 def store_observation(observation):
     """Store Observation metadata. Should generate and store a uuid
     as the 'observation_id' field.
@@ -488,6 +528,45 @@ def read_forecast_values(forecast_id, start=None, end=None):
     """
     return _read_fx_values('read_forecast_values', forecast_id,
                            start, end)
+
+
+def read_latest_forecast_value(forecast_id):
+    """Read the most recent forecast value.
+
+    Parameters
+    ----------
+    forecast_id: string
+        UUID of associated forecast.
+
+    Returns
+    -------
+    pandas.DataFrame
+        With a value column and datetime index and only one row
+    """
+    fx_vals = _call_procedure('read_latest_forecast_value', forecast_id,
+                              cursor_type='standard')
+    df = pd.DataFrame.from_records(
+        list(fx_vals), columns=['forecast_id', 'timestamp', 'value']
+    ).drop(columns='forecast_id').set_index('timestamp')
+    return df
+
+
+def read_forecast_time_range(forecast_id):
+    """Get the time range of values for a forecast.
+
+    Parameters
+    ----------
+    forecast_id: string
+        UUID of associated forecast.
+
+    Returns
+    -------
+    dict
+        With `min_timestamp` and `max_timestamp` keys that are either
+        dt.datetime objects or None
+    """
+    return _call_procedure_for_single(
+        'read_forecast_time_range', forecast_id)
 
 
 def store_forecast(forecast):
@@ -721,6 +800,45 @@ def read_cdf_forecast_values(forecast_id, start=None, end=None):
     """
     return _read_fx_values('read_cdf_forecast_values', forecast_id,
                            start, end)
+
+
+def read_latest_cdf_forecast_value(forecast_id):
+    """Read the most recent CDF forecast value.
+
+    Parameters
+    ----------
+    forecast_id: string
+        UUID of associated forecast.
+
+    Returns
+    -------
+    pandas.DataFrame
+        With a value column and datetime index and only one row
+    """
+    fx_vals = _call_procedure('read_latest_cdf_forecast_value', forecast_id,
+                              cursor_type='standard')
+    df = pd.DataFrame.from_records(
+        list(fx_vals), columns=['forecast_id', 'timestamp', 'value']
+    ).drop(columns='forecast_id').set_index('timestamp')
+    return df
+
+
+def read_cdf_forecast_time_range(forecast_id):
+    """Get the time range of values for a CDF forecast.
+
+    Parameters
+    ----------
+    forecast_id: string
+        UUID of associated forecast.
+
+    Returns
+    -------
+    dict
+        With `min_timestamp` and `max_timestamp` keys that are either
+        dt.datetime objects or None
+    """
+    return _call_procedure_for_single(
+        'read_cdf_forecast_time_range', forecast_id)
 
 
 def store_cdf_forecast(cdf_forecast):

--- a/sfa_api/utils/tests/test_storage_interface.py
+++ b/sfa_api/utils/tests/test_storage_interface.py
@@ -266,8 +266,8 @@ def test_read_observation_time_range_no_data(sql_app, user, nocommit_cursor):
     new_id = storage_interface.store_observation(observation)
     trange = storage_interface.read_observation_time_range(new_id)
     assert len(trange) == 2
-    assert trange['min_timestamp'] == None
-    assert trange['max_timestamp'] == None
+    assert trange['min_timestamp'] is None
+    assert trange['max_timestamp'] is None
 
 
 def test_read_observation_time_range_invalid_observation(sql_app, user):
@@ -536,8 +536,8 @@ def test_read_forecast_time_range_no_data(sql_app, user, nocommit_cursor):
     new_id = storage_interface.store_forecast(forecast)
     trange = storage_interface.read_forecast_time_range(new_id)
     assert len(trange) == 2
-    assert trange['min_timestamp'] == None
-    assert trange['max_timestamp'] == None
+    assert trange['min_timestamp'] is None
+    assert trange['max_timestamp'] is None
 
 
 def test_read_forecast_time_range_invalid_forecast(sql_app, user):
@@ -748,7 +748,8 @@ def test_read_latest_cdf_forecast_value(sql_app, user, forecast_id):
     assert (forecast_values.columns == ['value']).all()
 
 
-def test_read_latest_cdf_forecast_value_no_data(sql_app, user, nocommit_cursor):
+def test_read_latest_cdf_forecast_value_no_data(
+        sql_app, user, nocommit_cursor):
     cdf_forecast = {'parent': list(demo_group_cdf.keys())[0],
                     'constant_value': 100.0}
     new_id = storage_interface.store_cdf_forecast(cdf_forecast)
@@ -793,8 +794,8 @@ def test_read_cdf_forecast_time_range_no_data(sql_app, user, nocommit_cursor):
     new_id = storage_interface.store_cdf_forecast(cdf_forecast)
     trange = storage_interface.read_cdf_forecast_time_range(new_id)
     assert len(trange) == 2
-    assert trange['min_timestamp'] == None
-    assert trange['max_timestamp'] == None
+    assert trange['min_timestamp'] is None
+    assert trange['max_timestamp'] is None
 
 
 def test_read_cdf_forecast_time_range_invalid_forecast(sql_app, user):

--- a/sfa_api/utils/tests/test_storage_interface.py
+++ b/sfa_api/utils/tests/test_storage_interface.py
@@ -210,6 +210,72 @@ def test_read_observation_values_invalid_user(sql_app, invalid_user, startend):
             list(demo_observations.keys())[0], start, end)
 
 
+@pytest.mark.parametrize('observation_id', demo_observations.keys())
+def test_read_latest_observation_value(sql_app, user, observation_id):
+    idx_step = demo_observations[observation_id]['interval_length']
+    observation_values = storage_interface.read_latest_observation_value(
+        observation_id)
+    fx_index = observation_values.index
+    assert len(fx_index) == 1
+    assert fx_index[0] == TESTINDICES[idx_step].index[-1]
+    assert (observation_values.columns == ['value', 'quality_flag']).all()
+
+
+def test_read_latest_observation_value_no_data(sql_app, user, nocommit_cursor):
+    observation = list(demo_observations.values())[0].copy()
+    observation['name'] = 'new_observation'
+    new_id = storage_interface.store_observation(observation)
+    observation_values = storage_interface.read_latest_observation_value(new_id)
+    fx_index = observation_values.index
+    assert len(fx_index) == 0
+
+
+def test_read_latest_df_observation_value_invalid_observation(sql_app, user):
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.read_latest_observation_value(
+            str(uuid.uuid1()))
+
+
+def test_read_latest_observation_value_invalid_user(
+        sql_app, invalid_user):
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.read_observation_values(
+            list(demo_single_cdf.keys())[0])
+
+
+@pytest.mark.parametrize('observation_id', demo_observations.keys())
+def test_read_observation_time_range(sql_app, user, observation_id):
+    idx_step = demo_observations[observation_id]['interval_length']
+    trange = storage_interface.read_observation_time_range(
+        observation_id)
+    assert len(trange) == 2
+    assert trange['min_timestamp'] == TESTINDICES[idx_step].index[0]
+    assert trange['max_timestamp'] == TESTINDICES[idx_step].index[-1]
+
+
+def test_read_observation_time_range_no_data(sql_app, user, nocommit_cursor):
+    observation = list(demo_observations.values())[0].copy()
+    observation['name'] = 'new_observation'
+    new_id = storage_interface.store_observation(observation)
+    trange = storage_interface.read_observation_time_range(new_id)
+    assert len(trange) == 2
+    assert trange['min_timestamp'] == None
+    assert trange['max_timestamp'] == None
+
+
+def test_read_observation_time_range_invalid_observation(sql_app, user):
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.read_observation_time_range(
+            str(uuid.uuid1()))
+
+
+def test_read_observation_time_range_invalid_user(
+        sql_app, invalid_user):
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.read_observation_time_range(
+            list(demo_single_cdf.keys())[0])
+
+
 @pytest.mark.parametrize('observation', demo_observations.values())
 def test_store_observation(sql_app, user, observation, nocommit_cursor):
     observation = observation.copy()
@@ -408,6 +474,72 @@ def test_read_forecast_values_invalid_user(sql_app, invalid_user, startend):
             list(demo_forecasts.keys())[0], start, end)
 
 
+@pytest.mark.parametrize('forecast_id', demo_forecasts.keys())
+def test_read_latest_forecast_value(sql_app, user, forecast_id):
+    idx_step = demo_forecasts[forecast_id]['interval_length']
+    forecast_values = storage_interface.read_latest_forecast_value(
+        forecast_id)
+    fx_index = forecast_values.index
+    assert len(fx_index) == 1
+    assert fx_index[0] == TESTINDICES[idx_step].index[-1]
+    assert (forecast_values.columns == ['value']).all()
+
+
+def test_read_latest_forecast_value_no_data(sql_app, user, nocommit_cursor):
+    forecast = list(demo_forecasts.values())[0].copy()
+    forecast['name'] = 'new_forecast'
+    new_id = storage_interface.store_forecast(forecast)
+    forecast_values = storage_interface.read_latest_forecast_value(new_id)
+    fx_index = forecast_values.index
+    assert len(fx_index) == 0
+
+
+def test_read_latest_df_forecast_value_invalid_forecast(sql_app, user):
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.read_latest_forecast_value(
+            str(uuid.uuid1()))
+
+
+def test_read_latest_forecast_value_invalid_user(
+        sql_app, invalid_user):
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.read_forecast_values(
+            list(demo_single_cdf.keys())[0])
+
+
+@pytest.mark.parametrize('forecast_id', demo_forecasts.keys())
+def test_read_forecast_time_range(sql_app, user, forecast_id):
+    idx_step = demo_forecasts[forecast_id]['interval_length']
+    trange = storage_interface.read_forecast_time_range(
+        forecast_id)
+    assert len(trange) == 2
+    assert trange['min_timestamp'] == TESTINDICES[idx_step].index[0]
+    assert trange['max_timestamp'] == TESTINDICES[idx_step].index[-1]
+
+
+def test_read_forecast_time_range_no_data(sql_app, user, nocommit_cursor):
+    forecast = list(demo_forecasts.values())[0].copy()
+    forecast['name'] = 'new_forecast'
+    new_id = storage_interface.store_forecast(forecast)
+    trange = storage_interface.read_forecast_time_range(new_id)
+    assert len(trange) == 2
+    assert trange['min_timestamp'] == None
+    assert trange['max_timestamp'] == None
+
+
+def test_read_forecast_time_range_invalid_forecast(sql_app, user):
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.read_forecast_time_range(
+            str(uuid.uuid1()))
+
+
+def test_read_forecast_time_range_invalid_user(
+        sql_app, invalid_user):
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.read_forecast_time_range(
+            list(demo_single_cdf.keys())[0])
+
+
 @pytest.mark.parametrize('forecast', demo_forecasts.values())
 def test_store_forecast(sql_app, user, forecast, nocommit_cursor):
     forecast = forecast.copy()
@@ -589,6 +721,74 @@ def test_read_cdf_forecast_values_invalid_user(
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_cdf_forecast_values(
             list(demo_single_cdf.keys())[0], start, end)
+
+
+@pytest.mark.parametrize('forecast_id', demo_single_cdf.keys())
+def test_read_latest_cdf_forecast_value(sql_app, user, forecast_id):
+    parent_id = demo_single_cdf[forecast_id]['parent']
+    idx_step = demo_group_cdf[parent_id]['interval_length']
+    forecast_values = storage_interface.read_latest_cdf_forecast_value(
+        forecast_id)
+    fx_index = forecast_values.index
+    assert len(fx_index) == 1
+    assert fx_index[0] == TESTINDICES[idx_step].index[-1]
+    assert (forecast_values.columns == ['value']).all()
+
+
+def test_read_latest_cdf_forecast_value_no_data(sql_app, user, nocommit_cursor):
+    cdf_forecast = {'parent': list(demo_group_cdf.keys())[0],
+                    'constant_value': 100.0}
+    new_id = storage_interface.store_cdf_forecast(cdf_forecast)
+    forecast_values = storage_interface.read_latest_cdf_forecast_value(new_id)
+    fx_index = forecast_values.index
+    assert len(fx_index) == 0
+
+
+def test_read_latest_df_forecast_value_invalid_forecast(sql_app, user):
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.read_latest_cdf_forecast_value(
+            str(uuid.uuid1()))
+
+
+def test_read_latest_cdf_forecast_value_invalid_user(
+        sql_app, invalid_user):
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.read_cdf_forecast_values(
+            list(demo_single_cdf.keys())[0])
+
+
+@pytest.mark.parametrize('forecast_id', demo_single_cdf.keys())
+def test_read_cdf_forecast_time_range(sql_app, user, forecast_id):
+    parent_id = demo_single_cdf[forecast_id]['parent']
+    idx_step = demo_group_cdf[parent_id]['interval_length']
+    trange = storage_interface.read_cdf_forecast_time_range(
+        forecast_id)
+    assert len(trange) == 2
+    assert trange['min_timestamp'] == TESTINDICES[idx_step].index[0]
+    assert trange['max_timestamp'] == TESTINDICES[idx_step].index[-1]
+
+
+def test_read_cdf_forecast_time_range_no_data(sql_app, user, nocommit_cursor):
+    cdf_forecast = {'parent': list(demo_group_cdf.keys())[0],
+                    'constant_value': 100.0}
+    new_id = storage_interface.store_cdf_forecast(cdf_forecast)
+    trange = storage_interface.read_cdf_forecast_time_range(new_id)
+    assert len(trange) == 2
+    assert trange['min_timestamp'] == None
+    assert trange['max_timestamp'] == None
+
+
+def test_read_cdf_forecast_time_range_invalid_forecast(sql_app, user):
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.read_cdf_forecast_time_range(
+            str(uuid.uuid1()))
+
+
+def test_read_cdf_forecast_time_range_invalid_user(
+        sql_app, invalid_user):
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.read_cdf_forecast_time_range(
+            list(demo_single_cdf.keys())[0])
 
 
 @pytest.mark.parametrize('cdf_forecast_id', demo_single_cdf.keys())

--- a/sfa_api/utils/tests/test_storage_interface.py
+++ b/sfa_api/utils/tests/test_storage_interface.py
@@ -227,8 +227,8 @@ def test_read_latest_observation_value_no_data(sql_app, user, nocommit_cursor):
     new_id = storage_interface.store_observation(observation)
     observation_values = storage_interface.read_latest_observation_value(
         new_id)
-    fx_index = observation_values.index
-    assert len(fx_index) == 0
+    obs_index = observation_values.index
+    assert len(obs_index) == 0
 
 
 def test_read_latest_df_observation_value_invalid_observation(sql_app, user):

--- a/sfa_api/utils/tests/test_storage_interface.py
+++ b/sfa_api/utils/tests/test_storage_interface.py
@@ -20,9 +20,9 @@ from sfa_api.utils import storage_interface
 
 
 TESTINDICES = {
-    1: generate_randoms(1)[0].to_series(keep_tz=True),
-    5: generate_randoms(5)[0].to_series(keep_tz=True),
-    60: generate_randoms(60)[0].to_series(keep_tz=True),
+    1: generate_randoms(1)[0].to_series(),
+    5: generate_randoms(5)[0].to_series(),
+    60: generate_randoms(60)[0].to_series(),
 }
 
 
@@ -225,7 +225,8 @@ def test_read_latest_observation_value_no_data(sql_app, user, nocommit_cursor):
     observation = list(demo_observations.values())[0].copy()
     observation['name'] = 'new_observation'
     new_id = storage_interface.store_observation(observation)
-    observation_values = storage_interface.read_latest_observation_value(new_id)
+    observation_values = storage_interface.read_latest_observation_value(
+        new_id)
     fx_index = observation_values.index
     assert len(fx_index) == 0
 
@@ -234,6 +235,12 @@ def test_read_latest_df_observation_value_invalid_observation(sql_app, user):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_latest_observation_value(
             str(uuid.uuid1()))
+
+
+def test_read_latest_observation_value_fx_id(sql_app, user, forecast_id):
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.read_latest_observation_value(
+            forecast_id)
 
 
 def test_read_latest_observation_value_invalid_user(
@@ -494,10 +501,16 @@ def test_read_latest_forecast_value_no_data(sql_app, user, nocommit_cursor):
     assert len(fx_index) == 0
 
 
-def test_read_latest_df_forecast_value_invalid_forecast(sql_app, user):
+def test_read_latest_forecast_value_invalid_forecast(sql_app, user):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_latest_forecast_value(
             str(uuid.uuid1()))
+
+
+def test_read_latest_forecast_value_obs_id(sql_app, user, observation_id):
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.read_latest_forecast_value(
+            observation_id)
 
 
 def test_read_latest_forecast_value_invalid_user(
@@ -748,6 +761,12 @@ def test_read_latest_df_forecast_value_invalid_forecast(sql_app, user):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_latest_cdf_forecast_value(
             str(uuid.uuid1()))
+
+
+def test_read_latest_cdf_forecast_value_obs_id(sql_app, user, observation_id):
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.read_latest_cdf_forecast_value(
+            observation_id)
 
 
 def test_read_latest_cdf_forecast_value_invalid_user(


### PR DESCRIPTION
to observations, forecasts, and cdf singles. CDF groups and aggregate observations are not supported. Not sure if we should add these to `_links`

closes #168