### PR TITLE
Enforce maximum post data points

### DIFF
--- a/sfa_api/config.py
+++ b/sfa_api/config.py
@@ -28,6 +28,8 @@ class Config(object):
     JOB_BASE_URL = os.getenv('JOB_BASE_URL', None)
     REPORT_JOB_TIMEOUT = int(os.getenv('REPORT_JOB_TIMEOUT', 600))
     VALIDATION_JOB_TIMEOUT = int(os.getenv('VALIDATION_JOB_TIMEOUT', 150))
+    MAXIMUM_POST_DATAPOINTS = int(os.getenv('MAXIMUM_POST_DATAPOINTS',
+                                            2000000))
 
 
 class ProductionConfig(Config):

--- a/sfa_api/config.py
+++ b/sfa_api/config.py
@@ -28,8 +28,8 @@ class Config(object):
     JOB_BASE_URL = os.getenv('JOB_BASE_URL', None)
     REPORT_JOB_TIMEOUT = int(os.getenv('REPORT_JOB_TIMEOUT', 600))
     VALIDATION_JOB_TIMEOUT = int(os.getenv('VALIDATION_JOB_TIMEOUT', 150))
-    MAXIMUM_POST_DATAPOINTS = int(os.getenv('MAXIMUM_POST_DATAPOINTS',
-                                            2000000))
+    MAX_POST_DATAPOINTS = int(os.getenv('MAX_POST_DATAPOINTS',
+                                        200000))
 
 
 class ProductionConfig(Config):

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 import datetime as dt
 from functools import partial
 from io import StringIO
+import json
 
 
 from flask import _request_ctx_stack
@@ -2026,4 +2027,26 @@ def remove_all_perms(api, current_roles):
             for perm_id in to_remove:
                 api.delete(f'/roles/{role_id}/permissions/{perm_id}',
                            BASE_URL)
+    return fn
+
+
+@pytest.fixture
+def random_post_payload():
+    def fn(npts, mimetype, include_flags=True):
+        idx = pd.date_range(
+            start=pd.to_datetime('2017-01-01T00:00Z'),
+            periods=npts,
+            freq='1min'
+        )
+        data = {'value': np.random.uniform(0, 999.9, size=idx.size)}
+        if include_flags:
+            data['quality_flags'] = 0
+        df = pd.DataFrame(data=data, index=idx)
+        if mimetype == 'application/json':
+            value_string = json.dumps({
+                'values': df.to_dict(orient='records')
+            })
+        else:
+            value_string = df.to_csv(index=False)
+        return value_string
     return fn

--- a/sfa_api/utils/request_handling.py
+++ b/sfa_api/utils/request_handling.py
@@ -229,6 +229,12 @@ def validate_parsable_values():
         decoded_data = request.get_data(as_text=True)
         mimetype = request.mimetype
     value_df = parse_values(decoded_data, mimetype)
+    if value_df.index.size > current_app.config.MAXIMUM_POST_DATAPOINTS:
+        raise BadAPIRequest({
+            'error': ('File exceeds maximum number of datapoints. '
+                      f'{current_app.config.MAXIMUM_POST_DATAPOINTS} '
+                      f'datapoints allowed, {value_df.index.size} datapoints '
+                      'found in file.')
     return value_df
 
 

--- a/sfa_api/utils/request_handling.py
+++ b/sfa_api/utils/request_handling.py
@@ -175,7 +175,7 @@ def parse_values(decoded_data, mimetype):
     if values.index.size > current_app.config.get('MAX_POST_DATAPOINTS'):
         raise BadAPIRequest({
             'error': ('File exceeds maximum number of datapoints. '
-                      f'{current_app.config.get("MAXIMUM_POST_DATAPOINTS")} '
+                      f'{current_app.config.get("MAX_POST_DATAPOINTS")} '
                       f'datapoints allowed, {values.index.size} datapoints '
                       'found in file.')
         })

--- a/sfa_api/utils/request_handling.py
+++ b/sfa_api/utils/request_handling.py
@@ -162,7 +162,7 @@ def parse_values(decoded_data, mimetype):
         - If the MIME type is not one of 'text/csv', 'application/json',
           or 'application/vnd.ms-excel'
         - If parsing fails, see parse_json or parse_csv for conditions.
-        - If the filed contains more than the maximum allowed number of
+        - If the file contains more than the maximum allowed number of
           datapoints.
     """
     if mimetype == 'text/csv' or mimetype == 'application/vnd.ms-excel':


### PR DESCRIPTION
Checks for maximum number of data points when parsing posted timeseries data and returns an error message with the limit and provided number of points when the limit is exceeded.