### PR TITLE
add values/gaps endpoints

### DIFF
--- a/datastore/migrations/0043_find_missing_values.down.sql
+++ b/datastore/migrations/0043_find_missing_values.down.sql
@@ -1,0 +1,5 @@
+DROP PROCEDURE arbiter_data.find_cdf_single_forecast_gaps;
+DROP PROCEDURE arbiter_data.find_cdf_forecast_gaps;
+DROP PROCEDURE arbiter_data.find_forecast_gaps;
+DROP PROCEDURE arbiter_data.find_observation_gaps;
+DROP PROCEDURE arbiter_data.find_unflagged_observation_dates;

--- a/datastore/migrations/0043_find_missing_values.up.sql
+++ b/datastore/migrations/0043_find_missing_values.up.sql
@@ -11,7 +11,7 @@ BEGIN
     IF allowed THEN
         SELECT DISTINCT(DATE(CONVERT_TZ(timestamp, 'UTC', tz))) as date
         FROM arbiter_data.observations_values WHERE id = binid AND timestamp BETWEEN start AND end
-        AND NOT (quality_flag & flag);
+        AND (quality_flag & flag) != flag;
     ELSE
         SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "find unflagged observation dates"',
         MYSQL_ERRNO = 1142;

--- a/datastore/migrations/0043_find_missing_values.up.sql
+++ b/datastore/migrations/0043_find_missing_values.up.sql
@@ -1,0 +1,151 @@
+CREATE DEFINER = 'select_objects'@'localhost' PROCEDURE find_unflagged_observation_dates (
+    IN auth0id VARCHAR(32), IN strid CHAR(36), IN start TIMESTAMP, IN end TIMESTAMP,
+    IN flag INT, IN tz VARCHAR(64))
+COMMENT 'Find all days (in TZ) where data is not flagged with FLAG'
+READS SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+    SET binid = (SELECT UUID_TO_BIN(strid, 1));
+    SET allowed = (SELECT can_user_perform_action(auth0id, binid, 'read_values'));
+    IF allowed THEN
+        SELECT DISTINCT(DATE(CONVERT_TZ(timestamp, 'UTC', tz))) as date
+        FROM arbiter_data.observations_values WHERE id = binid AND timestamp BETWEEN start AND end
+        AND NOT (quality_flag & flag);
+    ELSE
+        SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "find unflagged observation dates"',
+        MYSQL_ERRNO = 1142;
+    END IF;
+END;
+GRANT EXECUTE ON PROCEDURE find_unflagged_observation_dates TO 'select_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE find_unflagged_observation_dates TO 'apiuser'@'%';
+
+
+CREATE DEFINER = 'select_objects'@'localhost' PROCEDURE find_observation_gaps (
+    IN auth0id VARCHAR(32), IN strid CHAR(36), IN start TIMESTAMP, IN end TIMESTAMP
+)
+COMMENT 'Find the gaps in observation values based on interval_length'
+READS SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    DECLARE il INT;
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+
+    SET binid = (SELECT UUID_TO_BIN(strid, 1));
+    SET allowed = (SELECT can_user_perform_action(auth0id, binid, 'read_values')
+                      AND can_user_perform_action(auth0id, binid, 'read'));
+    IF allowed THEN
+        SET il = (SELECT interval_length FROM arbiter_data.observations WHERE id = binid);
+        SELECT j.timestamp, j.next_timestamp AS next_timestamp FROM (
+            SELECT timestamp,
+                 TIMESTAMPDIFF(MINUTE, timestamp, LEAD(timestamp, 1) OVER w) AS 'diff',
+                 LEAD(timestamp, 1) OVER w AS 'next_timestamp'
+            FROM arbiter_data.observations_values WHERE id = binid
+            AND timestamp BETWEEN start and end WINDOW w AS (ORDER BY timestamp ASC)
+        ) AS j WHERE j.diff > il;
+    ELSE
+         SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "find observation gaps"',
+         MYSQL_ERRNO = 1142;
+    END IF;
+END;
+GRANT EXECUTE ON PROCEDURE find_observation_gaps TO 'select_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE find_observation_gaps TO 'apiuser'@'%';
+
+
+CREATE DEFINER = 'select_objects'@'localhost' PROCEDURE find_forecast_gaps (
+    IN auth0id VARCHAR(32), IN strid CHAR(36), IN start TIMESTAMP, IN end TIMESTAMP
+)
+COMMENT 'Find the gaps in forecast values based on interval_length'
+READS SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    DECLARE il INT;
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+
+    SET binid = (SELECT UUID_TO_BIN(strid, 1));
+    SET allowed = (SELECT can_user_perform_action(auth0id, binid, 'read_values')
+                      AND can_user_perform_action(auth0id, binid, 'read'));
+    IF allowed THEN
+        SET il = (SELECT interval_length FROM arbiter_data.forecasts WHERE id = binid);
+        SELECT j.timestamp, j.next_timestamp AS next_timestamp FROM (
+            SELECT timestamp,
+                 TIMESTAMPDIFF(MINUTE, timestamp, LEAD(timestamp, 1) OVER w) AS 'diff',
+                 LEAD(timestamp, 1) OVER w AS 'next_timestamp'
+            FROM arbiter_data.forecasts_values WHERE id = binid
+            AND timestamp BETWEEN start and end WINDOW w AS (ORDER BY timestamp ASC)
+        ) AS j WHERE j.diff > il;
+    ELSE
+         SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "find forecast gaps"',
+         MYSQL_ERRNO = 1142;
+    END IF;
+END;
+GRANT EXECUTE ON PROCEDURE find_forecast_gaps TO 'select_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE find_forecast_gaps TO 'apiuser'@'%';
+
+-- same for cdf single
+
+
+CREATE DEFINER = 'select_objects'@'localhost' PROCEDURE find_cdf_forecast_gaps (
+    IN auth0id VARCHAR(32), IN strid CHAR(36), IN start TIMESTAMP, IN end TIMESTAMP
+)
+COMMENT 'Find the maximum gaps between all forecast values in a CDF group'
+READS SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    DECLARE il INT;
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+
+    SET binid = (SELECT UUID_TO_BIN(strid, 1));
+    SET allowed = (SELECT can_user_perform_action(auth0id, binid, 'read_values')
+                      AND can_user_perform_action(auth0id, binid, 'read'));
+    IF allowed THEN
+        SET il = (SELECT interval_length FROM arbiter_data.cdf_forecasts_groups WHERE id = binid);
+        SELECT j.timestamp, MAX(j.next_timestamp) as next_timestamp FROM (
+            SELECT timestamp,
+                 TIMESTAMPDIFF(MINUTE, timestamp, LEAD(timestamp, 1) OVER w) AS 'diff',
+                 LEAD(timestamp, 1) OVER w AS 'next_timestamp'
+            FROM arbiter_data.cdf_forecasts_values WHERE id IN (
+                 SELECT id FROM arbiter_data.cdf_forecasts_singles WHERE cdf_forecast_group_id = binid
+             )
+            AND timestamp BETWEEN start and end WINDOW w AS (ORDER BY timestamp ASC)
+        ) AS j WHERE j.diff > il  GROUP BY j.timestamp;
+    ELSE
+         SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "find cdf forecast gaps"',
+         MYSQL_ERRNO = 1142;
+    END IF;
+END;
+GRANT EXECUTE ON PROCEDURE find_cdf_forecast_gaps TO 'select_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE find_cdf_forecast_gaps TO 'apiuser'@'%';
+
+
+CREATE DEFINER = 'select_objects'@'localhost' PROCEDURE find_cdf_single_forecast_gaps (
+    IN auth0id VARCHAR(32), IN strid CHAR(36), IN start TIMESTAMP, IN end TIMESTAMP
+)
+COMMENT 'Find the gaps in CDF forecast values based on interval_length'
+READS SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    DECLARE groupid BINARY(16);
+    DECLARE il INT;
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+
+    SET binid = (SELECT UUID_TO_BIN(strid, 1));
+    SET groupid = (SELECT cdf_forecast_group_id FROM arbiter_data.cdf_forecasts_singles WHERE id = binid);
+    SET allowed = (SELECT can_user_perform_action(auth0id, groupid, 'read_values')
+                      AND can_user_perform_action(auth0id, groupid, 'read'));
+    IF allowed THEN
+        SET il = (SELECT interval_length FROM arbiter_data.cdf_forecasts_groups WHERE id = groupid);
+        SELECT j.timestamp, j.next_timestamp AS next_timestamp FROM (
+            SELECT timestamp,
+                 TIMESTAMPDIFF(MINUTE, timestamp, LEAD(timestamp, 1) OVER w) AS 'diff',
+                 LEAD(timestamp, 1) OVER w AS 'next_timestamp'
+            FROM arbiter_data.cdf_forecasts_values WHERE id = binid
+            AND timestamp BETWEEN start and end WINDOW w AS (ORDER BY timestamp ASC)
+        ) AS j WHERE j.diff > il;
+    ELSE
+         SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "find cdf single forecast gaps"',
+         MYSQL_ERRNO = 1142;
+    END IF;
+END;
+GRANT EXECUTE ON PROCEDURE find_cdf_single_forecast_gaps TO 'select_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE find_cdf_single_forecast_gaps TO 'apiuser'@'%';

--- a/datastore/migrations/0043_find_missing_values.up.sql
+++ b/datastore/migrations/0043_find_missing_values.up.sql
@@ -1,6 +1,6 @@
 CREATE DEFINER = 'select_objects'@'localhost' PROCEDURE find_unflagged_observation_dates (
     IN auth0id VARCHAR(32), IN strid CHAR(36), IN start TIMESTAMP, IN end TIMESTAMP,
-    IN flag INT, IN tz VARCHAR(64))
+    IN flag SMALLINT UNSIGNED, IN tz VARCHAR(64))
 COMMENT 'Find all days (in TZ) where data is not flagged with FLAG'
 READS SQL DATA SQL SECURITY DEFINER
 BEGIN

--- a/datastore/migrations/0044_fixed_write_metadata.down.sql
+++ b/datastore/migrations/0044_fixed_write_metadata.down.sql
@@ -1,0 +1,43 @@
+DROP PROCEDURE read_metadata_for_value_write;
+CREATE DEFINER = 'select_objects'@'localhost' PROCEDURE read_metadata_for_value_write (
+    IN auth0id VARCHAR(32), IN strid CHAR(36), IN object_type VARCHAR(32), IN start TIMESTAMP)
+COMMENT 'Read the necessary metadata/values to allow proper validation of data being written'
+READS SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+    DECLARE groupid BINARY(16);
+    DECLARE il INT;
+    DECLARE previous_time TIMESTAMP;
+    DECLARE extra TEXT;
+    SET binid = (SELECT UUID_TO_BIN(strid, 1));
+    IF object_type IN ('observations', 'forecasts') THEN
+        SET allowed = (SELECT can_user_perform_action(auth0id, binid, 'write_values'));
+    ELSEIF object_type = 'cdf_forecasts' THEN
+        SET groupid = (SELECT cdf_forecast_group_id FROM cdf_forecasts_singles WHERE id = binid);
+        SET allowed = (SELECT can_user_perform_action(auth0id, groupid, 'write_values'));
+    ELSE
+        SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Invalid object_type for "read metadata for value write"',
+        MYSQL_ERRNO = 1146;
+    END IF;
+
+    IF allowed THEN
+        IF object_type = 'observations' THEN
+            SELECT interval_length, extra_parameters INTO il, extra FROM arbiter_data.observations WHERE id = binid;
+            SET previous_time = (SELECT MAX(timestamp) FROM arbiter_data.observations_values WHERE id = binid AND timestamp < start);
+        ELSEIF object_type = 'forecasts' THEN
+           SELECT interval_length, extra_parameters INTO il, extra FROM arbiter_data.forecasts WHERE id = binid;
+            SET previous_time = (SELECT MAX(timestamp) FROM arbiter_data.forecasts_values WHERE id = binid AND timestamp < start);
+        ELSEIF object_type = 'cdf_forecasts' THEN
+            SELECT interval_length, extra_parameters INTO il, extra FROM arbiter_data.cdf_forecasts_groups WHERE id = groupid;
+            SET previous_time = (SELECT MAX(timestamp) FROM arbiter_data.cdf_forecasts_values WHERE id = binid AND timestamp < start);
+        END IF;
+        SELECT il as interval_length, previous_time, extra as extra_parameters;
+    ELSE
+        SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "read metadata for value write"',
+        MYSQL_ERRNO = 1142;
+    END IF;
+END;
+
+GRANT EXECUTE ON PROCEDURE read_metadata_for_value_write TO 'select_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE read_metadata_for_value_write TO 'apiuser'@'%';

