### PR TITLE
Adjust job timeouts

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 from prometheus_flask_exporter.multiprocess import GunicornPrometheusMetrics
 from gunicorn.glogging import Logger
@@ -14,6 +15,9 @@ keyfile = '/certs/tls.key' if Path('/certs/tls.key').exists() else None
 # date X-Forwarded-For status "status line" response_length "referer" "user agent" request_time (s)  # NOQA
 access_log_format = '%(t)s %({X-Forwarded-For}i)s %(s)s "%(r)s" %(b)s "%(f)s" "%(a)s"  %(L)s'  # NOQA
 accesslog = '-'
+# has the most effect for large observation uploads
+# that can take time to load/validate
+timeout = os.getenv('TIMEOUT', 30)
 
 
 def when_ready(server):

--- a/sfa_api/cli.py
+++ b/sfa_api/cli.py
@@ -17,6 +17,14 @@ def cli():
 
 verbose_opt = click.option('-v', '--verbose', count=True,
                            help='Increase logging verbosity')
+worker_ttl = click.option(
+    '--worker-ttl', default=420,
+    help='The timeout for the worker monitoring process'
+)
+job_monitoring_interval = click.option(
+    '--job-monitoring-interval', default=30,
+    help='The timeout for an individual job running in a work-horse process'
+)
 
 
 def _get_log_level(config, verbose, key='LOG_LEVEL'):  # pragma: no cover
@@ -46,8 +54,10 @@ def _setup_logging(level):
 @verbose_opt
 @click.option('-q', '--queues', multiple=True, help='RQ queues',
               default=['default'])
+@worker_ttl
+@job_monitoring_interval
 @click.argument('config_file')
-def worker(verbose, queues, config_file):
+def worker(verbose, queues, worker_ttl, job_monitoring_interval, config_file):
     """
     Run an RQ worker, with config loaded from CONFIG_FILE,
     to process commands on the QUEUES.
@@ -71,9 +81,12 @@ def worker(verbose, queues, config_file):
 
     # will likely want to add prometheus in here somewhere,
     # perhaps as custom worker class
+    # if possible, get len report obj, time range
     red = make_redis_connection(config)
     with Connection(red):
-        w = Worker(queues)
+        w = Worker(queues,
+                   default_worker_ttl=worker_ttl,
+                   job_monitoring_interval=job_monitoring_interval)
         w.work(logging_level=worker_loglevel)
 
 
@@ -92,12 +105,8 @@ def devserver(port, config_name):
 @cli.command()
 @verbose_opt
 @click.argument('config_file')
-@click.option('--worker-ttl', default=420,
-              help='The timeout for the worker monitoring process')
-@click.option(
-    '--job-monitoring-interval', default=30,
-    help='The timeout for an individual job running in a work-horse process'
-)
+@worker_ttl
+@job_monitoring_interval
 def scheduled_worker(
         verbose, config_file, worker_ttl, job_monitoring_interval):
     """

--- a/sfa_api/cli.py
+++ b/sfa_api/cli.py
@@ -22,7 +22,7 @@ worker_ttl = click.option(
     help='The timeout for the worker monitoring process'
 )
 job_monitoring_interval = click.option(
-    '--job-monitoring-interval', default=30,
+    '--job-monitoring-interval', default=180,
     help='The timeout for an individual job running in a work-horse process'
 )
 

--- a/sfa_api/config.py
+++ b/sfa_api/config.py
@@ -25,6 +25,9 @@ class Config(object):
     SFA_API_STATIC_DATA = os.getenv('SFA_API_STATIC_DATA', False)
     # limit requests to 16MB
     MAX_CONTENT_LENGTH = os.getenv('MAX_CONTENT_LENGTH', 16 * 1024 * 1024)
+    JOB_BASE_URL = os.getenv('JOB_BASE_URL', None)
+    REPORT_JOB_TIMEOUT = int(os.getenv('REPORT_JOB_TIMEOUT', 600))
+    VALIDATION_JOB_TIMEOUT = int(os.getenv('VALIDATION_JOB_TIMEOUT', 150))
 
 
 class ProductionConfig(Config):

