### PR TITLE
Enforce max content length

### DIFF
--- a/sfa_api/aggregates.py
+++ b/sfa_api/aggregates.py
@@ -168,6 +168,8 @@ class AggregateValuesView(MethodView):
                   2018-10-29T12:00:00Z,32.93,0
                   2018-10-29T13:00:00Z,25.17,0
 
+          400:
+            $ref: '#/components/responses/400-TimerangeTooLarge'
           401:
             $ref: '#/components/responses/401-Unauthorized'
           404:

--- a/sfa_api/error_handlers.py
+++ b/sfa_api/error_handlers.py
@@ -34,7 +34,7 @@ def entity_too_large_handler(error):
     return jsonify({
         'errors': {
             '413': f'Payload Too Large. Maximum payload size is {max_payload}'
-                    ' bytes.'
+                   ' bytes.'
         }
     }), 413
 

--- a/sfa_api/error_handlers.py
+++ b/sfa_api/error_handlers.py
@@ -1,4 +1,7 @@
-from flask import jsonify
+from flask import jsonify, current_app
+from werkzeug.exceptions import RequestEntityTooLarge
+
+
 from sfa_api.utils.errors import (BaseAPIException, StorageAuthError,
                                   DeleteRestrictionError)
 
@@ -25,8 +28,21 @@ def auth_existence_handler(error):
     return jsonify({'errors': {'404': 'Not Found'}}), 404
 
 
+def entity_too_large_handler(error):
+    """Returns a 413 when the content length exceeds maximum"""
+    max_payload = current_app.config['MAX_CONTENT_LENGTH']
+    return jsonify({
+        'errors': {
+            '413': f'Payload Too Large. Maximum payload size is {max_payload}'
+                    ' bytes.'
+        }
+    }), 413
+
+
 def register_error_handlers(app):
     app.register_error_handler(BaseAPIException, base_error_handler)
     app.register_error_handler(StorageAuthError, auth_existence_handler)
     app.register_error_handler(DeleteRestrictionError,
                                delete_restriction_handler)
+    app.register_error_handler(RequestEntityTooLarge,
+                               entity_too_large_handler)

--- a/sfa_api/forecasts.py
+++ b/sfa_api/forecasts.py
@@ -179,6 +179,8 @@ class ForecastValuesView(MethodView):
                   timestamp,value
                   2018-10-29T12:00:00Z,32.93
                   2018-10-29T13:00:00Z,25.17
+          400:
+            $ref: '#/components/responses/400-TimerangeTooLarge'
           401:
             $ref: '#/components/responses/401-Unauthorized'
           404:
@@ -247,6 +249,8 @@ class ForecastValuesView(MethodView):
             $ref: '#/components/responses/401-Unauthorized'
           404:
             $ref: '#/components/responses/404-NotFound'
+          413:
+            $ref: '#/components/responses/413-PayloadTooLarge'
         """
         forecast_df = validate_parsable_values()
         validate_forecast_values(forecast_df)
@@ -568,6 +572,8 @@ class CDFForecastValues(MethodView):
                   timestamp,value
                   2018-10-29T12:00:00Z,32.93
                   2018-10-29T13:00:00Z,25.17
+          400:
+            $ref: '#/components/responses/400-TimerangeTooLarge'
           401:
             $ref: '#/components/responses/401-Unauthorized'
           404:
@@ -634,6 +640,8 @@ class CDFForecastValues(MethodView):
             $ref: '#/components/responses/401-Unauthorized'
           404:
             $ref: '#/components/responses/404-NotFound'
+          413:
+            $ref: '#/components/responses/413-PayloadTooLarge'
         """
         forecast_df = validate_parsable_values()
         validate_forecast_values(forecast_df)

--- a/sfa_api/observations.py
+++ b/sfa_api/observations.py
@@ -176,6 +176,8 @@ class ObservationValuesView(MethodView):
                   2018-10-29T12:00:00Z,32.93,0
                   2018-10-29T13:00:00Z,25.17,0
 
+          400:
+            $ref: '#/components/responses/400-TimerangeTooLarge'
           401:
             $ref: '#/components/responses/401-Unauthorized'
           404:
@@ -245,6 +247,8 @@ class ObservationValuesView(MethodView):
             $ref: '#/components/responses/401-Unauthorized'
           404:
             $ref: '#/components/responses/404-NotFound'
