### PR TITLE
Update report object pair schema

### DIFF
--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -730,7 +730,7 @@ class ReportObjectPair(ma.Schema):
     observation = ma.UUID(title="Observation UUID")
     aggregate = ma.UUID(title="Aggregate UUID")
     reference_forecast = ma.UUID(title="Reference Forecast UUID",
-                                 default=None)
+                                 missing=None)
 
 
 @spec.define_schema('ReportParameters')

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -729,6 +729,8 @@ class ReportObjectPair(ma.Schema):
     forecast = ma.UUID(title="Forecast UUID", required=True)
     observation = ma.UUID(title="Observation UUID")
     aggregate = ma.UUID(title="Aggregate UUID")
+    reference_forecast = ma.UUID(title="Reference Forecast UUID",
+                                 default=None)
 
 
 @spec.define_schema('ReportParameters')

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -737,7 +737,7 @@ class ReportObjectPair(ma.Schema):
         title='Uncertainty',
         description=(
             'How to determine uncertainty when calculating metrics. Set to '
-            '"null" to ignore uncertainty, "observation_uncertainty" to use '
+            '"null" (or  omit) to ignore uncertainty, "observation_uncertainty" to use '
             'uncertainty from the observation, or a quoted float value '
             'between 0.0 and 100.0 representing uncertainty as a percentage.'),
         allow_none=True,

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -730,7 +730,18 @@ class ReportObjectPair(ma.Schema):
     observation = ma.UUID(title="Observation UUID")
     aggregate = ma.UUID(title="Aggregate UUID")
     reference_forecast = ma.UUID(title="Reference Forecast UUID",
+                                 allow_none=True,
                                  missing=None)
+    uncertainty = ma.String(
+        title='Uncertainty',
+        description=(
+            'How to determine uncertainty when calculating metrics. Set to '
+            '"null" to ignore uncertainty, "observation_uncertainty" to use '
+            'uncertainty from the observation, or a float between 0 and 100 '
+            'representing uncertainty as a percentage.'),
+        allow_none=True,
+        missing=None,
+    )
 
 
 @spec.define_schema('ReportParameters')

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -5,7 +5,8 @@ import pytz
 
 from sfa_api import spec, ma
 from sfa_api.utils.validators import (
-    TimeFormat, UserstringValidator, TimezoneValidator, TimeLimitValidator)
+    TimeFormat, UserstringValidator, TimezoneValidator, TimeLimitValidator,
+    UncertaintyValidator)
 from solarforecastarbiter.datamodel import (
     ALLOWED_VARIABLES, ALLOWED_CATEGORIES, ALLOWED_DETERMINISTIC_METRICS)
 
@@ -737,10 +738,11 @@ class ReportObjectPair(ma.Schema):
         description=(
             'How to determine uncertainty when calculating metrics. Set to '
             '"null" to ignore uncertainty, "observation_uncertainty" to use '
-            'uncertainty from the observation, or a float between 0 and 100 '
-            'representing uncertainty as a percentage.'),
+            'uncertainty from the observation, or a quoted float value '
+            'between 0.0 and 100.0 representing uncertainty as a percentage.'),
         allow_none=True,
         missing=None,
+        validate=UncertaintyValidator(),
     )
 
 

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -737,9 +737,10 @@ class ReportObjectPair(ma.Schema):
         title='Uncertainty',
         description=(
             'How to determine uncertainty when calculating metrics. Set to '
-            '"null" (or  omit) to ignore uncertainty, "observation_uncertainty" to use '
-            'uncertainty from the observation, or a quoted float value '
-            'between 0.0 and 100.0 representing uncertainty as a percentage.'),
+            '"null" (or  omit) to ignore uncertainty, '
+            '"observation_uncertainty" to use uncertainty from the '
+            'observation, or a quoted float value between 0.0 and 100.0 '
+            'representing uncertainty as a percentage.'),
         allow_none=True,
         missing=None,
         validate=UncertaintyValidator(),

--- a/sfa_api/tests/test_schema.py
+++ b/sfa_api/tests/test_schema.py
@@ -1,6 +1,7 @@
 import datetime as dt
 
 
+import json
 import marshmallow
 import pytest
 import uuid
@@ -48,6 +49,7 @@ def test_object_pair_deserialization(inp):
     assert (bool('observation' in deserialized) !=
             bool('aggregate' in deserialized))
     assert deserialized['reference_forecast'] is None
