### PR TITLE
Limit data requests

### DIFF
--- a/datastore/migrations/0051_reference_jobs.up.sql
+++ b/datastore/migrations/0051_reference_jobs.up.sql
@@ -15,27 +15,27 @@ INSERT INTO sites (id, organization_id, name, latitude, longitude,
     backtrack, max_rotation_angle, dc_loss_factor, ac_loss_factor )
 VALUES (
     @abqsite, @reforgid, 'DOE RTC Albuquerque NM' , 35.050000 ,
-    -106.530000 , 1657.00 , 'America/Denver' , '{"network": "DOE RTC",
+    -106.530000 , 1657.00 , 'Etc/GMT+7' , '{"network": "DOE RTC",
     "network_api_id": "Albuquerque", "network_api_abbreviation": "",
     "observation_interval_length": 1, "attribution": "", "module":
     "Suniva 270W"}' , 0.003240 , 0.003240 , -0.420 , 'fixed' , 35.00 ,
     180.00 , NULL , NULL , NULL , NULL , NULL , 0.00 , 0.00
 ),(
     @nvsite, @reforgid, 'DOE RTC Henderson NV' , 36.040000 , -114.920000 , 538.00 ,
-    'America/Los_Angeles' , '{"network": "DOE RTC", "network_api_id":
+    'Etc/GMT+8' , '{"network": "DOE RTC", "network_api_id":
     "Henderson", "network_api_abbreviation": "",
     "observation_interval_length": 1, "attribution": "", "module":
     "Suniva 270W"}' , 0.003240 , 0.003240 , -0.420 , 'fixed' , 35.00 ,
     180.00 , NULL , NULL , NULL , NULL , NULL , 0.00 , 0.00
 ),(
     @vtsite, @reforgid, 'DOE RTC Williston VT' , 44.500000 , -73.100000 , 184.00 ,
-    'America/New_York' , '{"network": "DOE RTC", "network_api_id":
+    'Etc/GMT+5' , '{"network": "DOE RTC", "network_api_id":
     "Williston", "network_api_abbreviation": "",
     "observation_interval_length": 1, "attribution": "", "module":
     "Suniva 270W"}' , 0.003240 , 0.003240 , -0.420 , 'fixed' , 35.00 ,
     180.00 , NULL , NULL , NULL , NULL , NULL , 0.00 , 0.00
 ),(
-    @flsite, @reforgid, 'DOE RTC Cocoa FL' , 28.400000 , -80.770000 , 11.00 , 'America/New_York' ,
+    @flsite, @reforgid, 'DOE RTC Cocoa FL' , 28.400000 , -80.770000 , 11.00 , 'Etc/GMT+5' ,
     '{"network": "DOE RTC", "network_api_id": "Cocoa",
     "network_api_abbreviation": "", "observation_interval_length": 1,
     "attribution": "", "module": "Suniva 270W"}' , 0.003240 , 0.003240

--- a/sfa_api/aggregates.py
+++ b/sfa_api/aggregates.py
@@ -190,11 +190,9 @@ class AggregateValuesView(MethodView):
         accepts = request.accept_mimetypes.best_match(['application/json',
                                                        'text/csv'])
         if accepts == 'application/json':