+          413:
+            $ref: '#/components/responses/413-PayloadTooLarge'
         """
         run_validation = 'donotvalidate' not in request.args
         if run_validation:

--- a/sfa_api/spec.py
+++ b/sfa_api/spec.py
@@ -38,6 +38,12 @@ spec_components = {
         '404-NotFound': {
             'description': 'The resource could not be found.',
         },
+        '413-PayloadTooLarge':{
+            'description': 'Payload exceeds maximum of 16MB.',
+        },
+        '400-TimerangeTooLarge':{
+            'description': 'Requested more than maximum of 1 year of data.',
+        },
     },
     'securitySchemes': {
         'auth0': {

--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -457,3 +457,16 @@ def test_get_cdf_forecast_group_gaps_400(api, cdf_forecast_id, addmayvalues):
         f'/forecasts/cdf/{cdf_forecast_id}/values/gaps',
         base_url=BASE_URL)
     assert r.status_code == 400
+
+
+@pytest.mark.parametrize('content_type,payload', [
+    ('application/json', '{"values": ['+"1"*17*1024*1024+']}'),
+    ('text/csv', 'timestamp,value\n'+"1"*17*1024*1024),
+])
+def test_post_forecast_too_large(
+        api, cdf_forecast_id, content_type, payload):
+    req = api.post(
+            f'/forecasts/cdf/single/{cdf_forecast_id}/values',
+            content_type=content_type,
+            data=payload, base_url=BASE_URL)
+    assert req.status_code == 413

--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -491,3 +491,17 @@ def test_get_forecast_gaps_400(api, inaccessible_forecast_id):
         query_string={'start': '2019-04-01T00:00Z'},
         base_url=BASE_URL)
     assert r.status_code == 400
+
+
+@pytest.mark.parametrize('content_type,payload', [
+    ('application/json', '{"values": ['+"1"*17*1024*1024+']}'),
+    ('text/csv', 'timestamp,value\n'+"1"*17*1024*1024),
+])
+def test_post_forecast_too_large(
+        api, forecast_id, content_type, payload):
+    req = api.post(
+            f'/forecasts/single/{forecast_id}/values',
+            environ_base={'Content-Type': content_type,
+                          'Content-Length': 17*1024*1024},
+            data=payload, base_url=BASE_URL)
+    assert req.status_code == 413

--- a/sfa_api/tests/test_observations.py
+++ b/sfa_api/tests/test_observations.py
@@ -616,3 +616,17 @@ def test_get_observation_unflagged_404_fxid(api, forecast_id, addmayvalues):
                               'flag': 1},
                 base_url=BASE_URL)
     assert r.status_code == 404
+
+
+@pytest.mark.parametrize('content_type,payload', [
+    ('application/json', '{"values": ['+"1"*17*1024*1024+']}'),
+    ('text/csv', 'timestamp,value,quality_flag\n'+"1"*17*1024*1024),
+])
+def test_post_observation_too_large(
+        api, observation_id, content_type, payload):
+    req = api.post(
+            f'/observations/{observation_id}/values',
+            environ_base={'Content-Type': content_type,
+                          'Content-Length': 17*1024*1024},
+            data=payload, base_url=BASE_URL)
+    assert req.status_code == 413

--- a/sfa_api/utils/request_handling.py
+++ b/sfa_api/utils/request_handling.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 from solarforecastarbiter.datamodel import Forecast, Site
 from solarforecastarbiter.reference_forecasts import utils as fx_utils
+from werkzeug.exceptions import RequestEntityTooLarge
 
 
 from sfa_api.utils.errors import (
@@ -231,7 +232,14 @@ def validate_parsable_values():
     ------
     BadAPIRequest
         If the data cannot be parsed.
+    werkzeug.exceptions.RequestEntityTooLarge
+        If the `Content-Length` header is greater than the application's
+        `MAX_CONTENT_LENGTH` config variable.
     """
+    # Default for content length in case of empty body
+    content_length = int(request.headers.get('Content-Length', 0))
+    if (content_length > current_app.config['MAX_CONTENT_LENGTH']):
+        raise RequestEntityTooLarge
     if request.mimetype == 'multipart/form-data':
         decoded_data, mimetype = decode_file_in_request_body()
     else:


### PR DESCRIPTION
Manually enforces maximum content length and responds with a 413. Also adds documentation for the 400 received when exceeding one year of data.