--- a/sfa_api/config.py
+++ b/sfa_api/config.py
@@ -24,7 +24,7 @@ class Config(object):
     MYSQL_DATABASE = os.getenv('MYSQL_DATABASE', None)
     SFA_API_STATIC_DATA = os.getenv('SFA_API_STATIC_DATA', False)
     # limit requests to 16MB
-    MAX_CONTENT_LENGTH = os.getenv('MAX_CONTENT_LENGTH', 16 * 1024 * 1024)
+    MAX_CONTENT_LENGTH = int(os.getenv('MAX_CONTENT_LENGTH', 16 * 1024 * 1024))
     JOB_BASE_URL = os.getenv('JOB_BASE_URL', None)
     REPORT_JOB_TIMEOUT = int(os.getenv('REPORT_JOB_TIMEOUT', 600))
     VALIDATION_JOB_TIMEOUT = int(os.getenv('VALIDATION_JOB_TIMEOUT', 150))

--- a/sfa_api/config.py
+++ b/sfa_api/config.py
@@ -23,6 +23,8 @@ class Config(object):
     MYSQL_PASSWORD = os.getenv('MYSQL_PASSWORD', None)
     MYSQL_DATABASE = os.getenv('MYSQL_DATABASE', None)
     SFA_API_STATIC_DATA = os.getenv('SFA_API_STATIC_DATA', False)
+    # limit requests to 16MB
+    MAX_CONTENT_LENGTH = os.getenv('MAX_CONTENT_LENGTH', 16 * 1024 * 1024)
 
 
 class ProductionConfig(Config):

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -481,8 +481,9 @@ def jobid():
 
 @pytest.fixture()
 def mocked_queuing(mocker):
-    mocked = mocker.patch('rq.Queue.enqueue')
-    yield
+    mocked = mocker.patch('rq.Queue.enqueue',
+                          autospec=True)
+    yield mocked
     assert mocked.called
 
 

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -1,4 +1,5 @@
-from flask import Blueprint, request, jsonify, make_response, url_for
+from flask import (Blueprint, request, jsonify, make_response, url_for,
+                   current_app)
 from flask.views import MethodView
 from marshmallow import ValidationError
 from solarforecastarbiter.io.utils import HiddenToken
@@ -274,7 +275,11 @@ class ObservationValuesView(MethodView):
                 observation_id,
                 observation_df.index[0].isoformat(),
                 observation_df.index[-1].isoformat(),
-                base_url=request.url_root.rstrip('/'))
+                base_url=(current_app.config['JOB_BASE_URL']
+                          or request.url_root.rstrip('/')),
+                result_ttl=0,
+                job_timeout=current_app.config['VALIDATION_JOB_TIMEOUT']
+            )
         return stored, 201
 
 

--- a/sfa_api/reports.py
+++ b/sfa_api/reports.py
@@ -20,7 +20,7 @@ REPORT_STATUS_OPTIONS = ['pending', 'failed', 'complete']
 
 
 def enqueue_report(report_id, base_url):
-    alt_base_url = current_app.config['JOB_BASE_URL']
+    alt_base_url = current_app.config.get('JOB_BASE_URL')
     if alt_base_url is not None:
         base_url = alt_base_url
     q = get_queue('reports')

--- a/sfa_api/reports.py
+++ b/sfa_api/reports.py
@@ -1,4 +1,5 @@
-from flask import Blueprint, request, jsonify, make_response, url_for
+from flask import (
+    Blueprint, request, jsonify, make_response, url_for, current_app)
 from flask.views import MethodView
 from marshmallow import ValidationError
 from solarforecastarbiter.io.utils import HiddenToken