-            values['timestamp'] = values.index
-            dict_values = values.to_dict(orient='records')
+            values.index.name = 'timestamp'
             data = AggregateValuesSchema().dump(
-                {"aggregate_id": aggregate_id, "values": dict_values})
-
+                {"aggregate_id": aggregate_id, "values": values})
             return jsonify(data)
         else:
             meta_url = url_for('aggregates.metadata',

--- a/sfa_api/config.py
+++ b/sfa_api/config.py
@@ -1,6 +1,7 @@
 import os
 
 
+import pandas as pd
 import requests
 
 
@@ -30,6 +31,8 @@ class Config(object):
     VALIDATION_JOB_TIMEOUT = int(os.getenv('VALIDATION_JOB_TIMEOUT', 150))
     MAX_POST_DATAPOINTS = int(os.getenv('MAX_POST_DATAPOINTS',
                                         200000))
+    MAX_DATA_RANGE_DAYS = pd.Timedelta(os.getenv('MAX_DATA_RANGE_DAYS', '366')
+                                       + ' days')
 
 
 class ProductionConfig(Config):

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -2050,3 +2050,8 @@ def random_post_payload():
             value_string = df.to_csv(index=False)
         return value_string
     return fn
+
+
+@pytest.fixture()
+def startend():
+    return '?start=20190101T0000Z&end=20200101T0000Z'

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -110,13 +110,13 @@ VALID_OBS_VALUE_JSON = {
     'id': '123e4567-e89b-12d3-a456-426655440000',
     'values': [
         {'quality_flag': 0,
-         'timestamp': "2019-01-22T17:54:00+00:00",
+         'timestamp': "2019-01-22T17:54:00Z",
          'value': 1.0},
         {'quality_flag': 0,
-         'timestamp': "2019-01-22T17:59:00+00:00",
+         'timestamp': "2019-01-22T17:59:00Z",
          'value': 32.0},
         {'quality_flag': 0,
-         'timestamp': "2019-01-22T18:04:00+00:00",
+         'timestamp': "2019-01-22T18:04:00Z",
          'value': 3.0}
     ]
 }

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -131,22 +131,22 @@ VALID_OBS_VALUE_CSV = (
 VALID_FX_VALUE_JSON = {
     'id': '123e4567-e89b-12d3-a456-426655440000',
     'values': [
-        {'timestamp': "2019-01-22T17:54:00+00:00",
+        {'timestamp': "2019-01-22T17:54:00Z",
          'value': 1.0},
-        {'timestamp': "2019-01-22T17:59:00+00:00",
+        {'timestamp': "2019-01-22T17:59:00Z",
          'value': 32.0},
-        {'timestamp': "2019-01-22T18:04:00+00:00",
+        {'timestamp': "2019-01-22T18:04:00Z",
          'value': 3.0}
     ]
 }
 ADJ_FX_VALUE_JSON = {
     'id': '123e4567-e89b-12d3-a456-426655440000',
     'values': [
-        {'timestamp': "2019-11-01T07:00:00+00:00",
+        {'timestamp': "2019-11-01T07:00:00Z",
          'value': 1.0},
-        {'timestamp': "2019-11-01T07:05:00+00:00",
+        {'timestamp': "2019-11-01T07:05:00Z",
          'value': 32.0},
-        {'timestamp': "2019-11-01T07:10:00+00:00",
+        {'timestamp': "2019-11-01T07:10:00Z",
          'value': 3.0}
     ]
 }
@@ -154,11 +154,11 @@ ADJ_FX_VALUE_JSON = {
 UNSORTED_FX_VALUE_JSON = {
     'id': '123e4567-e89b-12d3-a456-426655440000',
     'values': [
-        {'timestamp': "2019-01-22T17:59:00+00:00",
+        {'timestamp': "2019-01-22T17:59:00Z",
          'value': 32.0},
-        {'timestamp': "2019-01-22T17:54:00+00:00",
+        {'timestamp': "2019-01-22T17:54:00Z",
          'value': 1.0},
-        {'timestamp': "2019-01-22T18:04:00+00:00",
+        {'timestamp': "2019-01-22T18:04:00Z",
          'value': 3.0}
     ]
 }

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -187,9 +187,8 @@ class ForecastValuesView(MethodView):
         accepts = request.accept_mimetypes.best_match(['application/json',
                                                        'text/csv'])
         if accepts == 'application/json':
-            dict_values = values.reset_index().to_dict(orient='records')
             data = ForecastValuesSchema().dump({"forecast_id": forecast_id,
-                                                "values": dict_values})
+                                                "values": values})
             return jsonify(data)
         else:
             meta_url = url_for('forecasts.metadata',
@@ -289,10 +288,8 @@ class ForecastLatestView(MethodView):
         """
         storage = get_storage()
         values = storage.read_latest_forecast_value(forecast_id)
-        values['timestamp'] = values.index
-        dict_values = values.to_dict(orient='records')
         data = ForecastValuesSchema().dump(
-            {"forecast_id": forecast_id, "values": dict_values})
+            {"forecast_id": forecast_id, "values": values})
         return jsonify(data)
 
 
@@ -546,10 +543,8 @@ class CDFForecastValues(MethodView):
         accepts = request.accept_mimetypes.best_match(['application/json',
                                                        'text/csv'])
         if accepts == 'application/json':
-            values['timestamp'] = values.index
-            dict_values = values.to_dict(orient='records')
             data = CDFForecastValuesSchema().dump({"forecast_id": forecast_id,
-                                                   "values": dict_values})
+                                                   "values": values})
             return jsonify(data)
         else:
             meta_url = url_for('forecasts.single_cdf_metadata',
@@ -647,10 +642,8 @@ class CDFForecastLatestView(MethodView):
         """
         storage = get_storage()
         values = storage.read_latest_cdf_forecast_value(forecast_id)
-        values['timestamp'] = values.index
-        dict_values = values.to_dict(orient='records')
         data = CDFForecastValuesSchema().dump(
-            {"forecast_id": forecast_id, "values": dict_values})
+            {"forecast_id": forecast_id, "values": values})
         return jsonify(data)
 
 

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -184,11 +184,8 @@ class ObservationValuesView(MethodView):
         accepts = request.accept_mimetypes.best_match(['application/json',
                                                        'text/csv'])
         if accepts == 'application/json':
-            values['timestamp'] = values.index
-            dict_values = values.to_dict(orient='records')
             data = ObservationValuesSchema().dump(
-                {"observation_id": observation_id, "values": dict_values})
-
+                {"observation_id": observation_id, "values": values})
             return jsonify(data)
         else:
             meta_url = url_for('observations.metadata',
@@ -254,7 +251,6 @@ class ObservationValuesView(MethodView):
             # but the validation task will post the quality flag
             # up a 2 byte unsigned int
             qf_range = [0, 2**16 - 1]
-
         observation_df = validate_observation_values(
             validate_parsable_values(), qf_range)
         observation_df = observation_df.set_index('timestamp')
@@ -308,10 +304,8 @@ class ObservationLatestView(MethodView):
         """
         storage = get_storage()
         values = storage.read_latest_observation_value(observation_id)
-        values['timestamp'] = values.index
-        dict_values = values.to_dict(orient='records')
         data = ObservationValuesSchema().dump(
-            {"observation_id": observation_id, "values": dict_values})
+            {"observation_id": observation_id, "values": values})
         return jsonify(data)
 
 

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -424,7 +424,7 @@ class ForecastValueSchema(ma.Schema):
 
 @spec.define_schema('ForecastValuesPost')
 class ForecastValuesPostSchema(ma.Schema):
-    values = ma.Nested(ForecastValueSchema, many=True)
+    values = TimeseriesField(ForecastValueSchema, many=True)
 
 
 @spec.define_schema('CDFForecastValues')

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -53,6 +53,9 @@ class TimeseriesField(ma.Nested):
                 else:
                     value = value.tz_convert('UTC')
             value = value.reset_index()
+        # annoying to dump to json, then load, then dump again
+        # via flask, but substantially (~1.5x - 2x) faster then dumping
+        # directly via flask/jsonify
         out_json = value.reindex(columns=cols).to_json(
             orient='records', date_format='iso', date_unit='s',
             double_precision=8

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -36,8 +36,8 @@ class ISODateTime(ma.AwareDateTime):
 
 class TimeseriesField(ma.Nested):
     """Support serialization of schemas that include a DataFrame along
-    with other parameters. Does not support deserialization; see
-    sfa_api.utils.request_handling for functions that do.
+    with other parameters. Does not support deserialization or validation;
+    see sfa_api.utils.request_handling for functions that do.
     """
     def _serialize(self, value, attr, obj, **kwargs):
         # errors are not handled. This should always be

--- a/sfa_api/spec.py
+++ b/sfa_api/spec.py
@@ -66,6 +66,7 @@ spec_components = {
         'start_time': {
             'in': 'query',
             'name': 'start',
+            'required': True,
             'description': 'Start of the period for which to request data.',
             'schema': {
                 'type': 'string',
@@ -75,6 +76,7 @@ spec_components = {
         'end_time': {
             'name': 'end',
             'in': 'query',
+            'required': True,
             'description': 'End of the period for which to request data.',
             'schema': {
                 'type': 'string',

--- a/sfa_api/tests/test_aggregates.py
+++ b/sfa_api/tests/test_aggregates.py
@@ -329,7 +329,8 @@ def test_get_aggregate_values_422(api, aggregate_id, startend):
         as_text=True)
 
 
-def test_get_aggregate_values_obs_deleted(api, aggregate_id, missing_id, startend):
+def test_get_aggregate_values_obs_deleted(api, aggregate_id, missing_id,
+                                          startend):
     res = api.delete('/observations/123e4567-e89b-12d3-a456-426655440000',
                      base_url=BASE_URL)
     assert res.status_code == 204

--- a/sfa_api/tests/test_aggregates.py
+++ b/sfa_api/tests/test_aggregates.py
@@ -282,8 +282,8 @@ def test_update_aggregate_bad_req(api, aggregate_id, payload, intext):
     assert intext in res.get_data(as_text=True)
 
 
-def test_get_aggregate_values(api, aggregate_id):
-    res = api.get(f'/aggregates/{aggregate_id}/values',
+def test_get_aggregate_values(api, aggregate_id, startend):
+    res = api.get(f'/aggregates/{aggregate_id}/values{startend}',
                   headers={'Accept': 'application/json'},
                   base_url=BASE_URL)
     assert res.status_code == 200
@@ -294,8 +294,8 @@ def test_get_aggregate_values(api, aggregate_id):
     assert 'quality_flag' in res.json['values'][0]
 
 
-def test_get_aggregate_values_csv(api, aggregate_id):
-    res = api.get(f'/aggregates/{aggregate_id}/values',
+def test_get_aggregate_values_csv(api, aggregate_id, startend):
+    res = api.get(f'/aggregates/{aggregate_id}/values{startend}',
                   headers={'Accept': 'text/csv'},
                   base_url=BASE_URL)
     assert res.status_code == 200
@@ -313,7 +313,7 @@ def test_get_aggregate_values_outside_range(api, aggregate_id):
     assert res.status_code == 422
 
 
-def test_get_aggregate_values_422(api, aggregate_id):
+def test_get_aggregate_values_422(api, aggregate_id, startend):
     payload = {'observations': [{
         'observation_id': '123e4567-e89b-12d3-a456-426655440000',
         'effective_until': '2019-01-01 01:23:00Z'}]}
@@ -321,7 +321,7 @@ def test_get_aggregate_values_422(api, aggregate_id):
                    json=payload,
                    base_url=BASE_URL)
     assert res.status_code == 200
-    res = api.get(f'/aggregates/{aggregate_id}/values',
+    res = api.get(f'/aggregates/{aggregate_id}/values{startend}',
                   headers={'Accept': 'application/json'},
                   base_url=BASE_URL)
     assert res.status_code == 422
@@ -329,17 +329,17 @@ def test_get_aggregate_values_422(api, aggregate_id):
         as_text=True)
 
 
-def test_get_aggregate_values_obs_deleted(api, aggregate_id, missing_id):
+def test_get_aggregate_values_obs_deleted(api, aggregate_id, missing_id, startend):
     res = api.delete('/observations/123e4567-e89b-12d3-a456-426655440000',
                      base_url=BASE_URL)
     assert res.status_code == 204
-    res = api.get(f'/aggregates/{aggregate_id}/values',
+    res = api.get(f'/aggregates/{aggregate_id}/values{startend}',
                   headers={'Accept': 'application/json'},
                   base_url=BASE_URL)
     assert res.status_code == 422
 
 
-def test_get_aggregate_values_limited_effective(api, aggregate_id):
+def test_get_aggregate_values_limited_effective(api, aggregate_id, startend):
     payload = {'observations': [{
         'observation_id': '123e4567-e89b-12d3-a456-426655440000',
         'effective_until': '2019-04-17 01:23:00Z'}]}
@@ -347,15 +347,15 @@ def test_get_aggregate_values_limited_effective(api, aggregate_id):
                    json=payload,
                    base_url=BASE_URL)
     assert res.status_code == 200
-    res = api.get(f'/aggregates/{aggregate_id}/values',
+    res = api.get(f'/aggregates/{aggregate_id}/values{startend}',
                   headers={'Accept': 'application/json'},
                   base_url=BASE_URL)
     assert res.status_code == 200
     assert not math.isnan(res.json['values'][-1]['value'])
 
 
-def test_get_aggregate_values_404(api, missing_id):
-    res = api.get(f'/aggregates/{missing_id}/values',
+def test_get_aggregate_values_404(api, missing_id, startend):
+    res = api.get(f'/aggregates/{missing_id}/values{startend}',
                   headers={'Accept': 'application/json'},
                   base_url=BASE_URL)
     assert res.status_code == 404

--- a/sfa_api/tests/test_api.py
+++ b/sfa_api/tests/test_api.py
@@ -115,7 +115,7 @@ def test_create_site_unauthorized(sql_api, auth_header):
 
 
 def test_create_delete_observation(sql_api, auth_header, mocked_queuing,
-                                   obs_vals):
+                                   obs_vals, startend):
     post = sql_api.post('/observations/',
                         headers=auth_header,
                         base_url=BASE_URL,
@@ -146,7 +146,7 @@ def test_create_delete_observation(sql_api, auth_header, mocked_queuing,
                                base_url=BASE_URL,
                                json={'values': json_values})
     assert post_values.status_code == 201
-    get_values = sql_api.get(f'/observations/{new_obs_id}/values',
+    get_values = sql_api.get(f'/observations/{new_obs_id}/values{startend}',
                              base_url=BASE_URL,
                              headers={'Accept': 'application/json',
                                       **auth_header})
@@ -161,7 +161,7 @@ def test_create_delete_observation(sql_api, auth_header, mocked_queuing,
                                         **auth_header},
                                data=csv_values)
     assert post_values.status_code == 201
-    get_values = sql_api.get(f'/observations/{new_obs_id}/values',
+    get_values = sql_api.get(f'/observations/{new_obs_id}/values{startend}',
                              base_url=BASE_URL,
                              headers={'Accept': 'text/csv', **auth_header})
     assert get_values.status_code == 200
@@ -171,7 +171,7 @@ def test_create_delete_observation(sql_api, auth_header, mocked_queuing,
     assert new_obs not in get_obs_list(sql_api, auth_header)
     assert new_obs not in get_site_obs(sql_api, auth_header,
                                        new_obs['site_id'])
-    get_values = sql_api.get(f'/observations/{new_obs_id}/values',
+    get_values = sql_api.get(f'/observations/{new_obs_id}/values{startend}',
                              base_url=BASE_URL,
                              headers={'Accept': 'text/csv', **auth_header})
     assert get_values.status_code == 404
@@ -203,7 +203,7 @@ def test_create_observation_site_dne(sql_api, auth_header, missing_id):
     assert observations == get_obs_list(sql_api, auth_header)
 
 
-def test_create_delete_forecast(sql_api, auth_header, fx_vals):
+def test_create_delete_forecast(sql_api, auth_header, fx_vals, startend):
     post = sql_api.post('/forecasts/single/',
                         headers=auth_header,
                         base_url=BASE_URL,
@@ -228,14 +228,15 @@ def test_create_delete_forecast(sql_api, auth_header, fx_vals):
     fx_vals['timestamp'] = fx_vals.index
     json_values = fx_vals.to_dict(orient='records')
 
-    post_values = sql_api.post(f'/forecasts/single/{new_fx_id}/values',
-                               headers=auth_header,
-                               base_url=BASE_URL,
-                               json={'values': json_values})
+    post_values = sql_api.post(
+        f'/forecasts/single/{new_fx_id}/values',
+        headers=auth_header,
+        base_url=BASE_URL,
+        json={'values': json_values})
     assert post_values.status_code == 201
 
     # request json values
-    get_values = sql_api.get(f'/forecasts/single/{new_fx_id}/values',
+    get_values = sql_api.get(f'/forecasts/single/{new_fx_id}/values{startend}',
                              base_url=BASE_URL,
                              headers={'Accept': 'application/json',
                                       **auth_header})
@@ -252,7 +253,7 @@ def test_create_delete_forecast(sql_api, auth_header, fx_vals):
     assert post_values.status_code == 201
 
     # request csv values
-    get_values = sql_api.get(f'/forecasts/single/{new_fx_id}/values',
+    get_values = sql_api.get(f'/forecasts/single/{new_fx_id}/values{startend}',
                              base_url=BASE_URL,
                              headers={'Accept': 'text/csv', **auth_header})
     assert get_values.status_code == 200
@@ -264,7 +265,7 @@ def test_create_delete_forecast(sql_api, auth_header, fx_vals):
                                      new_fx['site_id'])
 
     get_values = sql_api.get(
-        f'/forecasts/single/{new_fx_id}/values',
+        f'/forecasts/single/{new_fx_id}/values{startend}',
         base_url=BASE_URL,
         headers={'Accept': 'text/csv', **auth_header})
     assert get_values.status_code == 404
@@ -296,7 +297,7 @@ def test_post_forecast_site_dne(sql_api, auth_header, missing_id):
     assert forecasts == get_fx_list(sql_api, auth_header)
 
 
-def test_create_delete_cdf_forecast(sql_api, auth_header, fx_vals):
+def test_create_delete_cdf_forecast(sql_api, auth_header, fx_vals, startend):
     post = sql_api.post('/forecasts/cdf/',
                         headers=auth_header,
                         base_url=BASE_URL,
@@ -324,19 +325,20 @@ def test_create_delete_cdf_forecast(sql_api, auth_header, fx_vals):
             headers=auth_header,
             base_url=BASE_URL)
         assert get_const.status_code == 200
-        get_cdf_const_values = sql_api.get(value['_links']['values'],
-                                           headers=auth_header)
+        get_cdf_const_values = sql_api.get(
+            value['_links']['values'] + startend,
+            headers=auth_header)
         assert get_cdf_const_values.status_code == 200
 
         # Post values to the forecast
         fx_vals['timestamp'] = fx_vals.index
         json_values = fx_vals.to_dict(orient='records')
 
-        post_values = sql_api.post(value['_links']['values'],
+        post_values = sql_api.post(value['_links']['values'] + startend,
                                    headers=auth_header,
                                    json={'values': json_values})
         assert post_values.status_code == 201
-        get_values = sql_api.get(value['_links']['values'],
+        get_values = sql_api.get(value['_links']['values'] + startend,
                                  headers={'Accept': 'application/json',
                                           **auth_header})
         assert get_values.status_code == 200

--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -317,7 +317,8 @@ def test_get_latest_cdf_forecast_value_200(api, cdf_forecast_id, fx_vals):
     data = r.get_json()
     assert data['forecast_id'] == cdf_forecast_id
     assert len(data['values']) == 1
-    assert data['values'][0]['timestamp'] == fx_vals.index[-1].isoformat()
+    assert data['values'][0]['timestamp'] == fx_vals.index[-1].strftime(
+        '%Y-%m-%dT%H:%M:%SZ')
 
 
 def test_get_latest_cdf_forecast_value_404(api, missing_id):

--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -244,8 +244,8 @@ def test_post_forecast_values_valid_csv(api, cdf_forecast_id,
     assert r.status_code == 201
 
 
-def test_get_forecast_values_404(api, missing_id, mock_previous):
-    r = api.get(f'/forecasts/cdf/single/{missing_id}/values',
+def test_get_forecast_values_404(api, missing_id, mock_previous, startend):
+    r = api.get(f'/forecasts/cdf/single/{missing_id}/values{startend}',
                 base_url=BASE_URL)
     assert r.status_code == 404
 

--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -358,7 +358,8 @@ def test_get_latest_forecast_value_200(api, forecast_id, fx_vals):
     data = r.get_json()
     assert data['forecast_id'] == forecast_id
     assert len(data['values']) == 1
-    assert data['values'][0]['timestamp'] == fx_vals.index[-1].isoformat()
+    assert data['values'][0]['timestamp'] == fx_vals.index[-1].strftime(
+        '%Y-%m-%dT%H:%M:%SZ')
 
 
 def test_get_latest_forecast_value_new(api, new_forecast):

--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -285,8 +285,8 @@ def test_post_forecast_values_valid_csv(api, forecast_id, mock_previous):
     assert r.status_code == 201
 
 
-def test_get_forecast_values_404(api, missing_id):
-    r = api.get(f'/forecasts/single/{missing_id}/values',
+def test_get_forecast_values_404(api, missing_id, startend):
+    r = api.get(f'/forecasts/single/{missing_id}/values{startend}',
                 base_url=BASE_URL)
     assert r.status_code == 404
 

--- a/sfa_api/tests/test_observations.py
+++ b/sfa_api/tests/test_observations.py
@@ -385,7 +385,8 @@ def test_get_latest_observation_values_200(api, observation_id, ghi_obs_vals):
     data = r.get_json()
     assert data['observation_id'] == observation_id
     assert len(data['values']) == 1
-    assert data['values'][0]['timestamp'] == ghi_obs_vals.index[-1].isoformat()
+    assert data['values'][0]['timestamp'] == ghi_obs_vals.index[-1].strftime(
+        '%Y-%m-%dT%H:%M:%SZ')
 
 
 def test_get_latest_observation_values_404_fxid(api, forecast_id):

--- a/sfa_api/tests/test_observations.py
+++ b/sfa_api/tests/test_observations.py
@@ -197,8 +197,8 @@ def test_post_observation_values_valid_csv(api, observation_id,
     assert r.status_code == 201
 
 
-def test_get_observation_values_404(api, missing_id):
-    r = api.get(f'/observations/{missing_id}/values',
+def test_get_observation_values_404(api, missing_id, startend):
+    r = api.get(f'/observations/{missing_id}/values{startend}',
                 base_url=BASE_URL)
     assert r.status_code == 404
 

--- a/sfa_api/utils/request_handling.py
+++ b/sfa_api/utils/request_handling.py
@@ -285,13 +285,21 @@ def validate_start_end():
             start = parse_to_timestamp(start)
         except ValueError:
             errors.update({'start': ['Invalid start date format']})
+    else:
+        errors.update({'start': ['Must provide a start time']})
     if end is not None:
         try:
             end = parse_to_timestamp(end)
         except ValueError:
             errors.update({'end': ['Invalid end date format']})
+    else:
+        errors.update({'end': ['Must provide a end time']})
     if errors:
         raise BadAPIRequest(errors)
+    if end - start > current_app.config['MAX_DATA_RANGE_DAYS']:
+        raise BadAPIRequest({'end': [
+            f'Only {current_app.config["MAX_DATA_RANGE_DAYS"].days} days of '
+            'data may be requested per request']})
     return start, end
 
 

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -321,10 +321,9 @@ def read_observation_values(observation_id, start=None, end=None):
 
     Returns
     -------
-    list
-        A list of dictionaries representing data points.
-        Data points contain a timestamp, value and quality_flag.
-        Returns None if the Observation does not exist.
+    pandas.DataFrame
+        With 'value' and 'quality_flag' columns and a DatetimeIndex
+        named 'timestamp'.
     """
     if start is None:
         start = MINTIMESTAMP

--- a/sfa_api/utils/tests/test_request_handling.py
+++ b/sfa_api/utils/tests/test_request_handling.py
@@ -31,6 +31,23 @@ def test_validate_start_end_success(app, forecast_id, start, end):
         request_handling.validate_start_end()
 
 
+@pytest.mark.parametrize('query,exc', [
+    ('?start=20200101T0000Z', {'end'}),
+    ('?end=20200101T0000Z', {'start'}),
+    ('?start=20200101T0000Z&end=20210102T0000Z', {'end'}),
+    ('', {'start', 'end'}),
+    pytest.param('?start=20200101T0000Z&end=20200102T0000Z', {},
+                 marks=pytest.mark.xfail(strict=True))
+])
+def test_validate_start_end_not_provided(app, forecast_id, query, exc):
+    url = f'/forecasts/single/{forecast_id}/values{query}'
+    with app.test_request_context(url):
+        with pytest.raises(BadAPIRequest) as err:
+            request_handling.validate_start_end()
+        if exc:
+            assert set(err.value.errors.keys()) == exc
+
+
 @pytest.mark.parametrize('content_type,payload', [
     ('text/csv', ''),
     ('application/json', '{}'),


### PR DESCRIPTION
Limits data requests to a configurable number of days (currently 366) and in doing so, requires the start and end query parameters. I think these are always set in core, and looks like the dashboard is ok too.

closes #239

I also created a new schema field to serialized dataframes to json via pandas directly (although it requires another load and dump by flask/marshmallow). This is much faster than dumping the frame to a dict and then dumping to json. The new way is roughly the same speed as dumping to csv.

So the things that change for users, is that start and end are required query parameters and the timestamp field will now end in 'Z' instead of '+00:00'  which is still consistent with iso8601.