### PR TITLE
Add defaults for optional object pair fields

### DIFF
--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -77,8 +77,7 @@ INTERVAL_LABELS = ['beginning', 'ending', 'instant', 'event']
 AGGREGATE_TYPES = ['sum', 'mean', 'median', 'max', 'min']
 INTERVAL_VALUE_TYPES = ['interval_mean', 'interval_max', 'interval_min',
                         'interval_median', 'instantaneous']
-FORECAST_TYPES = ['deterministic_forecast', 'event_forecast',
-                  'probabilistic_forecast',
+FORECAST_TYPES = ['forecast', 'event_forecast', 'probabilistic_forecast',
                   'probabilistic_forecast_constant_value']
 
 EXTRA_PARAMETERS_FIELD = ma.String(

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -77,7 +77,8 @@ INTERVAL_LABELS = ['beginning', 'ending', 'instant', 'event']
 AGGREGATE_TYPES = ['sum', 'mean', 'median', 'max', 'min']
 INTERVAL_VALUE_TYPES = ['interval_mean', 'interval_max', 'interval_min',
                         'interval_median', 'instantaneous']
-FORECAST_TYPES = ['forecast', 'event_forecast', 'probabilistic_forecast',
+FORECAST_TYPES = ['deterministic_forecast', 'event_forecast',
+                  'probabilistic_forecast',
                   'probabilistic_forecast_constant_value']
 
 EXTRA_PARAMETERS_FIELD = ma.String(
@@ -855,7 +856,8 @@ class ReportObjectPair(ma.Schema):
     aggregate = ma.UUID(title="Aggregate UUID")
     reference_forecast = ma.UUID(title="Reference Forecast UUID",
                                  allow_none=True,
-                                 missing=None)
+                                 missing=None,
+                                 default=None)
     uncertainty = ma.String(
         title='Uncertainty',
         description=(
@@ -867,12 +869,14 @@ class ReportObjectPair(ma.Schema):
         allow_none=True,
         missing=None,
         validate=UncertaintyValidator(),
+        default=None,
     )
     forecast_type = ma.String(
         title='Forecast type',
         description='The type of forecast represented in the pair.',
-        missing='forecast',
-        validate=validate.OneOf(FORECAST_TYPES)
+        validate=validate.OneOf(FORECAST_TYPES),
+        default=FORECAST_TYPES[0],
+        missing=FORECAST_TYPES[0],
     )
 
 

--- a/sfa_api/tests/test_schema.py
+++ b/sfa_api/tests/test_schema.py
@@ -51,6 +51,7 @@ def test_object_pair_deserialization(inp):
             bool('aggregate' in deserialized))
     assert deserialized['reference_forecast'] is None
     assert deserialized['uncertainty'] is None
+    assert deserialized['forecast_type'] == 'deterministic_forecast'
 
 
 @pytest.mark.parametrize('inp', [
@@ -63,6 +64,33 @@ def test_object_pair_with_ref(inp):
     assert deserialized['forecast'] == uuid.UUID("11c20780-76ae-4b11-bef1-7a75bdc784e3")  # noqa
     assert deserialized['observation'] == uuid.UUID("123e4567-e89b-12d3-a456-426655440000")  # noqa
     assert deserialized['reference_forecast'] == uuid.UUID("11c20780-76ae-4b11-bef1-7a75bdc784e3")  # noqa
+
+
+@pytest.mark.parametrize('inp', [
+    ({"forecast": "11c20780-76ae-4b11-bef1-7a75bdc784e3",
+      "observation": "123e4567-e89b-12d3-a456-426655440000",
+      "reference_forecast": "11c20780-76ae-4b11-bef1-7a75bdc784e3",
+      "uncertainty": '0.1',
+      "forecast_type": "deteministic_forecast"}),
+])
+def test_object_pair_serialization(inp):
+    dumped = schema.ReportObjectPair().dumps(inp)
+    out = json.loads(dumped)
+    assert out == inp
+
+
+@pytest.mark.parametrize('inp', [
+    ({"forecast": "11c20780-76ae-4b11-bef1-7a75bdc784e3",
+     "observation": "123e4567-e89b-12d3-a456-426655440000"}),
+])
+def test_object_pair_serialization_defaults(inp):
+    dumped = schema.ReportObjectPair().dumps(inp)
+    out = json.loads(dumped)
+    assert out['forecast'] == inp['forecast']
+    assert out['observation'] == inp['observation']
+    assert out['reference_forecast'] is None
+    assert out['uncertainty'] is None
+    assert out['forecast_type'] == 'deterministic_forecast'
 
 
 base_pair_dict = {

--- a/sfa_api/tests/test_schema.py
+++ b/sfa_api/tests/test_schema.py
@@ -51,7 +51,7 @@ def test_object_pair_deserialization(inp):
             bool('aggregate' in deserialized))
     assert deserialized['reference_forecast'] is None
     assert deserialized['uncertainty'] is None
-    assert deserialized['forecast_type'] == 'deterministic_forecast'
+    assert deserialized['forecast_type'] == 'forecast'
 
 
 @pytest.mark.parametrize('inp', [
@@ -71,7 +71,7 @@ def test_object_pair_with_ref(inp):
       "observation": "123e4567-e89b-12d3-a456-426655440000",
       "reference_forecast": "11c20780-76ae-4b11-bef1-7a75bdc784e3",
       "uncertainty": '0.1',
-      "forecast_type": "deteministic_forecast"}),
+      "forecast_type": "forecast"}),
 ])
 def test_object_pair_serialization(inp):
     dumped = schema.ReportObjectPair().dumps(inp)
@@ -90,7 +90,7 @@ def test_object_pair_serialization_defaults(inp):
     assert out['observation'] == inp['observation']
     assert out['reference_forecast'] is None
     assert out['uncertainty'] is None
-    assert out['forecast_type'] == 'deterministic_forecast'
+    assert out['forecast_type'] == 'forecast'
 
 
 base_pair_dict = {
@@ -121,6 +121,19 @@ def test_object_pair_with_uncertainty(uncertainty, exp_type):
 def test_object_pair_with_invalid_uncertainty(uncertainty):
     pair_dict = base_pair_dict.copy()
     pair_dict.update({'uncertainty': uncertainty})
+    pair_json = json.dumps(pair_dict)
+    with pytest.raises(marshmallow.exceptions.ValidationError):
+        schema.ReportObjectPair().loads(pair_json)
+
+
+@pytest.mark.parametrize('forecast_type', [
+    'bad string',
+    'probabilistic',
+    'event',
+])
+def test_object_pair_with_invalid_forecast_type(forecast_type):
+    pair_dict = base_pair_dict.copy()
+    pair_dict.update({'forecast_type': forecast_type})
     pair_json = json.dumps(pair_dict)
     with pytest.raises(marshmallow.exceptions.ValidationError):
         schema.ReportObjectPair().loads(pair_json)


### PR DESCRIPTION
Adds defaults for Report Object pairs so that API responses always contain each field. <s>Also updates the deterministic type value to `deterministic_forecast` as suggested in https://github.com/SolarArbiter/solarforecastarbiter-core/issues/425.</s>  
The defaults are:
uncertainty: None
reference_forecast: None
forecast_type: 'forecast'