--- a/datastore/migrations/0044_fixed_write_metadata.up.sql
+++ b/datastore/migrations/0044_fixed_write_metadata.up.sql
@@ -1,0 +1,48 @@
+DROP PROCEDURE read_metadata_for_value_write;
+CREATE DEFINER = 'select_objects'@'localhost' PROCEDURE read_metadata_for_value_write (
+    IN auth0id VARCHAR(32), IN strid CHAR(36), IN object_type VARCHAR(32), IN start TIMESTAMP)
+COMMENT 'Read the necessary metadata/values to allow proper validation of data being written'
+READS SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE binid BINARY(16);
+    DECLARE allowed BOOLEAN DEFAULT FALSE;
+    DECLARE groupid BINARY(16);
+    DECLARE il INT;
+    DECLARE previous_time TIMESTAMP;
+    DECLARE extra TEXT;
+    SET binid = (SELECT UUID_TO_BIN(strid, 1));
+    IF object_type IN ('observations', 'forecasts') THEN
+        SET allowed = (SELECT can_user_perform_action(auth0id, binid, 'write_values'));
+    ELSEIF object_type = 'cdf_forecasts' THEN
+        SET groupid = (SELECT cdf_forecast_group_id FROM cdf_forecasts_singles WHERE id = binid);
+        SET allowed = (SELECT can_user_perform_action(auth0id, groupid, 'write_values'));
+    ELSE
+        SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Invalid object_type for "read metadata for value write"',
+        MYSQL_ERRNO = 1146;
+    END IF;
+
+    IF allowed THEN
+        IF object_type = 'observations' THEN
+            SELECT interval_length, extra_parameters INTO il, extra FROM arbiter_data.observations WHERE id = binid;
+            SET previous_time = (SELECT MAX(timestamp) FROM arbiter_data.observations_values WHERE id = binid AND timestamp < start);
+        ELSEIF object_type = 'forecasts' THEN
+           SELECT interval_length, extra_parameters INTO il, extra FROM arbiter_data.forecasts WHERE id = binid;
+            SET previous_time = (SELECT MAX(timestamp) FROM arbiter_data.forecasts_values WHERE id = binid AND timestamp < start);
+        ELSEIF object_type = 'cdf_forecasts' THEN
+            SELECT interval_length, extra_parameters INTO il, extra FROM arbiter_data.cdf_forecasts_groups WHERE id = groupid;
+            SET previous_time = (SELECT MAX(timestamp) FROM arbiter_data.cdf_forecasts_values WHERE id = binid AND timestamp < start);
+        END IF;
+        IF ISNULL(il) THEN
+            -- interval length will only be null if the object doesn't actually exist in the proper table
+            SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "read metadata for value write"',
+            MYSQL_ERRNO = 1142;
+        END IF;            
+        SELECT il as interval_length, previous_time, extra as extra_parameters;
+    ELSE
+        SIGNAL SQLSTATE '42000' SET MESSAGE_TEXT = 'Access denied to user on "read metadata for value write"',
+        MYSQL_ERRNO = 1142;
+    END IF;
+END;
+
+GRANT EXECUTE ON PROCEDURE read_metadata_for_value_write TO 'select_objects'@'localhost';
+GRANT EXECUTE ON PROCEDURE read_metadata_for_value_write TO 'apiuser'@'%';

