### PR TITLE
Handle permission failure when reading report values

### DIFF
--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -1523,7 +1523,10 @@ def read_report(report_id):
     """
     report = _decode_report_parameters(
         _call_procedure_for_single('read_report', report_id))
-    report_values = read_report_values(report_id)
+    try:
+        report_values = read_report_values(report_id)
+    except StorageAuthError:
+        report_values = []
     report['values'] = report_values
     return report
 

--- a/sfa_api/utils/tests/test_storage_interface.py
+++ b/sfa_api/utils/tests/test_storage_interface.py
@@ -1550,6 +1550,15 @@ def test_read_report(sql_app, report, user, reportid):
     assert out == report
 
 
+def test_read_report_values_missing(sql_app, report, user, reportid,
+                                    remove_perms_from_current_role):
+    remove_perms_from_current_role('read_values', 'reports')
+    out = storage_interface.read_report(reportid)
+    assert out['report_parameters'] == report['report_parameters']
+    assert out['values'] != report['values']
+    assert out['values'] == []
+
+
 def test_read_report_denied(sql_app, invalid_user, reportid):
     with pytest.raises(storage_interface.StorageAuthError):
         storage_interface.read_report(reportid)


### PR DESCRIPTION
To support viewing a report with only `read` permissions on the report(https://github.com/SolarArbiter/solarforecastarbiter-dashboard/issues/134). Just handles the StorageAuthError that is raised when a user does not have `read_values` and returns an empty list. @alorenzo175 Do you think this needs anything else? Any possible issues with core?