+    assert deserialized['uncertainty'] is None
 
 
 @pytest.mark.parametrize('inp', [
@@ -60,6 +62,39 @@ def test_object_pair_with_ref(inp):
     assert deserialized['forecast'] == uuid.UUID("11c20780-76ae-4b11-bef1-7a75bdc784e3")  # noqa
     assert deserialized['observation'] == uuid.UUID("123e4567-e89b-12d3-a456-426655440000")  # noqa
     assert deserialized['reference_forecast'] == uuid.UUID("11c20780-76ae-4b11-bef1-7a75bdc784e3")  # noqa
+
+
+base_pair_dict = {
+    "forecast": "11c20780-76ae-4b11-bef1-7a75bdc784e3",
+    "observation": "123e4567-e89b-12d3-a456-426655440000",
+    "reference_forecast": "11c20780-76ae-4b11-bef1-7a75bdc784e3"
+}
+
+
+@pytest.mark.parametrize('uncertainty,exp_type', [
+    (None, type(None)),
+    ('observation_uncertainty', str),
+    ('10.0', str),
+    ('0.0', str),
+    ('100.0', str),
+])
+def test_object_pair_with_uncertainty(uncertainty, exp_type):
+    pair_dict = base_pair_dict.copy()
+    pair_dict.update({'uncertainty': uncertainty})
+    pair_json = json.dumps(pair_dict)
+    deserialized = schema.ReportObjectPair().loads(pair_json)
+    assert isinstance(deserialized['uncertainty'], exp_type)
+
+
+@pytest.mark.parametrize('uncertainty', [
+    'bad string', 10.0, '-10.0', '101.0',
+])
+def test_object_pair_with_invalid_uncertainty(uncertainty):
+    pair_dict = base_pair_dict.copy()
+    pair_dict.update({'uncertainty': uncertainty})
+    pair_json = json.dumps(pair_dict)
+    with pytest.raises(marshmallow.exceptions.ValidationError):
+        schema.ReportObjectPair().loads(pair_json)
 
 
 @pytest.mark.parametrize('inp', [

--- a/sfa_api/tests/test_schema.py
+++ b/sfa_api/tests/test_schema.py
@@ -3,6 +3,7 @@ import datetime as dt
 
 import marshmallow
 import pytest
+import uuid
 
 
 from sfa_api import schema
@@ -46,6 +47,19 @@ def test_object_pair_deserialization(inp):
     assert 'forecast' in deserialized
     assert (bool('observation' in deserialized) !=
             bool('aggregate' in deserialized))
+    assert deserialized['reference_forecast'] is None
+
+
+@pytest.mark.parametrize('inp', [
+    ('{"forecast": "11c20780-76ae-4b11-bef1-7a75bdc784e3",'
+     '"observation": "123e4567-e89b-12d3-a456-426655440000",'
+     '"reference_forecast": "11c20780-76ae-4b11-bef1-7a75bdc784e3"}'),
+])
+def test_object_pair_with_ref(inp):
+    deserialized = schema.ReportObjectPair().loads(inp)
+    assert deserialized['forecast'] == uuid.UUID("11c20780-76ae-4b11-bef1-7a75bdc784e3")  # noqa
+    assert deserialized['observation'] == uuid.UUID("123e4567-e89b-12d3-a456-426655440000")  # noqa
+    assert deserialized['reference_forecast'] == uuid.UUID("11c20780-76ae-4b11-bef1-7a75bdc784e3")  # noqa
 
 
 @pytest.mark.parametrize('inp', [

--- a/sfa_api/utils/tests/test_validators.py
+++ b/sfa_api/utils/tests/test_validators.py
@@ -86,7 +86,7 @@ def test_uncertainty_validator(valid):
 
 
 @pytest.mark.parametrize("invalid", [
-    "None", "bad string",
+    "None", "bad string", "101", "-1.0"
 ])
 def test_uncertainty_validator_errors(invalid):
     with pytest.raises(ValidationError):

--- a/sfa_api/utils/tests/test_validators.py
+++ b/sfa_api/utils/tests/test_validators.py
@@ -75,3 +75,19 @@ def test_timelimit_validator(time_):
 def test_timelimit_validator_fail(time_):
     with pytest.raises(ValidationError):
         validators.TimeLimitValidator()(time_)
+
+
+@pytest.mark.parametrize("valid", [
+    None, "observation_uncertainty", "0.0",
+    ] + list(range(0, 101, 10))
+)
+def test_uncertainty_validator(valid):
+    assert validators.UncertaintyValidator()(valid) == valid
+
+
+@pytest.mark.parametrize("invalid", [
+    "None", "bad string",
+])
+def test_uncertainty_validator_errors(invalid):
+    with pytest.raises(ValidationError):
+        validators.UncertaintyValidator()(invalid)

--- a/sfa_api/utils/validators.py
+++ b/sfa_api/utils/validators.py
@@ -71,3 +71,28 @@ class TimeLimitValidator(Validator):
             raise ValidationError(
                 f'Less than minimum allowed timestamp of {MIN_SQL_TIME}')
         return value
+
+
+class UncertaintyValidator(Validator):
+    """Ensures value is None, 'observation_uncertainty' or a quoted float.
+    """
+    def __call__(self, value):
+        if value is not None:
+            if value != "observation_uncertainty":
+                try:
+                    float_value = float(value)
+                except ValueError:
+                    raise ValidationError(
+                        "Invalid uncertainty value. Must be one of: null, "
+                        "'observation_uncertainty' or a quoted float value "
+                        "from 0.0 to 100.0.")
+                else:
+                    if float_value > 100:
+                        raise ValidationError(
+                            "Unvertainty percentage must be less than or "
+                            "equal to 100.0.")
+                    if float_value < 0:
+                        raise ValidationError(
+                            "Unvertainty percentage must be greater than or "
+                            "equal to 0.0.")
+        return value


### PR DESCRIPTION
Adds reference_forecast and uncertainty to the report object pair schema to support forecast skill and deadband uncertainty. 