@@ -16,6 +17,21 @@ from sfa_api.schema import (ReportPostSchema, ReportValuesPostSchema,
 
 
 REPORT_STATUS_OPTIONS = ['pending', 'failed', 'complete']
+
+
+def enqueue_report(report_id, base_url):
+    alt_base_url = current_app.config['JOB_BASE_URL']
+    if alt_base_url is not None:
+        base_url = alt_base_url
+    q = get_queue('reports')
+    q.enqueue(
+        compute_report,
+        HiddenToken(current_access_token),
+        report_id,
+        base_url=base_url,
+        result_ttl=0,
+        job_timeout=current_app.config['REPORT_JOB_TIMEOUT']
+    )
 
 
 class AllReportsView(MethodView):
@@ -85,12 +101,7 @@ class AllReportsView(MethodView):
         response = make_response(report_id, 201)
         response.headers['Location'] = url_for('reports.single',
                                                report_id=report_id)
-        q = get_queue('reports')
-        q.enqueue(
-            compute_report,
-            HiddenToken(current_access_token),
-            report_id,
-            base_url=request.url_root.rstrip('/'))
+        enqueue_report(report_id, request.url_root.rstrip('/'))
         return response
 
 
@@ -127,12 +138,7 @@ class RecomputeReportView(MethodView):
         report_perms = storage.get_user_actions_on_object(report_id)
         if 'update' not in report_perms:
             raise StorageAuthError()
-        q = get_queue('reports')
-        q.enqueue(
-            compute_report,
-            HiddenToken(current_access_token),
-            report_id,
-            base_url=request.url_root.rstrip('/'))
+        enqueue_report(report_id, request.url_root.rstrip('/'))
         response = make_response(report_id, 200)
         response.headers['Location'] = url_for('reports.single',
                                                report_id=report_id)

--- a/sfa_api/spec.py
+++ b/sfa_api/spec.py
@@ -311,7 +311,7 @@ spec = APISpec(
         {'url': '//testing-api.solarforecastarbiter.org/',
          'description': 'Testing server'},
         {'url': '//api.solarforecastarbiter.org/',
-         'description': 'Prodution server'}
+         'description': 'Production server'}
     ]
 )
 

--- a/sfa_api/tests/test_reports.py
+++ b/sfa_api/tests/test_reports.py
@@ -1,12 +1,14 @@
-import hashlib
-import pytest
-
-
 from copy import deepcopy
-from sfa_api.conftest import BASE_URL
-from sfa_api.schema import ALLOWED_METRICS
+import hashlib
+
+
+import pytest
 from solarforecastarbiter.datamodel import (
     ALLOWED_CATEGORIES)
+
+
+from sfa_api.conftest import BASE_URL
+from sfa_api.schema import ALLOWED_METRICS
 
 
 @pytest.fixture()
@@ -239,3 +241,14 @@ def test_recompute_report_no_update(api, new_report, remove_all_perms):
     remove_all_perms('update', 'reports')
     res = api.get(f'/reports/{report_id}/recompute', base_url=BASE_URL)
     assert res.status_code == 404
+
+
+def test_post_report_alt_url(api, report_post_json, mocked_queuing,
+                             mocker, app):
+    mocker.patch.dict(app.config, {'JOB_BASE_URL': 'http://0.0.0.1'})
+    res = api.post('/reports/',
+                   base_url=BASE_URL,
+                   json=report_post_json)
+    assert res.status_code == 201
+    assert 'Location' in res.headers
+    assert mocked_queuing.call_args[1]['base_url'] == 'http://0.0.0.1'


### PR DESCRIPTION
Add the ability to adjust timeouts for the api worker, report jobs, and data validation jobs.  Also sets max content length and does not log requests by the kube probe that checks if the container is ready. 

This also adds the JOB_BASE_URL config variable that can direct jobs to use another api vs the one where the job was enqueued. The idea is that the worker pod could have an API running as a sidecar container, and that API instance can be used instead of the main instances. Then we can adjust the timeouts for that sidecar API to be long and allow for job completion even with large posts/gets. 

I also though about not using the APISession at all in the jobs like compute_report. But, the API provides a well defined interface, even if it does introduce more overhead vs direct database access, and the api and core code remain a bit more separated.