### PR TITLE
Add permissions queries for current user

### DIFF
--- a/datastore/conf/testing.cnf
+++ b/datastore/conf/testing.cnf
@@ -9,3 +9,4 @@ master_verify_checksum=ON
 binlog_checksum=crc32
 # encrypt by default
 default_table_encryption=ON
+sort_buffer_size=512K

--- a/datastore/migrations/0046_permissions_queries.down.sql
+++ b/datastore/migrations/0046_permissions_queries.down.sql
@@ -1,0 +1,2 @@
+DROP PROCEDURE get_user_create_permissions;
+DROP PROCEDURE list_actions_on_all_objects_of_type

--- a/datastore/migrations/0046_permissions_queries.down.sql
+++ b/datastore/migrations/0046_permissions_queries.down.sql
@@ -1,2 +1,2 @@
-DROP PROCEDURE get_user_create_permissions;
+DROP PROCEDURE get_user_creatable_types;
 DROP PROCEDURE list_actions_on_all_objects_of_type

--- a/datastore/migrations/0046_permissions_queries.up.sql
+++ b/datastore/migrations/0046_permissions_queries.up.sql
@@ -4,10 +4,12 @@ COMMENT 'Get a list of object types the user can create'
 READS SQL DATA SQL SECURITY DEFINER
 BEGIN
     DECLARE userid BINARY(16);
-    SET userid = (SELECT id FROM users WHERE auth0_id = auth0id);
+    DECLARE orgid BINARY(16);
 
-    SELECT DISTINCT(perm.object_type) from permissions as perm
-    WHERE action = 'create' AND perm.id IN(
+    SELECT id, organization_id INTO userid, orgid FROM users WHERE auth0_id = auth0id;
+
+    SELECT DISTINCT(object_type) from permissions
+    WHERE action = 'create' AND organization_id = orgid AND id IN(
         SELECT permission_id FROM role_permission_mapping
         WHERE role_id IN(
             SELECT role_id FROM user_role_mapping
@@ -38,7 +40,7 @@ BEGIN
 				FROM user_role_mapping
 				WHERE user_id = userid
 			)
-		) group by permission_objecct_mapping.object_id;
+		) group by permission_object_mapping.object_id;
 END;
 
 GRANT EXECUTE ON PROCEDURE list_actions_on_all_objects_of_type TO 'select_rbac'@'localhost';

--- a/datastore/migrations/0046_permissions_queries.up.sql
+++ b/datastore/migrations/0046_permissions_queries.up.sql
@@ -27,7 +27,7 @@ BEGIN
     DECLARE userid BINARY(16);
     SET userid = (SELECT id FROM users WHERE auth0_id = auth0id);
 
