### PR TITLE
validate matching interval_label and variable for events

### DIFF
--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -503,7 +503,7 @@ class ForecastPostSchema(ma.Schema):
     extra_parameters = EXTRA_PARAMETERS_FIELD
 
     @validates_schema
-    def validate_id(self, data, **kwargs):
+    def validate_forecast(self, data, **kwargs):
         if (
                 data.get('site_id') is not None and
                 data.get('aggregate_id') is not None

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -6,7 +6,7 @@ import pytz
 from sfa_api import spec, ma
 from sfa_api.utils.validators import (
     TimeFormat, UserstringValidator, TimezoneValidator, TimeLimitValidator,
-    UncertaintyValidator)
+    UncertaintyValidator, validate_if_event)
 from solarforecastarbiter.datamodel import (
     ALLOWED_VARIABLES, ALLOWED_CATEGORIES, ALLOWED_DETERMINISTIC_METRICS,
     ALLOWED_EVENT_METRICS)
@@ -334,6 +334,10 @@ class ObservationPostSchema(ma.Schema):
         required=True)
     extra_parameters = EXTRA_PARAMETERS_FIELD
 
+    @validates_schema
+    def validate_observation(self, data, **kwargs):
+        validate_if_event(self, data, **kwargs)
+
 
 @spec.define_schema('ObservationMetadata')
 class ObservationSchema(ObservationPostSchema):
@@ -513,6 +517,7 @@ class ForecastPostSchema(ma.Schema):
         ):
             raise ValidationError(
                 "One of site_id or aggregate_id must be provided")
+        validate_if_event(self, data, **kwargs)
 
 
 @spec.define_schema('ForecastMetadata')

--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -418,3 +418,21 @@ def test_get_forecast_timerange_404_obsid(api, observation_id):
     r = api.get(f'/forecasts/single/{observation_id}/values/timerange',
                 base_url=BASE_URL)
     assert r.status_code == 404
+
+
+EVENT_LABEL = copy_update(VALID_FORECAST_JSON, 'interval_label', 'event')
+EVENT_VARIABLE = copy_update(VALID_FORECAST_JSON, 'variable', 'event')
+
+
+@pytest.mark.parametrize('payload,message', [
+    (EVENT_VARIABLE, (f'{{"events":["Both interval_label and variable must be '
+                      'set to \'event\'."]}')),
+    (EVENT_LABEL, (f'{{"events":["Both interval_label and variable must be '
+                   'set to \'event\'."]}')),
+])
+def test_observation_post_bad_event(api, payload, message):
+    r = api.post('/forecasts/single/',
+                 base_url=BASE_URL,
+                 json=payload)
+    assert r.status_code == 400
+    assert r.get_data(as_text=True) == f'{{"errors":{message}}}\n'

--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -430,7 +430,7 @@ EVENT_VARIABLE = copy_update(VALID_FORECAST_JSON, 'variable', 'event')
     (EVENT_LABEL, (f'{{"events":["Both interval_label and variable must be '
                    'set to \'event\'."]}')),
 ])
-def test_observation_post_bad_event(api, payload, message):
+def test_forecast_post_bad_event(api, payload, message):
     r = api.post('/forecasts/single/',
                  base_url=BASE_URL,
                  json=payload)

--- a/sfa_api/tests/test_observations.py
+++ b/sfa_api/tests/test_observations.py
@@ -440,3 +440,21 @@ def test_get_observation_timerange_new(api, new_observation):
     data = r.get_json()
     assert data['min_timestamp'] is None
     assert data['max_timestamp'] is None
+
+
+EVENT_LABEL = copy_update(VALID_OBS_JSON, 'interval_label', 'event')
+EVENT_VARIABLE = copy_update(VALID_OBS_JSON, 'variable', 'event')
+
+
+@pytest.mark.parametrize('payload,message', [
+    (EVENT_VARIABLE, (f'{{"events":["Both interval_label and variable must be '
+                      'set to \'event\'."]}')),
+    (EVENT_LABEL, (f'{{"events":["Both interval_label and variable must be '
+                   'set to \'event\'."]}')),
+])
+def test_observation_post_bad_event(api, payload, message):
+    r = api.post('/observations/',
+                 base_url=BASE_URL,
+                 json=payload)
+    assert r.status_code == 400
+    assert r.get_data(as_text=True) == f'{{"errors":{message}}}\n'

--- a/sfa_api/utils/tests/test_validators.py
+++ b/sfa_api/utils/tests/test_validators.py
@@ -91,3 +91,20 @@ def test_uncertainty_validator(valid):
 def test_uncertainty_validator_errors(invalid):
     with pytest.raises(ValidationError):
         validators.UncertaintyValidator()(invalid)
+
+
+@pytest.mark.parametrize("data", [
+    {'variable': 'event', 'interval_label': 'event'},
+    {'variable': 'notevent', 'interval_label': 'notevent'},
+])
+def test_validate_if_event(data):
+    validators.validate_if_event({}, data)
+
+
+@pytest.mark.parametrize("data", [
+    {'variable': 'event', 'interval_label': 'notevent'},
+    {'variable': 'notevent', 'interval_label': 'event'},
+])
+def test_validate_if_event_error(data):
+    with pytest.raises(ValidationError):
+        validators.validate_if_event({}, data)

--- a/sfa_api/utils/validators.py
+++ b/sfa_api/utils/validators.py
@@ -96,3 +96,33 @@ class UncertaintyValidator(Validator):
                             "Unvertainty percentage must be greater than or "
                             "equal to 0.0.")
         return value
+
+
+def validate_if_event(schema, data, **kwargs):
+    """Checks for an event variable or interval label and ensures they are
+    the same.
+
+    This function is in the form of a marshmallow schema-level validator, which
+    is typically implemented as a decorated method but is instead placed here
+    to allow reuse.
+
+    Parameters
+    ----------
+    schema: marshmallow.Schema
+        The schema to validate.
+    data: dict
+        The data being used to instantiate the schema class.
+
+    Raises
+    ------
+    marshmallow.ValidationError
+        If either `variable` or `interval_label` are set to 'event' and the
+        other does not match.
+    """
+    variable = data.get('variable')
+    interval_label = data.get('interval_label')
+    if(variable == 'event' or interval_label == 'event'):
+        if (variable != interval_label):
+            raise ValidationError({
+                'events': ["Both interval_label and variable must be set to "
+                           "'event'."]})


### PR DESCRIPTION
closes #232 
Adds a validation function for calling in a `@validates_schema` method to check for the value 'event' in variable or interval label. Throws a validation error if one is found and the values aren't equal.