--- a/datastore/tests/test_reads.py
+++ b/datastore/tests/test_reads.py
@@ -1958,6 +1958,9 @@ def test_find_unflagged_observation_dates(cursor, obs_values, insertuser,
                     (auth0id, obsid, start, end, 2, 'UTC'))
     assert cursor.fetchall()[0] == (start.date(),)
     cursor.callproc('find_unflagged_observation_dates',
+                    (auth0id, obsid, start, end, 3, 'UTC'))
+    assert cursor.fetchall()[0] == (start.date(),)
+    cursor.callproc('find_unflagged_observation_dates',
                     (auth0id, obsid, start, end, 2, 'Etc/GMT+7'))
     assert cursor.fetchall()[0] == (start.date(),)
     cursor.callproc('find_unflagged_observation_dates',

--- a/datastore/tests/test_reads.py
+++ b/datastore/tests/test_reads.py
@@ -1943,4 +1943,328 @@ def test_read_forecast_time_range_denied_can_read_meta(
     with pytest.raises(pymysql.err.OperationalError) as e:
         cursor.callproc('read_forecast_time_range', (auth0id, fxid))
     assert e.value.args[0] == 1142
+
+
+def test_find_unflagged_observation_dates(cursor, obs_values, insertuser,
+                                          allow_read_observation_values):
+    auth0id, obsid, vals, start, end = obs_values(insertuser[3]['strid'])
+    cursor.execute(
+        'UPDATE observations_values SET quality_flag = 1 '
+        'WHERE id = UUID_TO_BIN(%s, 1)', obsid)
+    cursor.callproc('find_unflagged_observation_dates',
+                    (auth0id, obsid, start, end, 1, 'UTC'))
+    assert len(cursor.fetchall()) == 0
+    cursor.callproc('find_unflagged_observation_dates',
+                    (auth0id, obsid, start, end, 2, 'UTC'))
+    assert cursor.fetchall()[0] == (start.date(),)
+    cursor.callproc('find_unflagged_observation_dates',
+                    (auth0id, obsid, start, end, 2, 'Etc/GMT+7'))
+    assert cursor.fetchall()[0] == (start.date(),)
+    cursor.callproc('find_unflagged_observation_dates',
+                    (auth0id, obsid, start, end, 2, 'Etc/GMT-12'))
+    assert cursor.fetchall()[0] == (start.date() + dt.timedelta(days=1),)
     
+
+def test_find_unflagged_observation_dates_denied(
+        cursor, obs_values, insertuser, allow_read_observations):
+    auth0id, obsid, vals, start, end = obs_values(insertuser[3]['strid'])
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('find_unflagged_observation_dates',
+                        (auth0id, obsid, start, end, 1, 'UTC'))
+    assert e.value.args[0] == 1142
+
+
+def test_find_observation_gaps(
+        cursor, obs_values, insertuser, allow_read_observations,
+        allow_read_observation_values):
+    auth0id, obsid, vals, start, end = obs_values(insertuser[3]['strid'])
+    start = start - dt.timedelta(minutes=10)
+    end = end + dt.timedelta(days=36)
+    mid = start + dt.timedelta(minutes=10)
+    cursor.executemany(
+        'INSERT INTO observations_values (id, timestamp, value, quality_flag)'
+        ' VALUES (uuid_to_bin(%s, 1), %s, 0, 0)', (
+            (obsid, start), (obsid, end + dt.timedelta(minutes=5)),
+            (obsid, str(mid))))
+    cursor.callproc('find_observation_gaps',
+                    (auth0id, obsid, start, end))
+    out = cursor.fetchall()
+    assert len(out) == 2
+    assert out[0] == (start, mid)
+    assert out[1] == (mid, mid + dt.timedelta(seconds=20, minutes=8))
+
+    # single value
+    start = start + dt.timedelta(days=30)
+    cursor.execute(
+        'INSERT INTO observations_values (id, timestamp, value, quality_flag)'
+        ' VALUES (uuid_to_bin(%s, 1), %s, 0, 0)', (obsid, start))
+    cursor.callproc('find_observation_gaps',
+                    (auth0id, obsid, start, end))
+    assert len(cursor.fetchall()) == 0
+
+
+def test_find_observation_gaps_no_read_obs(
+        cursor, obs_values, insertuser, 
+        allow_read_observation_values):
+    auth0id, obsid, vals, start, end = obs_values(insertuser[3]['strid'])
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('find_observation_gaps',
+                        (auth0id, obsid, start, end))
+    assert e.value.args[0] == 1142
+
+
+def test_find_observation_gaps_no_read_obs_vals(
+        cursor, obs_values, insertuser, 
+        allow_read_observations):
+    auth0id, obsid, vals, start, end = obs_values(insertuser[3]['strid'])
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('find_observation_gaps',
+                        (auth0id, obsid, start, end))
+    assert e.value.args[0] == 1142
+
+
+def test_find_observation_gaps_is_fx(
+        cursor, obs_values, insertuser, allow_read_forecast_values,
+        allow_read_forecasts):
+    auth0id, obsid, vals, start, end = obs_values(insertuser.obs['strid'])
+    fxid = insertuser.fx['strid']
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('find_observation_gaps',
+                        (auth0id, fxid, start, end))
+    assert e.value.args[0] == 1142
+
+
+def test_find_forecast_gaps(
+        cursor, fx_values, insertuser, allow_read_forecasts,
+        allow_read_forecast_values):
+    auth0id, fxid, vals, start, end = fx_values
+    start = start - dt.timedelta(hours=3)
+    end = end + dt.timedelta(days=36)
+    mid = start + dt.timedelta(hours=2)
+    cursor.executemany(
+        'INSERT INTO forecasts_values (id, timestamp, value)'
+        ' VALUES (uuid_to_bin(%s, 1), %s, 0)', (
+            (fxid, start), (fxid, end + dt.timedelta(minutes=5)),
+            (fxid, str(mid))))
+    cursor.callproc('find_forecast_gaps',
+                    (auth0id, fxid, start, end))
+    out = cursor.fetchall()
+    assert len(out) == 2
+    assert out[0] == (start, mid)
+    assert out[1] == (mid, mid + dt.timedelta(hours=1, seconds=20, minutes=8))
+
+    # single value
+    start = start + dt.timedelta(days=30)
+    cursor.execute(
+        'INSERT INTO forecasts_values (id, timestamp, value)'
+        ' VALUES (uuid_to_bin(%s, 1), %s, 0)', (fxid, start))
+    cursor.callproc('find_forecast_gaps',
+                    (auth0id, fxid, start, end))
+    assert len(cursor.fetchall()) == 0
+
+
+def test_find_forecast_gaps_no_read_fx(
+        cursor, fx_values, insertuser, 
+        allow_read_forecast_values):
+    auth0id, fxid, vals, start, end = fx_values
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('find_forecast_gaps',
+                        (auth0id, fxid, start, end))
+    assert e.value.args[0] == 1142
+
+
+def test_find_forecast_gaps_no_read_fx_vals(
+        cursor, fx_values, insertuser, 
+        allow_read_forecasts):
+    auth0id, fxid, vals, start, end = fx_values
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('find_forecast_gaps',
+                        (auth0id, fxid, start, end))
+    assert e.value.args[0] == 1142
+
+
+def test_find_forecast_gaps_is_obs(
+        cursor, fx_values, insertuser, allow_read_forecast_values,
+        allow_read_forecasts):
+    auth0id, fxid, vals, start, end = fx_values
+    obsid = insertuser.obs['strid']
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('find_forecast_gaps',
+                        (auth0id, obsid, start, end))
+    assert e.value.args[0] == 1142
+
+
+def test_find_cdf_single_forecast_gaps(
+        cursor, cdf_fx_values, insertuser, allow_read_cdf_forecasts,
+        allow_read_cdf_forecast_values):
+    auth0id, cdf_fxid, vals, start, end = cdf_fx_values
+    start = start - dt.timedelta(hours=3)
+    end = end + dt.timedelta(days=36)
+    mid = start + dt.timedelta(hours=2)
+    cursor.executemany(
+        'INSERT INTO cdf_forecasts_values (id, timestamp, value)'
+        ' VALUES (uuid_to_bin(%s, 1), %s, 0)', (
+            (cdf_fxid, start), (cdf_fxid, end + dt.timedelta(minutes=5)),
+            (cdf_fxid, str(mid))))
+    cursor.callproc('find_cdf_single_forecast_gaps',
+                    (auth0id, cdf_fxid, start, end))
+    out = cursor.fetchall()
+    assert len(out) == 2
+    assert out[0] == (start, mid)
+    assert out[1] == (mid, mid + dt.timedelta(hours=1, seconds=20, minutes=8))
+
+    # singles value
+    start = start + dt.timedelta(days=30)
+    cursor.execute(
+        'INSERT INTO cdf_forecasts_values (id, timestamp, value)'
+        ' VALUES (uuid_to_bin(%s, 1), %s, 0)', (cdf_fxid, start))
+    cursor.callproc('find_cdf_single_forecast_gaps',
+                    (auth0id, cdf_fxid, start, end))
+    assert len(cursor.fetchall()) == 0
+
+
+def test_find_cdf_single_forecast_gaps_no_read_cdf_fx(
+        cursor, cdf_fx_values, insertuser, 
+        allow_read_cdf_forecast_values):
+    auth0id, cdf_fxid, vals, start, end = cdf_fx_values
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('find_cdf_single_forecast_gaps',
+                        (auth0id, cdf_fxid, start, end))
+    assert e.value.args[0] == 1142
+
+
+def test_find_cdf_single_forecast_gaps_no_read_cdf_fx_vals(
+        cursor, cdf_fx_values, insertuser,
+        allow_read_cdf_forecasts):
+    auth0id, cdf_fxid, vals, start, end = cdf_fx_values
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('find_cdf_single_forecast_gaps',
+                        (auth0id, cdf_fxid, start, end))
+    assert e.value.args[0] == 1142
+
+
+def test_find_cdf_single_forecast_gaps_is_obs(
+        cursor, cdf_fx_values, insertuser, allow_read_cdf_forecast_values,
+        allow_read_cdf_forecasts):
+    auth0id, cdf_fxid, vals, start, end = cdf_fx_values
+    obsid = insertuser.obs['strid']
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('find_cdf_single_forecast_gaps',
+                        (auth0id, obsid, start, end))
+    assert e.value.args[0] == 1142
+
+
+@pytest.fixture()
+def cdf_grp_fx_values(cursor, insertuser, request):
+    auth0id = insertuser[0]['auth0_id']
+    forecast = insertuser.cdf
+    strid = forecast['strid']
+    start = dt.datetime(2020, 1, 30, 12, 20)
+    for sid in forecast['constant_values'].keys():
+        vals = tuple([
+            (sid, start + dt.timedelta(hours=i),
+             float(random.randint(0, 100))) for i in range(10)])
+        cursor.executemany(
+            'INSERT INTO cdf_forecasts_values (id, timestamp, value) '
+            'VALUES (UUID_TO_BIN(%s, 1), %s, %s)', vals)
+    end = dt.datetime(2020, 1, 30, 23, 20)
+    return auth0id, strid, vals, start, end
+
+
+def test_find_cdf_forecast_gaps(
+        cursor, cdf_grp_fx_values, insertuser, allow_read_cdf_forecasts,
+        allow_read_cdf_forecast_values):
+    auth0id, cdf_fxid, vals, start, end = cdf_grp_fx_values
+    start = start - dt.timedelta(hours=6)
+    end = end + dt.timedelta(days=36)
+    mid = start + dt.timedelta(hours=2)
+    for sid in insertuser.cdf['constant_values'].keys():
+        cursor.executemany(
+            'INSERT INTO cdf_forecasts_values (id, timestamp, value)'
+            ' VALUES (uuid_to_bin(%s, 1), %s, 0)', (
+                (sid, start), (sid, end + dt.timedelta(hours=1)),
+                (sid, str(mid))))
+    cursor.callproc('find_cdf_forecast_gaps',
+                    (auth0id, cdf_fxid, start, end))
+    out = cursor.fetchall()
+    assert len(out) == 2
+    assert out[0] == (start, mid)
+    assert out[1] == (mid, mid + dt.timedelta(hours=4))
+    
+    # difference between singles
+    start = start + dt.timedelta(days=2)
+    mid = start + dt.timedelta(hours=2)
+    fin = mid + dt.timedelta(hours=8)
+
+    cursor.callproc('find_cdf_forecast_gaps',
+                    (auth0id, cdf_fxid, start, end))
+    out = cursor.fetchall()
+    assert len(out) == 0
+
+    sid = list(insertuser.cdf['constant_values'].keys())[0]
+    cursor.executemany(
+        'INSERT INTO cdf_forecasts_values (id, timestamp, value)'
+        ' VALUES (uuid_to_bin(%s, 1), %s, 0)', (
+            (sid, start), (sid, mid), (sid, fin)))
+    cursor.callproc('find_cdf_forecast_gaps',
+                    (auth0id, cdf_fxid, start, end))
+    out = cursor.fetchall()
+    assert len(out) == 2
+    assert out[0] == (start, mid)
+    assert out[1] == (mid, fin)
+
+    # add some data to a different cv
+    sid = list(insertuser.cdf['constant_values'].keys())[1]
+    inter = mid + dt.timedelta(hours=2)
+    cursor.executemany(
+        'INSERT INTO cdf_forecasts_values (id, timestamp, value)'
+        ' VALUES (uuid_to_bin(%s, 1), %s, 0)', (
+            (sid, start), (sid, inter)))
+    cursor.callproc('find_cdf_forecast_gaps',
+                    (auth0id, cdf_fxid, start, end))
+    out = cursor.fetchall()
+    assert len(out) == 3
+    assert out[0] == (start, mid)
+    assert out[1] == (mid, inter)
+    assert out[2] == (inter, fin)
+    
+    # single value
+    start = start + dt.timedelta(days=30)
+    for sid in insertuser.cdf['constant_values'].keys():
+        cursor.execute(
+            'INSERT INTO cdf_forecasts_values (id, timestamp, value)'
+            ' VALUES (uuid_to_bin(%s, 1), %s, 0)', (sid, start))
+    cursor.callproc('find_cdf_forecast_gaps',
+                    (auth0id, cdf_fxid, start, end))
+    assert len(cursor.fetchall()) == 0
+
+
+def test_find_cdf_forecast_gaps_no_read_cdf_fx(
+        cursor, cdf_grp_fx_values, insertuser, 
+        allow_read_cdf_forecast_values):
+    auth0id, cdf_fxid, vals, start, end = cdf_grp_fx_values
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('find_cdf_forecast_gaps',
+                        (auth0id, cdf_fxid, start, end))
+    assert e.value.args[0] == 1142
+
+
+def test_find_cdf_forecast_gaps_no_read_cdf_fx_vals(
+        cursor, cdf_grp_fx_values, insertuser,
+        allow_read_cdf_forecasts):
+    auth0id, cdf_fxid, vals, start, end = cdf_grp_fx_values
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('find_cdf_forecast_gaps',
+                        (auth0id, cdf_fxid, start, end))
+    assert e.value.args[0] == 1142
+
+
+def test_find_cdf_forecast_gaps_is_obs(
+        cursor, cdf_grp_fx_values, insertuser, allow_read_cdf_forecast_values,
+        allow_read_cdf_forecasts):
+    auth0id, cdf_fxid, vals, start, end = cdf_grp_fx_values
+    obsid = insertuser.obs['strid']
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        cursor.callproc('find_cdf_forecast_gaps',
+                        (auth0id, obsid, start, end))
+    assert e.value.args[0] == 1142

--- a/datastore/tests/test_reads.py
+++ b/datastore/tests/test_reads.py
@@ -1481,6 +1481,24 @@ def test_read_metadata_for_value_write_invalid(cursor, insertuser):
     assert e.value.args[0] == 1146
 
 
+def test_read_metadata_for_value_write_different_type(dictcursor, insertuser,
+                                                      allow_write_values):
+    time_ = dt.datetime(2019, 9, 30, 12, 45)
+    dictcursor.execute(
+        'INSERT INTO observations_values (id, timestamp, value, quality_flag)'
+        ' VALUES (%s, %s, %s, %s)', (insertuser.obs['id'], time_, 0, 0))
+    dictcursor.callproc('read_metadata_for_value_write',
+                        (insertuser.auth0id,
+                         insertuser.obs['strid'], 'observations',
+                         '2019-09-30 13:00'))    
+    with pytest.raises(pymysql.err.OperationalError) as e:
+        dictcursor.callproc('read_metadata_for_value_write',
+                            (insertuser.auth0id,
+                             insertuser.obs['strid'], 'forecasts',
+                             '2019-09-30 13:00'))
+    assert e.value.args[0] == 1142
+    
+
 def test_read_user_id(cursor, insertuser, new_user):
     u2 = new_user()
     cursor.callproc('read_user_id', (insertuser.auth0id, u2['auth0_id']))

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -2086,6 +2086,10 @@ def addmayvalues(root_cursor):
         " SELECT id, '2019-05-01 00:00', 1.0, 1 FROM observations"
     )
     root_cursor.execute(
+        "INSERT INTO observations_values (id, timestamp, value, quality_flag)"
+        " SELECT id, '2019-05-02 00:00', 1.0, 5 FROM observations"
+    )
+    root_cursor.execute(
         "INSERT INTO cdf_forecasts_values (id, timestamp, value) "
         "SELECT id, '2019-05-01 00:00', 1.0 FROM cdf_forecasts_singles"
     )

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -775,7 +775,8 @@ class CDFGroupForecastGapView(MethodView):
         """
         start, end = validate_start_end()
         storage = get_storage()
-        out = {'gaps': storage.find_cdf_forecast_group_gaps(forecast_id, start, end),
+        out = {'gaps': storage.find_cdf_forecast_group_gaps(
+            forecast_id, start, end),
                'forecast_id': forecast_id}
         data = CDFGroupForecastGapSchema().dump(out)
         return jsonify(data)

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -15,7 +15,10 @@ from sfa_api.schema import (ForecastValuesSchema,
                             CDFForecastGroupSchema,
                             CDFForecastSchema,
                             CDFForecastValuesSchema,
-                            CDFForecastTimeRangeSchema)
+                            CDFForecastTimeRangeSchema,
+                            ForecastGapSchema,
+                            CDFForecastGapSchema,
+                            CDFGroupForecastGapSchema)
 
 from sfa_api.utils.errors import BadAPIRequest
 from sfa_api.utils.storage import get_storage
@@ -323,6 +326,39 @@ class ForecastTimeRangeView(MethodView):
         return jsonify(data)
 
 
+class ForecastGapView(MethodView):
+    def get(self, forecast_id, *args):
+        """
+        ---
+        summary: Get the gaps in Forecast data.
+        description: |
+          Get the timestamps indicating where gaps in Forecast
+          data between start and end.
+        tags:
+        - Forecasts
+        parameters:
+          - forecast_id
+          - start_time
+          - end_time
+        responses:
+          200:
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ForecastValueGap'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+        """
+        start, end = validate_start_end()
+        storage = get_storage()
+        out = {'gaps': storage.find_forecast_gaps(forecast_id, start, end),
+               'forecast_id': forecast_id}
+        data = ForecastGapSchema().dump(out)
+        return jsonify(data)
+
+
 class ForecastMetadataView(MethodView):
     def get(self, forecast_id, *args):
         """
@@ -623,8 +659,8 @@ class CDFForecastLatestView(MethodView):
         ---
         summary: Get latest Probabilistic Forecast value.
         description: |
-          Get the most recent timeseries value from the Probabilistic
-          Forecast entry.
+          Get the most recent timeseries value for one constant value
+          from the Probabilistic Forecast entry.
         tags:
           - Probabilistic Forecasts
         parameters:
@@ -653,8 +689,8 @@ class CDFForecastTimeRangeView(MethodView):
         ---
         summary: Get the time range of an Probabilistic Forecast.
         description: |
-          Get the minimum and maximum timestamps of Probabilistic Forecast
-          values stored in the Arbiter.
+          Get the minimum and maximum timestamps for one constant value
+          of a Probabilistic Forecast values stored in the Arbiter.
         tags:
         - Probabilistic Forecasts
         parameters:
@@ -674,6 +710,74 @@ class CDFForecastTimeRangeView(MethodView):
         timerange = storage.read_cdf_forecast_time_range(forecast_id)
         timerange['forecast_id'] = forecast_id
         data = CDFForecastTimeRangeSchema().dump(timerange)
+        return jsonify(data)
+
+
+class CDFForecastGapView(MethodView):
+    def get(self, forecast_id, *args):
+        """
+        ---
+        summary: Get the gaps in Probabilistic Forecast
+        description: |
+          Get the timestamps indicating where gaps in the data
+          of one constant value from the probabilistic forecast
+          between start and end.
+        tags:
+        - Probabilistic Forecasts
+        parameters:
+          - forecast_id
+          - start_time
+          - end_time
+        responses:
+          200:
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/CDFForecastValueGap'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+        """
+        start, end = validate_start_end()
+        storage = get_storage()
+        out = {'gaps': storage.find_cdf_forecast_gaps(forecast_id, start, end),
+               'forecast_id': forecast_id}
+        data = CDFForecastGapSchema().dump(out)
+        return jsonify(data)
+
+
+class CDFGroupForecastGapView(MethodView):
+    def get(self, forecast_id, *args):
+        """
+        ---
+        summary: Get the gaps in Probabilistic Forecast Group
+        description: |
+          Get the timestamps indicating where gaps in the data
+          for all constant values of a Probabilistic Forecast
+          group between start and end.
+        tags:
+        - Probabilistic Forecasts
+        parameters:
+          - forecast_id
+          - start_time
+          - end_time
+        responses:
+          200:
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/CDFGroupForecastValueGap'
+          401:
+            $ref: '#/components/responses/401-Unauthorized'
+          404:
+            $ref: '#/components/responses/404-NotFound'
+        """
+        start, end = validate_start_end()
+        storage = get_storage()
+        out = {'gaps': storage.find_cdf_forecast_group_gaps(forecast_id, start, end),
+               'forecast_id': forecast_id}
+        data = CDFGroupForecastGapSchema().dump(out)
         return jsonify(data)
 
 
@@ -708,6 +812,9 @@ forecast_blp.add_url_rule(
     '/single/<uuid_str:forecast_id>/values/timerange',
     view_func=ForecastTimeRangeView.as_view('time_range'))
 forecast_blp.add_url_rule(
+    '/single/<uuid_str:forecast_id>/values/gaps',
+    view_func=ForecastGapView.as_view('gaps'))
+forecast_blp.add_url_rule(
     '/single/<uuid_str:forecast_id>/metadata',
     view_func=ForecastMetadataView.as_view('metadata'))
 
@@ -717,6 +824,9 @@ forecast_blp.add_url_rule(
 forecast_blp.add_url_rule(
     '/cdf/<uuid_str:forecast_id>',
     view_func=CDFForecastGroupMetadataView.as_view('single_cdf_group'))
+forecast_blp.add_url_rule(
+    '/cdf/<uuid_str:forecast_id>/values/gaps',
+    view_func=CDFGroupForecastGapView.as_view('cdf_group_gaps'))
 forecast_blp.add_url_rule(
     '/cdf/single/<uuid_str:forecast_id>',
     view_func=CDFForecastMetadata.as_view('single_cdf_metadata'))
@@ -729,3 +839,6 @@ forecast_blp.add_url_rule(
 forecast_blp.add_url_rule(
     '/cdf/single/<uuid_str:forecast_id>/values/timerange',
     view_func=CDFForecastTimeRangeView.as_view('cdf_time_range'))
+forecast_blp.add_url_rule(
+    '/cdf/single/<uuid_str:forecast_id>/values/gaps',
+    view_func=CDFForecastGapView.as_view('cdf_gaps'))

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -268,7 +268,7 @@ class ObservationValuesView(MethodView):
         if run_validation:
             q = get_queue()
             q.enqueue(
-                tasks.fetch_and_validate_observation,
+                tasks.immediate_observation_validation,
                 HiddenToken(current_access_token),
                 observation_id,
                 observation_df.index[0].isoformat(),

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -420,6 +420,10 @@ class ObservationUnflaggedView(MethodView):
                 int(flag)
             except ValueError:
                 errors['flag'] = 'Flag must be an integer'
+            else:
+                if int(flag) > (2**16 - 1) or int(flag) < 0:
+                    errors['flag'] = ('Flag must be a 2 byte unsigned '
+                                      'integer between 0 and 65535')
         if errors:
             raise BadAPIRequest(errors)
         storage = get_storage()

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -1108,3 +1108,41 @@ class AggregateValuesSchema(ObservationValuesPostSchema):
 class ActionList(ma.Schema):
     object_id = ma.UUID(title="Object UUID")
     actions = ma.List(ma.String(), title="Actions allowed on the object.")
+
+
+class ValueGap(ma.Schema):
+    timestamp = ISODateTime(
+        title='Gap Start Timestamp',
+        description='First timestamp in a gap of values')
+    next_timestamp = ISODateTime(
+        title='Gap End Timestamp',
+        description='Last timestamp in a gap of values')
+
+
+class ValueGapListSchema(ma.Schema):
+    gaps = ma.Nested(ValueGap, many=True,
+                     title='Data Gaps')
+
+
+@spec.define_schema('ForecastValueGap')
+class ForecastGapSchema(ValueGapListSchema):
+    forecast_id = ma.UUID(
+        title="Forecast ID",
+        description="UUID of the forecast associated with this data.")
+
+
+@spec.define_schema('CDFForecastValueGap')
+class CDFForecastGapSchema(ValueGapListSchema):
+    forecast_id = ma.UUID(
+        title="Forecast ID",
+        description=("UUID of the probabilistic forecast constant value"
+                     " associated with this data."))
+
+
+@spec.define_schema('CDFGroupForecastValueGap')
+class CDFGroupForecastGapSchema(ValueGapListSchema):
+    forecast_id = ma.UUID(
+        title="Forecast ID",
+        description=("UUID of the probabilistic forecast associated "
+                     "with this data."))
+

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -1,3 +1,6 @@
+from copy import deepcopy
+
+
 from marshmallow import validate, validates_schema
 from marshmallow.exceptions import ValidationError
 import pandas as pd
@@ -459,6 +462,7 @@ class ObservationUnflaggedSchema(ma.Schema):
                     description=("List of dates that includes data not flagged"
                                  " with the given flag."))
 
+
 # Forecasts
 FORECAST_LINKS = ma.Hyperlinks(
         {
@@ -633,26 +637,34 @@ AXIS_FIELD = ma.String(
     required=True,
     validate=validate.OneOf(['x', 'y'])
 )
+_cdf_links = {
+    'values': ma.AbsoluteURLFor(
+        'forecasts.single_cdf_value',
+        forecast_id='<forecast_id>'),
+    'timerange': ma.AbsoluteURLFor(
+        'forecasts.cdf_time_range',
+        forecast_id='<forecast_id>'),
+    'latest': ma.AbsoluteURLFor(
+        'forecasts.cdf_latest_value',
+        forecast_id='<forecast_id>'),
+    'gaps': ma.AbsoluteURLFor(
+        'forecasts.cdf_gaps',
+        forecast_id='<forecast_id>'),
+}
+_cdf_links_full = deepcopy(_cdf_links)
+_cdf_links_full['probability_forecast_group'] = ma.AbsoluteURLFor(
+    'forecasts.single_cdf_group',
+    forecast_id='<parent>')
 CDF_LINKS = ma.Hyperlinks(
-        {
-            'probability_forecast_group': ma.AbsoluteURLFor(
-                'forecasts.single_cdf_group',
-                forecast_id='<parent>'),
-            'values': ma.AbsoluteURLFor(
-                'forecasts.single_cdf_value',
-                forecast_id='<forecast_id>'),
-            'timerange': ma.AbsoluteURLFor(
-                'forecasts.cdf_time_range',
-                forecast_id='<forecast_id>'),
-            'latest': ma.AbsoluteURLFor(
-                'forecasts.cdf_latest_value',
-                forecast_id='<forecast_id>'),
-            'gaps': ma.AbsoluteURLFor(
-                'forecasts.cdf_gaps',
-                forecast_id='<forecast_id>'),
-        },
-        description="Contains a link to the constant value endpoints."
-    )
+    _cdf_links,
+    name="Probabilistic constant value links",
+    description="Contains a link to the constant value endpoints."
+)
+CDF_LINKS_FULL = ma.Hyperlinks(
+    _cdf_links_full,
+    name="Full probabilistic constant value links",
+    description="Contains a link to the constant value endpoints."
+)
 
 
 @spec.define_schema('CDFForecastTimeRange')
@@ -685,7 +697,7 @@ class CDFForecastGroupPostSchema(ForecastPostSchema):
 
 @spec.define_schema('CDFForecastMetadata')
 class CDFForecastSchema(ForecastSchema):
-    _links = CDF_LINKS
+    _links = CDF_LINKS_FULL
     forecast_id = ma.UUID()
     axis = AXIS_FIELD
     parent = ma.UUID()

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -683,7 +683,7 @@ class CDFForecastGroupSchema(CDFForecastGroupPostSchema):
             'site': ma.AbsoluteURLFor('sites.single',
                                       site_id='<site_id>'),
         },
-        description="Contains a link to the associated site."
+        description="Contains a link to associated endpoints."
     )
     forecast_id = ma.UUID()
     provider = ma.String()
@@ -1093,7 +1093,7 @@ class AggregateLinksSchema(ma.Schema):
 @spec.define_schema('AggregateValues')
 class AggregateValuesSchema(ObservationValuesPostSchema):
     aggregate_id = ma.UUID(
-        title='Obs ID',
+        title='Aggregate ID',
         description="UUID of the Aggregate associated with this data.")
     _links = ma.Hyperlinks(
         {
@@ -1146,3 +1146,15 @@ class CDFGroupForecastGapSchema(ValueGapListSchema):
         description=("UUID of the probabilistic forecast associated "
                      "with this data."))
 
+
+@spec.define_schema('ObservationValueGap')
+class ObservationGapSchema(ValueGapListSchema):
+    observation_id = ma.UUID(title="Observation ID")
+
+
+@spec.define_schema('ObservationUnflagged')
+class ObservationUnflaggedSchema(ma.Schema):
+    observation_id = ma.UUID(title="Observation ID")
+    dates = ma.List(ma.Date, title="Unflagged dates",
+                    description=("List of dates that includes data not flagged"
+                                 " with the given flag."))

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -296,6 +296,20 @@ class ZoneListSchema(ma.Schema):
     )
 
 
+class ValueGap(ma.Schema):
+    timestamp = ISODateTime(
+        title='Gap Start Timestamp',
+        description='First timestamp in a gap of values')
+    next_timestamp = ISODateTime(
+        title='Gap End Timestamp',
+        description='Last timestamp in a gap of values')
+
+
+class ValueGapListSchema(ma.Schema):
+    gaps = ma.Nested(ValueGap, many=True,
+                     title='Data Gaps')
+
+
 # Observations
 @spec.define_schema('ObservationValue')
 class ObservationValueSchema(ma.Schema):
@@ -324,20 +338,31 @@ class ObservationValuesPostSchema(ma.Schema):
     values = TimeseriesField(ObservationValueSchema, many=True)
 
 
-@spec.define_schema('ObservationValues')
-class ObservationValuesSchema(ObservationValuesPostSchema):
-    observation_id = ma.UUID(
-        title='Obs ID',
-        description="UUID of the Observation associated with this data.")
-    _links = ma.Hyperlinks(
+OBSERVATION_LINKS = ma.Hyperlinks(
         {
             'metadata': ma.AbsoluteURLFor('observations.metadata',
                                           observation_id='<observation_id>'),
+            'values': ma.AbsoluteURLFor('observations.values',
+                                        observation_id='<observation_id>'),
             'timerange': ma.AbsoluteURLFor('observations.time_range',
                                            observation_id='<observation_id>'),
+            'latest': ma.AbsoluteURLFor('observations.latest_value',
+                                        observation_id='<observation_id>'),
+            'gaps': ma.AbsoluteURLFor('observations.gaps',
+                                      observation_id='<observation_id>'),
+            'unflagged': ma.AbsoluteURLFor('observations.unflagged',
+                                           observation_id='<observation_id>'),
         },
-        description="Contains a link to the values endpoint."
+        description="Contains a link to the Observation endpoints."
     )
+
+
+@spec.define_schema('ObservationValues')
+class ObservationValuesSchema(ObservationValuesPostSchema):
+    observation_id = ma.UUID(
+        title='Observation ID',
+        description="UUID of the Observation associated with this data.")
+    _links = OBSERVATION_LINKS
 
 
 class TimeRangeSchema(ma.Schema):
@@ -361,6 +386,7 @@ class ObservationTimeRangeSchema(TimeRangeSchema):
     observation_id = ma.UUID(
         title='Obs ID',
         description="UUID of the Observation associated with this data.")
+    _links = OBSERVATION_LINKS
 
 
 @spec.define_schema('ObservationDefinition')
@@ -416,20 +442,41 @@ class ObservationLinksSchema(ma.Schema):
         strict = True
         ordered = True
     observation_id = ma.UUID()
-    _links = ma.Hyperlinks(
+    _links = OBSERVATION_LINKS
+
+
+@spec.define_schema('ObservationValueGap')
+class ObservationGapSchema(ValueGapListSchema):
+    observation_id = ma.UUID(title="Observation ID")
+    _links = OBSERVATION_LINKS
+
+
+@spec.define_schema('ObservationUnflagged')
+class ObservationUnflaggedSchema(ma.Schema):
+    _links = OBSERVATION_LINKS
+    observation_id = ma.UUID(title="Observation ID")
+    dates = ma.List(ma.Date, title="Unflagged dates",
+                    description=("List of dates that includes data not flagged"
+                                 " with the given flag."))
+
+# Forecasts
+FORECAST_LINKS = ma.Hyperlinks(
         {
-            'metadata': ma.AbsoluteURLFor('observations.metadata',
-                                          observation_id='<observation_id>'),
-            'values': ma.AbsoluteURLFor('observations.values',
-                                        observation_id='<observation_id>'),
-            'timerange': ma.AbsoluteURLFor('observations.time_range',
-                                           observation_id='<observation_id>'),
+            'metadata': ma.AbsoluteURLFor('forecasts.metadata',
+                                          forecast_id='<forecast_id>'),
+            'values': ma.AbsoluteURLFor('forecasts.values',
+                                        forecast_id='<forecast_id>'),
+            'timerange': ma.AbsoluteURLFor('forecasts.time_range',
+                                           forecast_id='<forecast_id>'),
+            'latest': ma.AbsoluteURLFor('forecasts.latest_value',
+                                        forecast_id='<forecast_id>'),
+            'gaps': ma.AbsoluteURLFor('forecasts.gaps',
+                                      forecast_id='<forecast_id>'),
         },
-        description="Contains links to the values and metadata endpoints."
+        description="Contains a link to the Forecast endpoints."
     )
 
 
-# Forecasts
 @spec.define_schema('ForecastValue')
 class ForecastValueSchema(ma.Schema):
     class Meta:
@@ -453,36 +500,12 @@ class ForecastValuesPostSchema(ma.Schema):
     values = TimeseriesField(ForecastValueSchema, many=True)
 
 
-@spec.define_schema('CDFForecastValues')
-class CDFForecastValuesSchema(ForecastValuesPostSchema):
-    forecast_id = ma.UUID(
-        title="Forecast ID",
-        description="UUID of the forecast associated with this data.")
-    _links = ma.Hyperlinks(
-        {
-            'metadata': ma.AbsoluteURLFor('forecasts.single_cdf_metadata',
-                                          forecast_id='<forecast_id>'),
-            'timerange': ma.AbsoluteURLFor('forecasts.cdf_time_range',
-                                           forecast_id='<forecast_id>'),
-        },
-        description="Contains a link to the metadata endpoint."
-    )
-
-
 @spec.define_schema('ForecastValues')
 class ForecastValuesSchema(ForecastValuesPostSchema):
     forecast_id = ma.UUID(
         title="Forecast ID",
         description="UUID of the forecast associated with this data.")
-    _links = ma.Hyperlinks(
-        {
-            'metadata': ma.AbsoluteURLFor('forecasts.metadata',
-                                          forecast_id='<forecast_id>'),
-            'timerange': ma.AbsoluteURLFor('forecasts.time_range',
-                                           forecast_id='<forecast_id>'),
-        },
-        description="Contains a link to the metadata endpoint."
-    )
+    _links = FORECAST_LINKS
 
 
 @spec.define_schema('ForecastTimeRange')
@@ -490,14 +513,6 @@ class ForecastTimeRangeSchema(TimeRangeSchema):
     forecast_id = ma.UUID(
         title='Forecast ID',
         description="UUID of the forecast associated with this data.")
-
-
-@spec.define_schema('CDFForecastTimeRange')
-class CDFForecastTimeRangeSchema(TimeRangeSchema):
-    forecast_id = ma.UUID(
-        title='Forecast ID',
-        description=(
-            "UUID of the probabilistic forecast associated with this data."))
 
 
 @spec.define_schema('ForecastDefinition')
@@ -596,17 +611,15 @@ class ForecastLinksSchema(ma.Schema):
         string = True
         ordered = True
     forecast_id = ma.UUID()
-    _links = ma.Hyperlinks(
-        {
-            'metadata': ma.AbsoluteURLFor('forecasts.metadata',
-                                          forecast_id='<forecast_id>'),
-            'values': ma.AbsoluteURLFor('forecasts.values',
-                                        forecast_id='<forecast_id>'),
-            'timerange': ma.AbsoluteURLFor('forecasts.time_range',
-                                           forecast_id='<forecast_id>'),
-        },
-        description="Contains links to the values and metadata endpoints."
-    )
+    _links = FORECAST_LINKS
+
+
+@spec.define_schema('ForecastValueGap')
+class ForecastGapSchema(ValueGapListSchema):
+    forecast_id = ma.UUID(
+        title="Forecast ID",
+        description="UUID of the forecast associated with this data.")
+    _links = FORECAST_LINKS
 
 
 # Probabilistic Forecasts
@@ -620,6 +633,42 @@ AXIS_FIELD = ma.String(
     required=True,
     validate=validate.OneOf(['x', 'y'])
 )
+CDF_LINKS = ma.Hyperlinks(
+        {
+            'probability_forecast_group': ma.AbsoluteURLFor(
+                'forecasts.single_cdf_group',
+                forecast_id='<parent>'),
+            'values': ma.AbsoluteURLFor(
+                'forecasts.single_cdf_value',
+                forecast_id='<forecast_id>'),
+            'timerange': ma.AbsoluteURLFor(
+                'forecasts.cdf_time_range',
+                forecast_id='<forecast_id>'),
+            'latest': ma.AbsoluteURLFor(
+                'forecasts.cdf_latest_value',
+                forecast_id='<forecast_id>'),
+            'gaps': ma.AbsoluteURLFor(
+                'forecasts.cdf_gaps',
+                forecast_id='<forecast_id>'),
+        },
+        description="Contains a link to the constant value endpoints."
+    )
+
+
+@spec.define_schema('CDFForecastTimeRange')
+class CDFForecastTimeRangeSchema(TimeRangeSchema):
+    forecast_id = ma.UUID(
+        title='Forecast ID',
+        description=(
+            "UUID of the probabilistic forecast associated with this data."))
+
+
+@spec.define_schema('CDFForecastValues')
+class CDFForecastValuesSchema(ForecastValuesPostSchema):
+    forecast_id = ma.UUID(
+        title="Forecast ID",
+        description="UUID of the forecast associated with this data.")
+    _links = CDF_LINKS
 
 
 @spec.define_schema('CDFForecastGroupDefinition')
@@ -636,21 +685,7 @@ class CDFForecastGroupPostSchema(ForecastPostSchema):
 
 @spec.define_schema('CDFForecastMetadata')
 class CDFForecastSchema(ForecastSchema):
-    _links = ma.Hyperlinks(
-        {
-            'probability_forecast_group': ma.AbsoluteURLFor(
-                'forecasts.single_cdf_group',
-                forecast_id='<parent>'),
-            'values': ma.AbsoluteURLFor(
-                'forecasts.single_cdf_value',
-                forecast_id='<forecast_id>'),
-            'timerange': ma.AbsoluteURLFor(
-                'forecasts.cdf_time_range',
-                forecast_id='<forecast_id>'),
-        },
-        description=("Contains a link to the associated Probabilistic "
-                     "Forecast Group."),
-    )
+    _links = CDF_LINKS
     forecast_id = ma.UUID()
     axis = AXIS_FIELD
     parent = ma.UUID()
@@ -665,15 +700,7 @@ class CDFForecastSchema(ForecastSchema):
 class CDFForecastSingleSchema(ma.Schema):
     forecast_id = ma.UUID()
     constant_value = ma.Float()
-    _links = ma.Hyperlinks(
-        {
-            'values': ma.AbsoluteURLFor('forecasts.single_cdf_value',
-                                        forecast_id='<forecast_id>'),
-            'timerange': ma.AbsoluteURLFor('forecasts.cdf_time_range',
-                                           forecast_id='<forecast_id>'),
-        },
-        description="Contains a link to the values endpoint."
-    )
+    _links = CDF_LINKS
 
 
 @spec.define_schema('CDFForecastGroupMetadata')
@@ -682,6 +709,8 @@ class CDFForecastGroupSchema(CDFForecastGroupPostSchema):
         {
             'site': ma.AbsoluteURLFor('sites.single',
                                       site_id='<site_id>'),
+            'gaps': ma.AbsoluteURLFor('forecasts.cdf_group_gaps',
+                                      forecast_id='<forecast_id>'),
         },
         description="Contains a link to associated endpoints."
     )
@@ -692,6 +721,24 @@ class CDFForecastGroupSchema(CDFForecastGroupPostSchema):
     modified_at = MODIFIED_AT
 
 
+@spec.define_schema('CDFForecastValueGap')
+class CDFForecastGapSchema(ValueGapListSchema):
+    forecast_id = ma.UUID(
+        title="Forecast ID",
+        description=("UUID of the probabilistic forecast constant value"
+                     " associated with this data."))
+    _links = CDF_LINKS
+
+
+@spec.define_schema('CDFGroupForecastValueGap')
+class CDFGroupForecastGapSchema(ValueGapListSchema):
+    forecast_id = ma.UUID(
+        title="Forecast ID",
+        description=("UUID of the probabilistic forecast associated "
+                     "with this data."))
+
+
+# Permissions
 @spec.define_schema('UserSchema')
 class UserSchema(ma.Schema):
     user_id = ma.UUID(
@@ -1108,53 +1155,3 @@ class AggregateValuesSchema(ObservationValuesPostSchema):
 class ActionList(ma.Schema):
     object_id = ma.UUID(title="Object UUID")
     actions = ma.List(ma.String(), title="Actions allowed on the object.")
-
-
-class ValueGap(ma.Schema):
-    timestamp = ISODateTime(
-        title='Gap Start Timestamp',
-        description='First timestamp in a gap of values')
-    next_timestamp = ISODateTime(
-        title='Gap End Timestamp',
-        description='Last timestamp in a gap of values')
-
-
-class ValueGapListSchema(ma.Schema):
-    gaps = ma.Nested(ValueGap, many=True,
-                     title='Data Gaps')
-
-
-@spec.define_schema('ForecastValueGap')
-class ForecastGapSchema(ValueGapListSchema):
-    forecast_id = ma.UUID(
-        title="Forecast ID",
-        description="UUID of the forecast associated with this data.")
-
-
-@spec.define_schema('CDFForecastValueGap')
-class CDFForecastGapSchema(ValueGapListSchema):
-    forecast_id = ma.UUID(
-        title="Forecast ID",
-        description=("UUID of the probabilistic forecast constant value"
-                     " associated with this data."))
-
-
-@spec.define_schema('CDFGroupForecastValueGap')
-class CDFGroupForecastGapSchema(ValueGapListSchema):
-    forecast_id = ma.UUID(
-        title="Forecast ID",
-        description=("UUID of the probabilistic forecast associated "
-                     "with this data."))
-
-
-@spec.define_schema('ObservationValueGap')
-class ObservationGapSchema(ValueGapListSchema):
-    observation_id = ma.UUID(title="Observation ID")
-
-
-@spec.define_schema('ObservationUnflagged')
-class ObservationUnflaggedSchema(ma.Schema):
-    observation_id = ma.UUID(title="Observation ID")
-    dates = ma.List(ma.Date, title="Unflagged dates",
-                    description=("List of dates that includes data not flagged"
-                                 " with the given flag."))

--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -354,3 +354,91 @@ def test_get_cdf_forecast_timerange_404_obsid(api, observation_id):
     r = api.get(f'/forecasts/cdf/single/{observation_id}/values/timerange',
                 base_url=BASE_URL)
     assert r.status_code == 404
+
+
+def test_get_cdf_forecast_gaps_200(api, cdf_forecast_id, fx_vals, addmayvalues):
+    r = api.get(f'/forecasts/cdf/single/{cdf_forecast_id}/values/gaps',
+                query_string={'start': '2019-04-01T00:00Z',
+                              'end': '2019-06-01T00:00Z'},
+                base_url=BASE_URL)
+    assert r.status_code == 200
+    assert r.mimetype == 'application/json'
+    data = r.get_json()
+    assert '_links' in data
+    assert data['forecast_id'] == cdf_forecast_id
+    assert data['gaps'] == [{'timestamp': '2019-04-17T06:55:00+00:00',
+                             'next_timestamp': '2019-05-01T00:00:00+00:00'}]
+
+
+def test_get_cdf_forecast_gaps_none(api, cdf_forecast_id, addmayvalues):
+    r = api.get(f'/forecasts/cdf/single/{cdf_forecast_id}/values/gaps',
+                query_string={'start': '2019-07-01T00:00Z',
+                              'end': '2019-10-01T00:00Z'},
+                base_url=BASE_URL)
+    assert r.status_code == 200
+    assert r.mimetype == 'application/json'
+    data = r.get_json()
+    assert '_links' in data
+    assert data['forecast_id'] == cdf_forecast_id
+    assert data['gaps'] == []
+
+
+def test_get_cdf_forecast_gaps_404(api, cdf_forecast_group_id, addmayvalues):
+    r = api.get(
+        f'/forecasts/cdf/single/{cdf_forecast_group_id}/values/gaps',
+        query_string={'start': '2019-04-01T00:00Z',
+                      'end': '2019-06-01T00:00Z'},
+        base_url=BASE_URL)
+    assert r.status_code == 404
+
+
+def test_get_forecast_gaps_404_obsid(api, observation_id, addmayvalues):
+    r = api.get(f'/forecasts/cdf/single/{observation_id}/values/gaps',
+                query_string={'start': '2019-04-01T00:00Z',
+                              'end': '2019-06-01T00:00Z'},
+                base_url=BASE_URL)
+    assert r.status_code == 404
+
+
+def test_get_cdf_forecast_group_gaps_200(api, cdf_forecast_group_id, fx_vals,
+                                         addmayvalues):
+    r = api.get(f'/forecasts/cdf/{cdf_forecast_group_id}/values/gaps',
+                query_string={'start': '2019-04-01T00:00Z',
+                              'end': '2019-06-01T00:00Z'},
+                base_url=BASE_URL)
+    assert r.status_code == 200
+    assert r.mimetype == 'application/json'
+    data = r.get_json()
+    assert data['forecast_id'] == cdf_forecast_group_id
+    assert data['gaps'] == [{'timestamp': '2019-04-17T06:55:00+00:00',
+                             'next_timestamp': '2019-05-01T00:00:00+00:00'}]
+
+
+def test_get_cdf_forecast_group_gaps_none(api, cdf_forecast_group_id,
+                                          addmayvalues):
+    r = api.get(f'/forecasts/cdf/{cdf_forecast_group_id}/values/gaps',
+                query_string={'start': '2019-07-01T00:00Z',
+                              'end': '2019-10-01T00:00Z'},
+                base_url=BASE_URL)
+    assert r.status_code == 200
+    assert r.mimetype == 'application/json'
+    data = r.get_json()
+    assert data['forecast_id'] == cdf_forecast_group_id
+    assert data['gaps'] == []
+
+
+def test_get_cdf_forecast_group_gaps_404(api, cdf_forecast_id, addmayvalues):
+    r = api.get(
+        f'/forecasts/cdf/{cdf_forecast_id}/values/gaps',
+        query_string={'start': '2019-04-01T00:00Z',
+                      'end': '2019-06-01T00:00Z'},
+        base_url=BASE_URL)
+    assert r.status_code == 404
+
+
+def test_get_forecast_group_gaps_404_obsid(api, observation_id, addmayvalues):
+    r = api.get(f'/forecasts/cdf/{observation_id}/values/gaps',
+                query_string={'start': '2019-04-01T00:00Z',
+                              'end': '2019-06-01T00:00Z'},
+                base_url=BASE_URL)
+    assert r.status_code == 404

--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -356,7 +356,8 @@ def test_get_cdf_forecast_timerange_404_obsid(api, observation_id):
     assert r.status_code == 404
 
 
-def test_get_cdf_forecast_gaps_200(api, cdf_forecast_id, fx_vals, addmayvalues):
+def test_get_cdf_forecast_gaps_200(api, cdf_forecast_id, fx_vals,
+                                   addmayvalues):
     r = api.get(f'/forecasts/cdf/single/{cdf_forecast_id}/values/gaps',
                 query_string={'start': '2019-04-01T00:00Z',
                               'end': '2019-06-01T00:00Z'},

--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -400,6 +400,13 @@ def test_get_forecast_gaps_404_obsid(api, observation_id, addmayvalues):
     assert r.status_code == 404
 
 
+def test_get_cdf_forecast_gaps_400(api, cdf_forecast_group_id, addmayvalues):
+    r = api.get(
+        f'/forecasts/cdf/single/{cdf_forecast_group_id}/values/gaps',
+        base_url=BASE_URL)
+    assert r.status_code == 400
+
+
 def test_get_cdf_forecast_group_gaps_200(api, cdf_forecast_group_id, fx_vals,
                                          addmayvalues):
     r = api.get(f'/forecasts/cdf/{cdf_forecast_group_id}/values/gaps',
@@ -442,3 +449,10 @@ def test_get_forecast_group_gaps_404_obsid(api, observation_id, addmayvalues):
                               'end': '2019-06-01T00:00Z'},
                 base_url=BASE_URL)
     assert r.status_code == 404
+
+
+def test_get_cdf_forecast_group_gaps_400(api, cdf_forecast_id, addmayvalues):
+    r = api.get(
+        f'/forecasts/cdf/{cdf_forecast_id}/values/gaps',
+        base_url=BASE_URL)
+    assert r.status_code == 400

--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -483,3 +483,11 @@ def test_get_forecast_gaps_404_obsid(api, observation_id, addmayvalues):
                               'end': '2019-06-01T00:00Z'},
                 base_url=BASE_URL)
     assert r.status_code == 404
+
+
+def test_get_forecast_gaps_400(api, inaccessible_forecast_id):
+    r = api.get(
+        f'/forecasts/single/{inaccessible_forecast_id}/values/gaps',
+        query_string={'start': '2019-04-01T00:00Z'},
+        base_url=BASE_URL)
+    assert r.status_code == 400

--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -428,9 +428,9 @@ EVENT_VARIABLE = copy_update(VALID_FORECAST_JSON, 'variable', 'event')
 
 
 @pytest.mark.parametrize('payload,message', [
-    (EVENT_VARIABLE, (f'{{"events":["Both interval_label and variable must be '
+    (EVENT_VARIABLE, ('{"events":["Both interval_label and variable must be '
                       'set to \'event\'."]}')),
-    (EVENT_LABEL, (f'{{"events":["Both interval_label and variable must be '
+    (EVENT_LABEL, ('{"events":["Both interval_label and variable must be '
                    'set to \'event\'."]}')),
 ])
 def test_forecast_post_bad_event(api, payload, message):
@@ -439,3 +439,47 @@ def test_forecast_post_bad_event(api, payload, message):
                  json=payload)
     assert r.status_code == 400
     assert r.get_data(as_text=True) == f'{{"errors":{message}}}\n'
+
+
+def test_get_forecast_gaps_200(api, forecast_id, addmayvalues):
+    r = api.get(f'/forecasts/single/{forecast_id}/values/gaps',
+                query_string={'start': '2019-04-01T00:00Z',
+                              'end': '2019-06-01T00:00Z'},
+                base_url=BASE_URL)
+    assert r.status_code == 200
+    assert r.mimetype == 'application/json'
+    data = r.get_json()
+    assert '_links' in data
+    assert data['forecast_id'] == forecast_id
+    assert data['gaps'] == [{'timestamp': '2019-04-17T06:55:00+00:00',
+                             'next_timestamp': '2019-05-01T00:00:00+00:00'}]
+
+
+def test_get_forecast_gaps_none(api, forecast_id, addmayvalues):
+    r = api.get(f'/forecasts/single/{forecast_id}/values/gaps',
+                query_string={'start': '2019-07-01T00:00Z',
+                              'end': '2019-10-01T00:00Z'},
+                base_url=BASE_URL)
+    assert r.status_code == 200
+    assert r.mimetype == 'application/json'
+    data = r.get_json()
+    assert '_links' in data
+    assert data['forecast_id'] == forecast_id
+    assert data['gaps'] == []
+
+
+def test_get_forecast_gaps_404(api, inaccessible_forecast_id):
+    r = api.get(
+        f'/forecasts/single/{inaccessible_forecast_id}/values/gaps',
+        query_string={'start': '2019-04-01T00:00Z',
+                      'end': '2019-06-01T00:00Z'},
+        base_url=BASE_URL)
+    assert r.status_code == 404
+
+
+def test_get_forecast_gaps_404_obsid(api, observation_id, addmayvalues):
+    r = api.get(f'/forecasts/single/{observation_id}/values/gaps',
+                query_string={'start': '2019-04-01T00:00Z',
+                              'end': '2019-06-01T00:00Z'},
+                base_url=BASE_URL)
+    assert r.status_code == 404

--- a/sfa_api/tests/test_observations.py
+++ b/sfa_api/tests/test_observations.py
@@ -540,6 +540,21 @@ def test_get_observation_unflagged_200_compound_flag(
     assert data['dates'] == ['2019-05-01']
 
 
+def test_get_observation_unflagged_200_flag_limit(
+        api, observation_id, addmayvalues):
+    r = api.get(f'/observations/{observation_id}/values/unflagged',
+                query_string={'start': '2019-05-01T00:00Z',
+                              'end': '2019-06-01T00:00Z',
+                              'flag': 65535},
+                base_url=BASE_URL)
+    assert r.status_code == 200
+    assert r.mimetype == 'application/json'
+    data = r.get_json()
+    assert '_links' in data
+    assert data['observation_id'] == observation_id
+    assert data['dates'] == ['2019-05-01', '2019-05-02']
+
+
 def test_get_observation_unflagged_200_tz(
         api, observation_id, addmayvalues):
     r = api.get(f'/observations/{observation_id}/values/unflagged',
@@ -573,6 +588,8 @@ def test_get_observation_unflagged_none(api, observation_id, addmayvalues):
 
 @pytest.mark.parametrize('qsup,err', [
     ({'flag': 'no'}, 'flag'),
+    ({'flag': 2**17}, 'flag'),
+    ({'flag': -1}, 'flag'),
     ({}, 'flag'),
     ({'flag': 1, 'timezone': 'bad'}, 'timezone'),
     ({'timezone': 'bad'}, 'timezone'),

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -2085,3 +2085,40 @@ def find_climate_zones(latitude, longitude):
     return _call_procedure(
         'find_climate_zones', latitude, longitude,
         with_current_user=False)
+
+
+def find_unflagged_observation_dates(
+        observation_id, start, end, flag, timezone='UTC'):
+    """List the dates between start and end (in timezone) where the observations
+    values are not flagged with the given flag.
+
+    Parameters
+    ----------
+    Parameters
+    ----------
+    observation_id: string
+        UUID of associated observation.
+    start: datetime
+        Beginning of the period for which to request data.
+    end: datetime
+        End of the period for which to request data.
+    flag: int
+        The integer quality flag to check if data has NOT been
+        flagged with
+    timezone: str
+        Timezone to adjust unflagged timestamps before retrieving date
+
+    Returns
+    -------
+    list of datetime.date
+        List of dates that contain observations not flagged
+
+    Raises
+    ------
+    StorageAuthError
+        If the user does not have permission to read values on the Observation
+        or if the Observation does not exists
+    """
+    return [d['date'] for d in _call_procedure(
+        'find_unflagged_observation_dates',
+        observation_id, start, end, flag, timezone)]

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -2094,8 +2094,6 @@ def find_unflagged_observation_dates(
 
     Parameters
     ----------
-    Parameters
-    ----------
     observation_id: string
         UUID of associated observation.
     start: datetime
@@ -2122,3 +2120,117 @@ def find_unflagged_observation_dates(
     return [d['date'] for d in _call_procedure(
         'find_unflagged_observation_dates',
         observation_id, start, end, flag, timezone)]
+
+
+def find_observation_gaps(observation_id, start, end):
+    """Find gaps in the observation values between start and end
+
+    Parameters
+    ----------
+    observation_id: string
+        UUID of associated observation.
+    start: datetime
+        Beginning of the period for which to request data.
+    end: datetime
+        End of the period for which to request data.
+
+    Returns
+    -------
+    list of dicts
+        With keys 'timestamp' and 'next_timestamp' which indicate
+        the range where data is missing.
+
+    Raises
+    ------
+    StorageAuthError
+        If the user does not have permission to read values on the Observation
+        or the user does not have permission to read the Observation metadata
+        or if the Observation does not exists
+    """
+    return _call_procedure('find_observation_gaps', observation_id, start, end)
+
+
+def find_forecast_gaps(forecast_id, start, end):
+    """Find gaps in the forecast values between start and end
+
+    Parameters
+    ----------
+    forecast_id: string
+        UUID of associated forecast.
+    start: datetime
+        Beginning of the period for which to request data.
+    end: datetime
+        End of the period for which to request data.
+
+    Returns
+    -------
+    list of dicts
+        With keys 'timestamp' and 'next_timestamp' which indicate
+        the range where data is missing.
+
+    Raises
+    ------
+    StorageAuthError
+        If the user does not have permission to read values on the Forecast
+        or the user does not have permission to read the Forecast metadata
+        or if the Forecast does not exists
+    """
+    return _call_procedure('find_forecast_gaps', forecast_id, start, end)
+
+
+def find_cdf_forecast_gaps(cdf_forecast_id, start, end):
+    """Find gaps in the single CDF forecast values between start and end
+
+    Parameters
+    ----------
+    cdf_forecast_id: string
+        UUID of associated cdf_forecast.
+    start: datetime
+        Beginning of the period for which to request data.
+    end: datetime
+        End of the period for which to request data.
+
+    Returns
+    -------
+    list of dicts
+        With keys 'timestamp' and 'next_timestamp' which indicate
+        the range where data is missing.
+
+    Raises
+    ------
+    StorageAuthError
+        If the user does not have permission to read values on the CDF Forecast
+        or the user does not have permission to read the CDF Forecast metadata
+        or if the CDF Forecast does not exists
+    """
+    return _call_procedure('find_cdf_single_forecast_gaps', cdf_forecast_id,
+                           start, end)
+
+
+def find_cdf_forecast_group_gaps(cdf_group_id, start, end):
+    """Find gaps in the CDF forecast group values between start and end
+
+    Parameters
+    ----------
+    cdf_group_id: string
+        UUID of associated CDF forecast group.
+    start: datetime
+        Beginning of the period for which to request data.
+    end: datetime
+        End of the period for which to request data.
+
+    Returns
+    -------
+    list of dicts
+        With keys 'timestamp' and 'next_timestamp' which indicate
+        the range where data is missing.
+
+    Raises
+    ------
+    StorageAuthError
+        If the user does not have permission to read values on the CDF Forecast
+        or the user does not have permission to read the CDF Forecast metadata
+        or if the CDF Forecast does not exists
+    """
+    return _call_procedure('find_cdf_forecast_gaps', cdf_group_id,
+                           start, end)

--- a/sfa_api/utils/tests/test_storage_interface.py
+++ b/sfa_api/utils/tests/test_storage_interface.py
@@ -1155,6 +1155,17 @@ def test_read_metadata_for_forecast_values(sql_app, user, nocommit_cursor,
     assert isinstance(ep, str)
 
 
+def test_read_metadata_for_forecast_values_w_obs(
+        sql_app, user, nocommit_cursor):
+    obs = list(demo_observations.values())[0]
+    start = pd.Timestamp('1970-01-02')
+    storage_interface.read_metadata_for_observation_values(
+            obs['observation_id'], start)
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.read_metadata_for_forecast_values(
+            obs['observation_id'], start)
+
+
 def test_read_metadata_for_forecast_values_start(
         sql_app, user, nocommit_cursor):
     forecast = list(demo_forecasts.values())[0]

--- a/sfa_api/utils/tests/test_storage_interface.py
+++ b/sfa_api/utils/tests/test_storage_interface.py
@@ -1909,8 +1909,8 @@ def test_find_forecast_gaps_invalid_forecast(sql_app, user):
             str(uuid.uuid1()), start, end)
 
 
-def test_find_forecast_gaps_invalid_is_fx(sql_app, user,
-                                          observation_id):
+def test_find_forecast_gaps_invalid_is_obs(sql_app, user,
+                                           observation_id):
     start = pd.Timestamp('20190414T1205Z')
     end = pd.Timestamp('20190417T1215Z')
     with pytest.raises(storage_interface.StorageAuthError):
@@ -1945,8 +1945,8 @@ def test_find_cdf_forecast_gaps_invalid_cdf_forecast(sql_app, user):
             str(uuid.uuid1()), start, end)
 
 
-def test_find_cdf_forecast_gaps_invalid_is_fx(sql_app, user,
-                                              observation_id):
+def test_find_cdf_forecast_gaps_invalid_is_obs(sql_app, user,
+                                               observation_id):
     start = pd.Timestamp('20190414T1205Z')
     end = pd.Timestamp('20190417T1215Z')
     with pytest.raises(storage_interface.StorageAuthError):
@@ -1984,8 +1984,8 @@ def test_find_cdf_forecast_group_gaps_invalid_cdf_forecast(sql_app, user):
             str(uuid.uuid1()), start, end)
 
 
-def test_find_cdf_forecast_group_gaps_invalid_is_fx(sql_app, user,
-                                                    observation_id):
+def test_find_cdf_forecast_group_gaps_invalid_is_obs(sql_app, user,
+                                                     observation_id):
     start = pd.Timestamp('20190414T1205Z')
     end = pd.Timestamp('20190417T1215Z')
     with pytest.raises(storage_interface.StorageAuthError):

--- a/sfa_api/utils/tests/test_storage_interface.py
+++ b/sfa_api/utils/tests/test_storage_interface.py
@@ -1805,7 +1805,7 @@ def test_find_zone(sql_app, lat, lon, zones):
 
 @pytest.mark.parametrize('observation_id', demo_observations.keys())
 def test_find_unflagged_observation_dates(sql_app, user, observation_id,
-                                          obs_vals):
+                                          obs_vals, nocommit_cursor):
     start = pd.Timestamp('20190415T1205Z')
     end = pd.Timestamp('20190418T1215Z')
     # more varied qf
@@ -1844,7 +1844,7 @@ def test_read_unflagged_observation_dates_invalid_is_fx(sql_app, user,
 
 
 @pytest.mark.parametrize('observation_id', demo_observations.keys())
-def test_find_observation_gaps(sql_app, user, observation_id):
+def test_find_observation_gaps(sql_app, user, observation_id, nocommit_cursor):
     start = pd.Timestamp('20190413T1205Z')
     end = pd.Timestamp('20190418T1215Z')
     obs_vals = pd.DataFrame({'value': 0, 'quality_flag': 2},
@@ -1878,7 +1878,7 @@ def test_find_observation_gaps_invalid_is_fx(sql_app, user,
 
 
 @pytest.mark.parametrize('forecast_id', demo_forecasts.keys())
-def test_find_forecast_gaps(sql_app, user, forecast_id):
+def test_find_forecast_gaps(sql_app, user, forecast_id, nocommit_cursor):
     start = pd.Timestamp('20180413T1205Z')
     end = pd.Timestamp('20180418T1215Z')
     il = pd.Timedelta(f"{demo_forecasts[forecast_id]['interval_length']}min")
@@ -1912,7 +1912,8 @@ def test_find_forecast_gaps_invalid_is_fx(sql_app, user,
 
 
 @pytest.mark.parametrize('cdf_forecast_id', demo_single_cdf.keys())
-def test_find_cdf_forecast_gaps(sql_app, user, cdf_forecast_id):
+def test_find_cdf_forecast_gaps(sql_app, user, cdf_forecast_id,
+                                nocommit_cursor):
     start = pd.Timestamp('20180413T1205Z')
     end = pd.Timestamp('20180418T1215Z')
     il = pd.Timedelta(
@@ -1947,7 +1948,8 @@ def test_find_cdf_forecast_gaps_invalid_is_fx(sql_app, user,
 
 
 @pytest.mark.parametrize('cdf_group_id', demo_group_cdf.keys())
-def test_find_cdf_forecast_group_gaps(sql_app, user, cdf_group_id):
+def test_find_cdf_forecast_group_gaps(sql_app, user, cdf_group_id,
+                                      nocommit_cursor):
     start = pd.Timestamp('20180413T1205Z')
     end = pd.Timestamp('20180418T1215Z')
     il = pd.Timedelta(

--- a/sfa_api/utils/tests/test_storage_interface.py
+++ b/sfa_api/utils/tests/test_storage_interface.py
@@ -1810,7 +1810,7 @@ def test_find_unflagged_observation_dates(sql_app, user, observation_id,
     end = pd.Timestamp('20190418T1215Z')
     # more varied qf
     obs_vals['quality_flag'] = 2
-    obs_vals.loc[start:start+pd.Timedelta('1d'), 'quality_flag'] |= 8
+    obs_vals.loc[start:start+pd.Timedelta('1d'), 'quality_flag'] |= 12
     storage_interface.store_observation_values(observation_id, obs_vals)
     dates = storage_interface.find_unflagged_observation_dates(
         observation_id, start, end, 8)
@@ -1824,6 +1824,13 @@ def test_find_unflagged_observation_dates(sql_app, user, observation_id,
     dates = storage_interface.find_unflagged_observation_dates(
         observation_id, start, end, 2)
     assert dates == []
+
+    # compound flag
+    dates = storage_interface.find_unflagged_observation_dates(
+        observation_id, start, end, 9)
+    assert dates == [dt.date(2019, 4, 15),
+                     dt.date(2019, 4, 16),
+                     dt.date(2019, 4, 17)]
 
 
 def test_read_unflagged_observation_dates_invalid_observation(sql_app, user):

--- a/sfa_api/utils/tests/test_storage_interface.py
+++ b/sfa_api/utils/tests/test_storage_interface.py
@@ -1841,3 +1841,144 @@ def test_read_unflagged_observation_dates_invalid_is_fx(sql_app, user,
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.find_unflagged_observation_dates(
             forecast_id, start, end, 0)
+
+
+@pytest.mark.parametrize('observation_id', demo_observations.keys())
+def test_find_observation_gaps(sql_app, user, observation_id):
+    start = pd.Timestamp('20190413T1205Z')
+    end = pd.Timestamp('20190418T1215Z')
+    obs_vals = pd.DataFrame({'value': 0, 'quality_flag': 2},
+                            index=[start, start + pd.Timedelta('10min')])
+    storage_interface.store_observation_values(observation_id, obs_vals)
+    ds = storage_interface.find_observation_gaps(observation_id, start, end)
+    assert ds[0]['timestamp'] == start.to_pydatetime()
+    assert ds[0]['next_timestamp'] == (
+        start + pd.Timedelta('10min')).to_pydatetime()
+    assert ds[1]['timestamp'] == (
+        start + pd.Timedelta('10min')).to_pydatetime()
+    assert ds[1]['next_timestamp'] == (
+        pd.Timestamp('20190414T07:00Z')).to_pydatetime()
+
+
+def test_find_observation_gaps_invalid_observation(sql_app, user):
+    start = pd.Timestamp('20190414T1205Z')
+    end = pd.Timestamp('20190417T1215Z')
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.find_observation_gaps(
+            str(uuid.uuid1()), start, end)
+
+
+def test_find_observation_gaps_invalid_is_fx(sql_app, user,
+                                             forecast_id):
+    start = pd.Timestamp('20190414T1205Z')
+    end = pd.Timestamp('20190417T1215Z')
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.find_observation_gaps(
+            forecast_id, start, end)
+
+
+@pytest.mark.parametrize('forecast_id', demo_forecasts.keys())
+def test_find_forecast_gaps(sql_app, user, forecast_id):
+    start = pd.Timestamp('20180413T1205Z')
+    end = pd.Timestamp('20180418T1215Z')
+    il = pd.Timedelta(f"{demo_forecasts[forecast_id]['interval_length']}min")
+    vals = pd.DataFrame({'value': 0},
+                        index=[start, start + 3 * il,
+                               start + 4 * il,
+                               start + 7 * il])
+    storage_interface.store_forecast_values(forecast_id, vals)
+    ds = storage_interface.find_forecast_gaps(forecast_id, start, end)
+    assert ds[0]['timestamp'] == start.to_pydatetime()
+    assert ds[0]['next_timestamp'] == vals.index[1].to_pydatetime()
+    assert ds[1]['timestamp'] == vals.index[2].to_pydatetime()
+    assert ds[1]['next_timestamp'] == vals.index[3].to_pydatetime()
+
+
+def test_find_forecast_gaps_invalid_forecast(sql_app, user):
+    start = pd.Timestamp('20190414T1205Z')
+    end = pd.Timestamp('20190417T1215Z')
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.find_forecast_gaps(
+            str(uuid.uuid1()), start, end)
+
+
+def test_find_forecast_gaps_invalid_is_fx(sql_app, user,
+                                          observation_id):
+    start = pd.Timestamp('20190414T1205Z')
+    end = pd.Timestamp('20190417T1215Z')
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.find_forecast_gaps(
+            observation_id, start, end)
+
+
+@pytest.mark.parametrize('cdf_forecast_id', demo_single_cdf.keys())
+def test_find_cdf_forecast_gaps(sql_app, user, cdf_forecast_id):
+    start = pd.Timestamp('20180413T1205Z')
+    end = pd.Timestamp('20180418T1215Z')
+    il = pd.Timedelta(
+        f"{demo_group_cdf[demo_single_cdf[cdf_forecast_id]['parent']]['interval_length']}min")  # NOQA
+    vals = pd.DataFrame({'value': 0},
+                        index=[start, start + 3 * il,
+                               start + 4 * il,
+                               start + 7 * il])
+    storage_interface.store_cdf_forecast_values(cdf_forecast_id, vals)
+    ds = storage_interface.find_cdf_forecast_gaps(cdf_forecast_id, start, end)
+    assert ds[0]['timestamp'] == start.to_pydatetime()
+    assert ds[0]['next_timestamp'] == vals.index[1].to_pydatetime()
+    assert ds[1]['timestamp'] == vals.index[2].to_pydatetime()
+    assert ds[1]['next_timestamp'] == vals.index[3].to_pydatetime()
+
+
+def test_find_cdf_forecast_gaps_invalid_cdf_forecast(sql_app, user):
+    start = pd.Timestamp('20190414T1205Z')
+    end = pd.Timestamp('20190417T1215Z')
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.find_cdf_forecast_gaps(
+            str(uuid.uuid1()), start, end)
+
+
+def test_find_cdf_forecast_gaps_invalid_is_fx(sql_app, user,
+                                              observation_id):
+    start = pd.Timestamp('20190414T1205Z')
+    end = pd.Timestamp('20190417T1215Z')
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.find_cdf_forecast_gaps(
+            observation_id, start, end)
+
+
+@pytest.mark.parametrize('cdf_group_id', demo_group_cdf.keys())
+def test_find_cdf_forecast_group_gaps(sql_app, user, cdf_group_id):
+    start = pd.Timestamp('20180413T1205Z')
+    end = pd.Timestamp('20180418T1215Z')
+    il = pd.Timedelta(
+        f"{demo_group_cdf[cdf_group_id]['interval_length']}min")  # NOQA
+    vals = pd.DataFrame({'value': 0},
+                        index=[start, start + 3 * il,
+                               start + 4 * il,
+                               start + 7 * il])
+    cdf_forecast_id = [k for k, v in demo_single_cdf.items()
+                       if v['parent'] == cdf_group_id][0]
+    storage_interface.store_cdf_forecast_values(cdf_forecast_id, vals)
+    ds = storage_interface.find_cdf_forecast_group_gaps(
+        cdf_group_id, start, end)
+    assert ds[0]['timestamp'] == start.to_pydatetime()
+    assert ds[0]['next_timestamp'] == vals.index[1].to_pydatetime()
+    assert ds[1]['timestamp'] == vals.index[2].to_pydatetime()
+    assert ds[1]['next_timestamp'] == vals.index[3].to_pydatetime()
+
+
+def test_find_cdf_forecast_group_gaps_invalid_cdf_forecast(sql_app, user):
+    start = pd.Timestamp('20190414T1205Z')
+    end = pd.Timestamp('20190417T1215Z')
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.find_cdf_forecast_group_gaps(
+            str(uuid.uuid1()), start, end)
+
+
+def test_find_cdf_forecast_group_gaps_invalid_is_fx(sql_app, user,
+                                                    observation_id):
+    start = pd.Timestamp('20190414T1205Z')
+    end = pd.Timestamp('20190417T1215Z')
+    with pytest.raises(storage_interface.StorageAuthError):
+        storage_interface.find_cdf_forecast_group_gaps(
+            observation_id, start, end)


### PR DESCRIPTION
- fix issue in read_write_metadata when the object exists and the user has permissions but the object is not the right type, so should raise mysqlerr
- add values/gaps endpoints to, for example, support finding gaps in persistence forecasts that need to be filled
- add /observations//values/unflagged to find days that are not flagged with a given flag to support https://github.com/SolarArbiter/solarforecastarbiter-core/issues/377
- fix up/add _links to many endpoints