-	SELECT dt.id, json_arrayagg(dt.action) AS actions FROM (
+	SELECT dt.id as object_id, json_arrayagg(dt.action) AS actions FROM (
 		SELECT DISTINCT bin_to_uuid(object_id, 1) as id, action
 		FROM permission_object_mapping
         INNER JOIN permissions ON (permission_object_mapping.permission_id=permissions.id)

--- a/datastore/migrations/0046_permissions_queries.up.sql
+++ b/datastore/migrations/0046_permissions_queries.up.sql
@@ -1,0 +1,48 @@
+CREATE DEFINER = 'select_rbac'@'localhost' PROCEDURE get_user_create_permissions(
+    IN auth0id VARCHAR(32))
+COMMENT 'Get a list of object types the user can create'
+READS SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE userid BINARY(16);
+    SET userid = (SELECT id FROM users WHERE auth0_id = auth0id);
+
+    SELECT DISTINCT(perm.object_type) from permissions as perm
+    WHERE action = 'create' AND perm.id IN(
+        SELECT permission_id FROM role_permission_mapping
+        WHERE role_id IN(
+            SELECT role_id FROM user_role_mapping
+            WHERE user_id = userid)
+        );
+END;
+
+GRANT EXECUTE ON PROCEDURE get_user_create_permissions TO 'select_rbac'@'localhost';
+GRANT EXECUTE ON PROCEDURE get_user_create_permissions TO 'apiuser'@'%';
+
+
+CREATE DEFINER = 'select_rbac'@'localhost' PROCEDURE list_actions_on_all_objects_of_type(
+    IN auth0id VARCHAR(32), IN objecttype VARCHAR(32))
+COMMENT 'List the uuids and actions users can take on all objects of a given type'
+READS SQL DATA SQL SECURITY DEFINER
+BEGIN
+    DECLARE userid BINARY(16);
+    SET userid = (SELECT id FROM users WHERE auth0_id = auth0id);
+
+	SELECT id, json_arrayagg(action) AS actions FROM (
+		SELECT DISTINCT bin_to_uuid(object_id, 1) as id, action
+		FROM permission_object_mapping
+		JOIN permissions
+		WHERE object_type=objecttype AND permission_id IN(
+			SELECT permission_id
+			FROM role_permission_mapping
+			WHERE role_id in (
+				SELECT role_id
+				FROM user_role_mapping
+				WHERE user_id = userid
+			)
+		)
+	) as dt group by id;
+END;
+
+GRANT EXECUTE ON PROCEDURE list_actions_on_all_objects_of_type TO 'select_rbac'@'localhost';
+GRANT EXECUTE ON PROCEDURE list_actions_on_all_objects_of_type TO 'apiuser'@'%';
+

--- a/datastore/migrations/0046_permissions_queries.up.sql
+++ b/datastore/migrations/0046_permissions_queries.up.sql
@@ -1,4 +1,4 @@
-CREATE DEFINER = 'select_rbac'@'localhost' PROCEDURE get_user_create_permissions(
+CREATE DEFINER = 'select_rbac'@'localhost' PROCEDURE get_user_creatable_types(
     IN auth0id VARCHAR(32))
 COMMENT 'Get a list of object types the user can create'
 READS SQL DATA SQL SECURITY DEFINER
@@ -15,8 +15,8 @@ BEGIN
         );
 END;
 
-GRANT EXECUTE ON PROCEDURE get_user_create_permissions TO 'select_rbac'@'localhost';
-GRANT EXECUTE ON PROCEDURE get_user_create_permissions TO 'apiuser'@'%';
+GRANT EXECUTE ON PROCEDURE get_user_creatable_types TO 'select_rbac'@'localhost';
+GRANT EXECUTE ON PROCEDURE get_user_creatable_types TO 'apiuser'@'%';
 
 
 CREATE DEFINER = 'select_rbac'@'localhost' PROCEDURE list_actions_on_all_objects_of_type(

--- a/datastore/migrations/0046_permissions_queries.up.sql
+++ b/datastore/migrations/0046_permissions_queries.up.sql
@@ -27,10 +27,10 @@ BEGIN
     DECLARE userid BINARY(16);
     SET userid = (SELECT id FROM users WHERE auth0_id = auth0id);
 
-	SELECT id, json_arrayagg(action) AS actions FROM (
+	SELECT dt.id, json_arrayagg(dt.action) AS actions FROM (
 		SELECT DISTINCT bin_to_uuid(object_id, 1) as id, action
 		FROM permission_object_mapping
-		JOIN permissions
+        INNER JOIN permissions ON (permission_object_mapping.permission_id=permissions.id)
 		WHERE object_type=objecttype AND permission_id IN(
 			SELECT permission_id
 			FROM role_permission_mapping

--- a/datastore/tests/test_reads.py
+++ b/datastore/tests/test_reads.py
@@ -2306,13 +2306,13 @@ def object_combinations():
 
 
 @pytest.mark.parametrize('object_types', object_combinations())
-def test_get_user_create_permissions(
+def test_get_user_creatable_types(
         cursor, insertuser, add_perm, object_types):
     cursor.execute('DELETE FROM permissions WHERE action = "create"')
     for object_type in object_types:
         add_perm('create', object_type)
     auth0id = insertuser[0]['auth0_id']
-    cursor.callproc('get_user_create_permissions', (auth0id,))
+    cursor.callproc('get_user_creatable_types', (auth0id,))
     create_perms = cursor.fetchall()
     assert tuple([tup[0] for tup in create_perms]) == object_types
 

--- a/datastore/tests/test_reads.py
+++ b/datastore/tests/test_reads.py
@@ -3,6 +3,7 @@ import datetime as dt
 import itertools
 import json
 import random
+import unittest
 
 
 import pytest
@@ -1574,14 +1575,14 @@ def action_combinations():
         combos = combos + list(itertools.combinations(all_actions, i))
     return combos
 
-@pytest.mark.parametrize('granted', action_combinations())  
+@pytest.mark.parametrize('granted', action_combinations())
 def test_get_user_actions_on_object(
         dictcursor, user_org_role, new_role, add_perm, granted):
     user, org, _ = user_org_role
     auth0id = user['auth0_id']
     role = new_role(org=org)
     role_id = bin_to_uuid(role['id'])
-    
+
     for action in granted:
         add_perm(action, 'roles')
 
@@ -2250,7 +2251,7 @@ def test_find_cdf_forecast_gaps(
     assert out[0] == (start, mid)
     assert out[1] == (mid, inter)
     assert out[2] == (inter, fin)
-    
+
     # single value
     start = start + dt.timedelta(days=30)
     for sid in insertuser.cdf['constant_values'].keys():
@@ -2291,3 +2292,106 @@ def test_find_cdf_forecast_gaps_is_obs(
         cursor.callproc('find_cdf_forecast_gaps',
                         (auth0id, obsid, start, end))
     assert e.value.args[0] == 1142
+
+
+all_object_types = ['forecasts', 'observations', 'cdf_forecasts',
+                    'aggregates', 'reports', 'users', 'permissions', 'roles']
+
+
+def object_combinations():
+    combos = []
+    for i in range(1, 9):
+        combos = combos + list(itertools.combinations(all_object_types, i))
+    return combos
+
+
+@pytest.mark.parametrize('object_types', object_combinations())
+def test_get_user_create_permissions(
+        cursor, insertuser, add_perm, object_types):
+    cursor.execute('DELETE FROM permissions WHERE action = "create"')
+    for object_type in object_types:
+        add_perm('create', object_type)
+    auth0id = insertuser[0]['auth0_id']
+    cursor.callproc('get_user_create_permissions', (auth0id,))
+    create_perms = cursor.fetchall()
+    assert tuple([tup[0] for tup in create_perms]) == object_types
+
+
+@pytest.fixture(params=['forecasts', 'observations', 'cdf_forecasts',
+                        'aggregates', 'reports', 'users', 'permissions',
+                        'roles', 'users'])
+def perm_object_type(request):
+    return request.param
+
+
+@pytest.fixture(params=action_combinations()[::10])
+def generate_object_and_perms(
+        request, cursor, getfcn, user_org_role, new_permission):
+    new_func, object_type = getfcn
+    _, _, role = user_org_role
+
+    cursor.execute('DELETE FROM permissions')
+
+    new_obj = new_func()
+    all_actions = list(request.param)
+    object_id = bin_to_uuid(new_obj['id'])
+    for action in request.param:
+        new_perm = new_permission(action, object_type, False)
+        cursor.execute(
+            'INSERT INTO permission_object_mapping (permission_id, object_id) '
+            'VALUES (%s, %s)', (new_perm['id'], new_obj['id']))
+        cursor.execute(
+            'INSERT INTO role_permission_mapping (role_id, permission_id) '
+            'VALUES (%s, %s)', (role['id'], new_perm['id']))
+    return object_type, object_id, all_actions
+
+
+def test_list_actions_on_all_objects_of_type(
+        dictcursor, user_org_role, generate_object_and_perms):
+    auth0id = user_org_role[0]['auth0_id']
+
+    object_type, object_id, actions = generate_object_and_perms
+    dictcursor.callproc('list_actions_on_all_objects_of_type',
+                        (auth0id, object_type))
+    result = dictcursor.fetchall()
+
+    the_object = result[0]
+    assert the_object['id'] == object_id
+    assert json.loads(the_object['actions']).sort() == (actions).sort()
+
+
+@pytest.fixture
+def make_lots_of_one_thing(cursor, getfcn, user_org_role, new_permission):
+    _, org, role = user_org_role
+
+    action_sets = action_combinations()[::random.randint(5, 10)][5:]
+    new_func, object_type = getfcn
+    the_objects = {}
+
+    for i in range(0, random.randint(5, 10)):
+        new_obj = new_func()
+        actions_on_new_obj = list(action_sets[i])
+        for action in actions_on_new_obj:
+            new_perm = new_permission(action, object_type, False, org)
+            cursor.execute(
+                'INSERT INTO permission_object_mapping (permission_id, '
+                'object_id) VALUES (%s, %s)', (new_perm['id'], new_obj['id']))
+            cursor.execute(
+                'INSERT INTO role_permission_mapping (role_id, permission_id) '
+                'VALUES (%s, %s)', (role['id'], new_perm['id']))
+        the_objects[bin_to_uuid(new_obj['id'])] = actions_on_new_obj.sort()
+    return the_objects, object_type
+
+
+def test_list_actions_on_all_objects_of_type_multiple_objects(
+        dictcursor, user_org_role, make_lots_of_one_thing):
+    auth0id = user_org_role[0]['auth0_id']
+
+    objects, object_type = make_lots_of_one_thing
+    dictcursor.callproc('list_actions_on_all_objects_of_type',
+                        (auth0id, object_type))
+    result = dictcursor.fetchall()
+    id_action_dict = {res['id']: json.loads(res['actions']).sort()
+                      for res in result}
+    for k, v in objects.items():
+        assert id_action_dict[k] == v

--- a/datastore/tests/test_reads.py
+++ b/datastore/tests/test_reads.py
@@ -2316,13 +2316,6 @@ def test_get_user_creatable_types(
     assert tuple([tup[0] for tup in create_perms]) == object_types
 
 
-@pytest.fixture(params=['forecasts', 'observations', 'cdf_forecasts',
-                        'aggregates', 'reports', 'users', 'permissions',
-                        'roles', 'users'])
-def perm_object_type(request):
-    return request.param
-
-
 @pytest.fixture(params=action_combinations()[::10])
 def generate_object_and_perms(
         request, cursor, getfcn, user_org_role, new_permission):

--- a/datastore/tests/test_reads.py
+++ b/datastore/tests/test_reads.py
@@ -2356,7 +2356,7 @@ def test_list_actions_on_all_objects_of_type(
     result = dictcursor.fetchall()
 
     the_object = result[0]
-    assert the_object['id'] == object_id
+    assert the_object['object_id'] == object_id
     assert json.loads(the_object['actions']).sort() == (actions).sort()
 
 
@@ -2392,7 +2392,7 @@ def test_list_actions_on_all_objects_of_type_multiple_objects(
                         (auth0id, object_type))
     result = dictcursor.fetchall()
     assert len(result) == 7
-    id_action_dict = {res['id']: json.loads(res['actions']).sort()
+    id_action_dict = {res['object_id']: json.loads(res['actions']).sort()
                       for res in result}
     for k, v in objects.items():
         assert id_action_dict[k] == v

--- a/datastore/tests/test_reads.py
+++ b/datastore/tests/test_reads.py
@@ -3,7 +3,6 @@ import datetime as dt
 import itertools
 import json
 import random
-import unittest
 
 
 import pytest

--- a/datastore/tests/test_reads.py
+++ b/datastore/tests/test_reads.py
@@ -2391,6 +2391,7 @@ def test_list_actions_on_all_objects_of_type_multiple_objects(
     dictcursor.callproc('list_actions_on_all_objects_of_type',
                         (auth0id, object_type))
     result = dictcursor.fetchall()
+    assert len(result) == 7
     id_action_dict = {res['id']: json.loads(res['actions']).sort()
                       for res in result}
     for k, v in objects.items():

--- a/datastore/tests/test_reads.py
+++ b/datastore/tests/test_reads.py
@@ -2364,11 +2364,11 @@ def test_list_actions_on_all_objects_of_type(
 def make_lots_of_one_thing(cursor, getfcn, user_org_role, new_permission):
     _, org, role = user_org_role
 
-    action_sets = action_combinations()[::random.randint(5, 10)][5:]
+    action_sets = action_combinations()[::7][5:]
     new_func, object_type = getfcn
     the_objects = {}
 
-    for i in range(0, random.randint(5, 10)):
+    for i in range(0, 7):
         new_obj = new_func()
         actions_on_new_obj = list(action_sets[i])
         for action in actions_on_new_obj:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pyyaml
 pymysql==0.9.3
 sqlalchemy
 redis
-rq
+rq==1.4.3
 rq_scheduler
 fakeredis>=1.1.1
 sentry_sdk

--- a/sfa_api/conftest.py
+++ b/sfa_api/conftest.py
@@ -2119,3 +2119,13 @@ def addmayvalues(root_cursor):
         "INSERT INTO cdf_forecasts_values (id, timestamp, value) "
         "SELECT id, '2019-05-01 00:00', 1.0 FROM cdf_forecasts_singles"
     )
+
+
+def _get_large_test_payload(content_type):
+    """Produces a large test payload, to avoid having pytest output print the
+    contents of a fixture.
+    """
+    if content_type == 'text/csv':
+        return 'timestamp,value\n'+"1"*17*1024*1024
+    else:
+        return '{"values": ['+"1"*17*1024*1024+']}'

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -1449,3 +1449,17 @@ class AggregateValuesSchema(ObservationValuesPostSchema):
 class ActionList(ma.Schema):
     object_id = ma.UUID(title="Object UUID")
     actions = ma.List(ma.String(), title="Actions allowed on the object.")
+
+
+@spec.define_schema('ActionsOnTypeList')
+class ActionsOnTypeList(ma.Schema):
+    """Only used for documentation"""
+    object_type = ma.String(validate=validate.OneOf(ALLOWED_OBJECT_TYPES))
+    objects = ma.Nested(ActionList, many=True)
+
+
+@spec.define_schema('UserCreatePerms')
+class UserCreatePerms(ma.Schema):
+    """Only used for documentation"""
+    can_create = ma.List(
+        ma.String(validate=validate.OneOf(ALLOWED_OBJECT_TYPES)))

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -23,6 +23,10 @@ ALLOWED_METRICS.update(ALLOWED_DETERMINISTIC_METRICS)
 ALLOWED_METRICS.update(ALLOWED_EVENT_METRICS)
 ALLOWED_METRICS.update(ALLOWED_PROBABILISTIC_METRICS)
 
+ALLOWED_OBJECT_TYPES = ['sites', 'aggregates', 'forecasts', 'observations',
+                        'users', 'roles', 'permissions', 'cdf_forecasts',
+                        'reports']
+
 
 class ISODateTime(ma.AwareDateTime):
     """
@@ -788,9 +792,7 @@ class PermissionPostSchema(ma.Schema):
         title="Object Type",
         description="The type of object this permission will act on.",
         required=True,
-        validate=validate.OneOf(['sites', 'aggregates', 'forecasts',
-                                 'observations', 'users', 'roles',
-                                 'permissions', 'cdf_forecasts', 'reports']),
+        validate=validate.OneOf(ALLOWED_OBJECT_TYPES),
     )
     applies_to_all = ma.Boolean(
         title="Applies to all",

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -1453,13 +1453,20 @@ class ActionList(ma.Schema):
 
 @spec.define_schema('ActionsOnTypeList')
 class ActionsOnTypeList(ma.Schema):
-    """Only used for documentation"""
-    object_type = ma.String(validate=validate.OneOf(ALLOWED_OBJECT_TYPES))
-    objects = ma.Nested(ActionList, many=True)
+    object_type = ma.String(
+        title="Object type",
+        description="Type of objects included in `objects` field.",
+        validate=validate.OneOf(ALLOWED_OBJECT_TYPES))
+    objects = ma.Nested(
+        ActionList,
+        tite="Objects",
+        description="List of object uuids and allowed actions.",
+        many=True)
 
 
 @spec.define_schema('UserCreatePerms')
 class UserCreatePerms(ma.Schema):
-    """Only used for documentation"""
     can_create = ma.List(
-        ma.String(validate=validate.OneOf(ALLOWED_OBJECT_TYPES)))
+        ma.String(validate=validate.OneOf(ALLOWED_OBJECT_TYPES)),
+        title="Can create",
+        description="List of types of objects the user can create.")

--- a/sfa_api/tests/rbac/test_users.py
+++ b/sfa_api/tests/rbac/test_users.py
@@ -266,3 +266,97 @@ def test_get_user_actions_on_object_404_no_permissions(
     remove_perms_from_current_role(res.json['actions'][-1], 'forecasts')
     res = api.get(f'/users/actions-on/{forecast_id}', BASE_URL)
     assert res.status_code == 404
+
+
+all_object_types = ['sites', 'aggregates', 'cdf_forecasts', 'forecasts',
+                    'observations', 'roles', 'permissions', 'reports']
+
+
+@pytest.mark.parametrize('to_remove', [
+    ['sites'],
+    ['forecasts'],
+    ['roles', 'permissions'],
+    ['forecasts', 'observations', 'aggregates', 'reports'],
+])
+def test_get_user_create_permissions(
+        api, to_remove, remove_perms_from_current_role):
+    for otype in to_remove:
+        remove_perms_from_current_role('create', otype)
+    res = api.get(f'/users/can-create/', BASE_URL)
+    expected_types = [otype for otype in all_object_types
+                      if otype not in to_remove]
+    assert res.json == {'can_create': expected_types}
+
+
+@pytest.mark.parametrize('object_type,expected_actions', [
+    ('observations', ['create', 'read', 'delete', 'read_values',
+                      'write_values', 'delete_values']),
+    ('forecasts', ['create', 'read', 'delete', 'read_values', 'write_values',
+                   'delete_values']),
+    ('cdf_forecasts', ['create', 'read', 'update', 'delete', 'read_values',
+                       'write_values', 'delete_values']),
+    ('roles', ['create', 'read', 'update', 'delete', 'grant', 'revoke']),
+    ('permissions', ['create', 'read', 'update', 'delete']),
+    ('users', ['read', 'update']),
+    ('reports', ['create', 'read', 'update', 'delete', 'read_values',
+                 'write_values']),
+])
+def test_get_user_actions_on_type(
+        api, object_type, expected_actions):
+    res = api.get(f'/users/actions-on-type/{object_type}', BASE_URL)
+    objects = res.json[f'{object_type}']
+    for object_id, actions in objects.items():
+        assert actions == expected_actions
+
+
+@pytest.mark.parametrize('object_type,expected_actions', [
+    ('observations', ['create', 'read', 'delete', 'read_values',
+                      'write_values', 'delete_values']),
+    ('forecasts', ['create', 'read', 'delete', 'read_values', 'write_values',
+                   'delete_values']),
+    ('aggregates', ['create', 'read', 'update', 'delete', 'read_values',
+                    'write_values', 'delete_values']),
+    ('cdf_forecasts', ['create', 'read', 'update', 'delete', 'read_values',
+                       'write_values', 'delete_values']),
+    ('roles', ['create', 'grant', 'revoke', 'delete',  'read']),
+    ('permissions', ['create', 'delete', 'update', 'read']),
+    ('users', ['read', 'update']),
+    ('reports', ['create', 'read', 'update', 'delete', 'read_values',
+                 'write_values']),
+])
+def test_get_user_actions_on_type_minimum_test_perms(
+        api, object_type, expected_actions, remove_all_perms, orgid):
+    if object_type == 'cdf_forecasts':
+        id_key = 'forecast_id'
+        listing_path = '/forecasts/cdf/'
+    else:
+        if object_type == 'forecasts':
+            listing_path = '/forecasts/single/'
+        else:
+            listing_path = f'/{object_type}/'
+        id_key = f'{object_type[:-1]}_id'
+
+    listing = api.get(listing_path, BASE_URL).json
+    all_objects = {o[id_key]: o for o in listing}
+
+    for action in expected_actions:
+        remove_all_perms(action, object_type)
+    res = api.get(f'/users/actions-on-type/{object_type}', BASE_URL)
+    objects = res.json[f'{object_type}']
+
+    for k, v in objects.items():
+        the_object = all_objects[k]
+        org = the_object.get('provider', the_object.get('organization', None))
+        if object_type == 'roles':
+            # can't test roles for update, becasue removing it causes perm
+            # removal to fail, and resets the nocommit cursor so instead test
+            # that only these minimal permissions remain.
+            assert v == ['update']
+            assert the_object['name'] in [
+                'Test user role',
+                'Read Weather Station',
+                'DEFAULT User role 0c90950a-7cca-11e9-a81f-54bf64606445']
+        else:
+            for action in v:
+                assert action in ['read', 'read_values']
+                assert org == 'Reference'

--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -460,11 +460,13 @@ def test_get_cdf_forecast_group_gaps_400(api, cdf_forecast_id, addmayvalues):
 
 
 @pytest.mark.parametrize('content_type,payload', [
-    ('application/json', '{"values": ['+"1"*17*1024*1024+']}'),
-    ('text/csv', 'timestamp,value\n'+"1"*17*1024*1024),
+    ('application/json', '{"values": [1, 2]}'),
+    ('text/csv', 'timestamp,value\n1,2'),
 ])
 def test_post_forecast_too_large(
-        api, cdf_forecast_id, content_type, payload):
+        api, cdf_forecast_id, content_type, payload, mocker):
+    req_headers = mocker.patch('sfa_api.utils.request_handling.request')
+    req_headers.headers = {'Content-Length': 17*1024*1024}
     req = api.post(
             f'/forecasts/cdf/single/{cdf_forecast_id}/values',
             content_type=content_type,

--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -6,7 +6,8 @@ from sfa_api.conftest import (variables, interval_value_types, interval_labels,
                               BASE_URL, VALID_CDF_FORECAST_JSON, copy_update,
                               VALID_FX_VALUE_JSON, VALID_CDF_VALUE_CSV,
                               VALID_CDF_FORECAST_AGG_JSON,
-                              UNSORTED_FX_VALUE_JSON, ADJ_FX_VALUE_JSON)
+                              UNSORTED_FX_VALUE_JSON, ADJ_FX_VALUE_JSON,
+                              _get_large_test_payload)
 
 
 INVALID_NAME = copy_update(VALID_CDF_FORECAST_JSON, 'name', '@drain')
@@ -463,10 +464,24 @@ def test_get_cdf_forecast_group_gaps_400(api, cdf_forecast_id, addmayvalues):
     ('application/json', '{"values": [1, 2]}'),
     ('text/csv', 'timestamp,value\n1,2'),
 ])
-def test_post_forecast_too_large(
+def test_post_forecast_too_large_from_header(
         api, cdf_forecast_id, content_type, payload, mocker):
     req_headers = mocker.patch('sfa_api.utils.request_handling.request')
     req_headers.headers = {'Content-Length': 17*1024*1024}
+    req = api.post(
+            f'/forecasts/cdf/single/{cdf_forecast_id}/values',
+            content_type=content_type,
+            data=payload, base_url=BASE_URL)
+    assert req.status_code == 413
+
+
+@pytest.mark.parametrize('content_type', [
+    'application/json',
+    'text/csv',
+])
+def test_post_forecast_too_large_from_body(
+        api, cdf_forecast_id, content_type, mocker):
+    payload = _get_large_test_payload(content_type)
     req = api.post(
             f'/forecasts/cdf/single/{cdf_forecast_id}/values',
             content_type=content_type,

--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -6,7 +6,8 @@ from sfa_api.conftest import (variables, interval_value_types, interval_labels,
                               BASE_URL, VALID_FORECAST_JSON, copy_update,
                               VALID_FX_VALUE_JSON, VALID_FX_VALUE_CSV,
                               VALID_FORECAST_AGG_JSON, UNSORTED_FX_VALUE_JSON,
-                              ADJ_FX_VALUE_JSON, demo_forecasts)
+                              ADJ_FX_VALUE_JSON, demo_forecasts,
+                              _get_large_test_payload)
 from sfa_api.utils.storage_interface import POWER_VARIABLES
 
 
@@ -498,7 +499,7 @@ def test_get_forecast_gaps_400(api, inaccessible_forecast_id):
     ('application/json', '{"values": [1, 2]}'),
     ('text/csv', 'timestamp,value\n'+"1,2"),
 ])
-def test_post_forecast_too_large(
+def test_post_forecast_too_large_from_header(
         api, forecast_id, content_type, payload, mocker):
     req_headers = mocker.patch('sfa_api.utils.request_handling.request')
     req_headers.headers = {'Content-Length': 17*1024*1024}
@@ -506,6 +507,20 @@ def test_post_forecast_too_large(
             f'/forecasts/single/{forecast_id}/values',
             environ_base={'Content-Type': content_type,
                           'Content-Length': 17*1024*1024},
+            data=payload, base_url=BASE_URL)
+    assert req.status_code == 413
+
+
+@pytest.mark.parametrize('content_type', [
+    'application/json',
+    'text/csv',
+])
+def test_post_forecast_too_large_from_body(
+        api, forecast_id, content_type, mocker):
+    payload = _get_large_test_payload(content_type)
+    req = api.post(
+            f'/forecasts/single/{forecast_id}/values',
+            environ_base={'Content-Type': content_type},
             data=payload, base_url=BASE_URL)
     assert req.status_code == 413
 

--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -495,11 +495,13 @@ def test_get_forecast_gaps_400(api, inaccessible_forecast_id):
 
 
 @pytest.mark.parametrize('content_type,payload', [
-    ('application/json', '{"values": ['+"1"*17*1024*1024+']}'),
-    ('text/csv', 'timestamp,value\n'+"1"*17*1024*1024),
+    ('application/json', '{"values": [1, 2]}'),
+    ('text/csv', 'timestamp,value\n'+"1,2"),
 ])
 def test_post_forecast_too_large(
-        api, forecast_id, content_type, payload):
+        api, forecast_id, content_type, payload, mocker):
+    req_headers = mocker.patch('sfa_api.utils.request_handling.request')
+    req_headers.headers = {'Content-Length': 17*1024*1024}
     req = api.post(
             f'/forecasts/single/{forecast_id}/values',
             environ_base={'Content-Type': content_type,

--- a/sfa_api/tests/test_observations.py
+++ b/sfa_api/tests/test_observations.py
@@ -619,11 +619,13 @@ def test_get_observation_unflagged_404_fxid(api, forecast_id, addmayvalues):
 
 
 @pytest.mark.parametrize('content_type,payload', [
-    ('application/json', '{"values": ['+"1"*17*1024*1024+']}'),
-    ('text/csv', 'timestamp,value,quality_flag\n'+"1"*17*1024*1024),
+    ('application/json', '{"values": [1, 2]}'),
+    ('text/csv', 'timestamp,value,quality_flag\n1,2'),
 ])
 def test_post_observation_too_large(
-        api, observation_id, content_type, payload):
+        api, observation_id, content_type, payload, mocker):
+    req_headers = mocker.patch('sfa_api.utils.request_handling.request')
+    req_headers.headers = {'Content-Length': 17*1024*1024}
     req = api.post(
             f'/observations/{observation_id}/values',
             environ_base={'Content-Type': content_type,

--- a/sfa_api/tests/test_observations.py
+++ b/sfa_api/tests/test_observations.py
@@ -6,7 +6,8 @@ import pytest
 
 from sfa_api.conftest import (variables, interval_labels, BASE_URL,
                               VALID_OBS_VALUE_JSON, VALID_OBS_VALUE_CSV,
-                              VALID_OBS_JSON, copy_update)
+                              VALID_OBS_JSON, copy_update,
+                              _get_large_test_payload)
 
 
 INVALID_NAME = copy_update(VALID_OBS_JSON, 'name', '#Nope')
@@ -622,7 +623,7 @@ def test_get_observation_unflagged_404_fxid(api, forecast_id, addmayvalues):
     ('application/json', '{"values": [1, 2]}'),
     ('text/csv', 'timestamp,value,quality_flag\n1,2'),
 ])
-def test_post_observation_too_large(
+def test_post_observation_too_large_from_header(
         api, observation_id, content_type, payload, mocker):
     req_headers = mocker.patch('sfa_api.utils.request_handling.request')
     req_headers.headers = {'Content-Length': 17*1024*1024}
@@ -630,6 +631,19 @@ def test_post_observation_too_large(
             f'/observations/{observation_id}/values',
             environ_base={'Content-Type': content_type,
                           'Content-Length': 17*1024*1024},
+            data=payload, base_url=BASE_URL)
+    assert req.status_code == 413
+
+
+@pytest.mark.parametrize('content_type', [
+    'application/json', 'text/csv',
+])
+def test_post_observation_too_large_from_body(
+        api, observation_id, content_type, mocker):
+    payload = _get_large_test_payload(content_type)
+    req = api.post(
+            f'/observations/{observation_id}/values',
+            environ_base={'Content-Type': content_type},
             data=payload, base_url=BASE_URL)
     assert req.status_code == 413
 

--- a/sfa_api/users.py
+++ b/sfa_api/users.py
@@ -1,9 +1,10 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, Response
 from flask.views import MethodView
 
 
 from sfa_api import spec
-from sfa_api.schema import UserSchema, ActionList, ALLOWED_OBJECT_TYPES
+from sfa_api.schema import (UserSchema, ActionList, ALLOWED_OBJECT_TYPES,
+                            UserCreatePerms, ActionsOnTypeList)
 from sfa_api.utils.auth0_info import (
     get_email_of_user, list_user_emails, get_auth0_id_of_user)
 from sfa_api.utils.errors import StorageAuthError, BadAPIRequest
@@ -321,8 +322,8 @@ class UserCreatePermissions(MethodView):
 
         storage = get_storage()
         object_types = storage.get_user_creatable_types()
-        json_response = {'can_create': object_types}
-        return jsonify(json_response)
+        return Response(UserCreatePerms().dumps({'can_create': object_types}),
+                        mimetype="application/json")
 
 
 class UserActionsOnType(MethodView):
@@ -358,7 +359,8 @@ class UserActionsOnType(MethodView):
         object_dict = storage.list_actions_on_all_objects_of_type(object_type)
         json_response = {'object_type': object_type,
                          'objects': object_dict}
-        return jsonify(json_response)
+        return Response(ActionsOnTypeList().dumps(json_response),
+                        mimetype="application/json")
 
 
 spec.components.parameter(

--- a/sfa_api/users.py
+++ b/sfa_api/users.py
@@ -312,7 +312,7 @@ class UserCreatePermissions(MethodView):
             content:
               application/json:
                 schema:
-                  $ref: '#/components/schemas/CreateObjectList'
+                  $ref: '#/components/schemas/UserCreatePerms'
           404:
             $ref: '#/components/responses/404-NotFound'
           401:
@@ -343,7 +343,7 @@ class UserActionsOnType(MethodView):
             content:
               application/json:
                 schema:
-                  $ref: '#/components/schemas/ActionList'
+                  $ref: '#/components/schemas/ActionsOnTypeList'
           404:
             $ref: '#/components/responses/404-NotFound'
           401:
@@ -356,7 +356,8 @@ class UserActionsOnType(MethodView):
             })
         storage = get_storage()
         object_dict = storage.list_actions_on_all_objects_of_type(object_type)
-        json_response = {object_type: object_dict}
+        json_response = {'object_type': object_type,
+                         'objects': object_dict}
         return jsonify(json_response)
 
 
@@ -381,6 +382,16 @@ spec.components.parameter(
         'description': "The user's email address",
         'required': 'true',
         'name': 'email'
+    })
+spec.components.parameter(
+    'object_type', 'path',
+    {
+        'schema': {
+            'type': 'string',
+        },
+        'description': "The type of object to query for.",
+        'requires': 'true',
+        'name': 'object_type',
     })
 user_blp = Blueprint(
     'users', 'users', url_prefix='/users',

--- a/sfa_api/users.py
+++ b/sfa_api/users.py
@@ -355,8 +355,8 @@ class UserActionsOnType(MethodView):
                                f'{", ".join(ALLOWED_OBJECT_TYPES)}'
             })
         storage = get_storage()
-        object_list = storage.list_actions_on_all_objects_of_type(object_type)
-        json_response = {f'{object_type}s': object_list}
+        object_dict = storage.list_actions_on_all_objects_of_type(object_type)
+        json_response = {object_type: object_dict}
         return jsonify(json_response)
 
 

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -2321,3 +2321,37 @@ def _assert_variable_matches_aggregate(variable, aggregate_id):
     aggregate = read_aggregate(aggregate_id)
     if variable != aggregate['variable']:
         raise BadAPIRequest(variable="Forecast variable must match aggregate.")
+
+
+def get_user_creatable_types():
+    """Get the types of objects the user has permission to create.
+
+    Returns
+    -------
+    list
+        The list of object types the user can create.
+    """
+    object_types = _call_procedure('get_user_creatable_types',
+                                   cursor_type='standard')
+    object_types = [obj[0] for obj in object_types]
+    return object_types
+
+
+def list_actions_on_all_objects_of_type(object_type):
+    """Get a list of objects and the actions a user can take on them.
+
+    Parameters
+    ----------
+    object_type: str
+        The type of object to query for, e.g. `observations`.
+
+    Returns
+    -------
+    dict
+        Dict where keys are object uuids and values are lists of actions the
+        user can take.
+    """
+    object_action_list = _call_procedure(
+        'list_actions_on_all_objects_of_type',
+        object_type)
+    return {obj['id']: obj['actions'] for obj in object_action_list}

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -2347,9 +2347,10 @@ def list_actions_on_all_objects_of_type(object_type):
 
     Returns
     -------
-    dict
-        Dict where keys are object uuids and values are lists of actions the
-        user can take.
+    list
+        List of dictionaries that contain `object_id`, the uuid of the object
+        and `actions`, a list of actions the user has permission to perform
+        on the object.
     """
     object_action_list = _call_procedure(
         'list_actions_on_all_objects_of_type',

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -2354,4 +2354,4 @@ def list_actions_on_all_objects_of_type(object_type):
     object_action_list = _call_procedure(
         'list_actions_on_all_objects_of_type',
         object_type)
-    return {obj['id']: obj['actions'] for obj in object_action_list}
+    return object_action_list

--- a/sfa_api/utils/tests/test_storage_interface.py
+++ b/sfa_api/utils/tests/test_storage_interface.py
@@ -2046,16 +2046,16 @@ def test_get_user_creatable_types(sql_app, user, nocommit_cursor):
 
 
 @pytest.mark.parametrize('object_type,expected_actions', [
-    ('observations', ['create', 'read', 'delete', 'read_values',
+    ('observations', ['read', 'delete', 'read_values',
                       'write_values', 'delete_values']),
-    ('forecasts', ['create', 'read', 'delete', 'read_values', 'write_values',
+    ('forecasts', ['read', 'delete', 'read_values', 'write_values',
                    'delete_values']),
-    ('cdf_forecasts', ['create', 'read', 'update', 'delete', 'read_values',
+    ('cdf_forecasts', ['read', 'update', 'delete', 'read_values',
                        'write_values', 'delete_values']),
-    ('roles', ['create', 'read', 'update', 'delete', 'grant', 'revoke']),
-    ('permissions', ['create', 'read', 'update', 'delete']),
+    ('roles', ['read', 'update', 'delete', 'grant', 'revoke']),
+    ('permissions', ['read', 'update', 'delete']),
     ('users', ['read', 'update']),
-    ('reports', ['create', 'read', 'update', 'delete', 'read_values',
+    ('reports', ['read', 'update', 'delete', 'read_values',
                  'write_values']),
 ])
 def test_list_actions_on_all_objects_of_type(
@@ -2064,5 +2064,5 @@ def test_list_actions_on_all_objects_of_type(
         object_type)
     # Test user is granted "applies_to_all" permissions, so we can assert that
     # each object has the same permissions
-    for k, v in object_list.items():
-        assert v == expected_actions
+    for o in object_list:
+        assert o['actions'].sort() == expected_actions.sort()

--- a/sfa_api/utils/tests/test_storage_interface.py
+++ b/sfa_api/utils/tests/test_storage_interface.py
@@ -2037,3 +2037,32 @@ def test__assert_variable_matches_aggregate_failure(
         storage_interface._assert_variable_matches_aggregate(
             'dni', aggregate_id)
     storage_interface._assert_variable_matches_aggregate('ghi', aggregate_id)
+
+
+def test_get_user_creatable_types(sql_app, user, nocommit_cursor):
+    objects = storage_interface.get_user_creatable_types()
+    assert objects == ['sites', 'aggregates', 'cdf_forecasts', 'forecasts',
+                       'observations', 'roles', 'permissions', 'reports']
+
+
+@pytest.mark.parametrize('object_type,expected_actions', [
+    ('observations', ['create', 'read', 'delete', 'read_values',
+                      'write_values', 'delete_values']),
+    ('forecasts', ['create', 'read', 'delete', 'read_values', 'write_values',
+                   'delete_values']),
+    ('cdf_forecasts', ['create', 'read', 'update', 'delete', 'read_values',
+                       'write_values', 'delete_values']),
+    ('roles', ['create', 'read', 'update', 'delete', 'grant', 'revoke']),
+    ('permissions', ['create', 'read', 'update', 'delete']),
+    ('users', ['read', 'update']),
+    ('reports', ['create', 'read', 'update', 'delete', 'read_values',
+                 'write_values']),
+])
+def test_list_actions_on_all_objects_of_type(
+        sql_app, user, object_type, expected_actions):
+    object_list = storage_interface.list_actions_on_all_objects_of_type(
+        object_type)
+    # Test user is granted "applies_to_all" permissions, so we can assert that
+    # each object has the same permissions
+    for k, v in object_list.items():
+        assert v == expected_actions


### PR DESCRIPTION
Adds endpoints to list the types of objects the current user can create, and to get a list of object uuids of one type of object and the actions the user can take on those objects. 