### PR TITLE
Aggregate values

### DIFF
--- a/datastore/tests/test_updates.py
+++ b/datastore/tests/test_updates.py
@@ -273,6 +273,7 @@ def test_update_site(dictcursor, insertuser, allow_update_sites,
     dictcursor.execute('SELECT * from arbiter_data.sites WHERE id = %s',
                        insertuser.site['id'])
     new = dictcursor.fetchall()[0]
+    assert new.pop('modified_at') >= expected['modified_at']
     for k, v in new.items():
         if k not in kwargs or (
                 k in ('latitude', 'longitude', 'name', 'elevation',

--- a/sfa_api/aggregates.py
+++ b/sfa_api/aggregates.py
@@ -190,15 +190,15 @@ class AggregateValuesView(MethodView):
             end.tz_convert(aggregate['timezone']),
             freq=f"{aggregate['interval_length']}min"
         )
-        request_index = request_index[request_index > start]
+        request_index = request_index[request_index >= start]
 
         # compute agg
         try:
             values = compute_aggregate(
-                request_index,
                 indv_obs, f"{aggregate['interval_length']}min",
                 aggregate['interval_label'], aggregate['timezone'],
-                aggregate['aggregate_type'], aggregate['observations'])
+                aggregate['aggregate_type'], aggregate['observations'],
+                request_index)
         except (KeyError, ValueError) as err:
             raise BaseAPIException(422, values=str(err))
         accepts = request.accept_mimetypes.best_match(['application/json',

--- a/sfa_api/aggregates.py
+++ b/sfa_api/aggregates.py
@@ -184,18 +184,22 @@ class AggregateValuesView(MethodView):
         aggregate = storage.read_aggregate(aggregate_id)
         indv_obs = storage.read_aggregate_values(aggregate_id, start, end)
 
-        start_midnight = start.tz_convert(aggregate['timezone']).floor('D')
+        aggregate_interval = f"{aggregate['interval_length']}min"
+
+        index_start = start.tz_convert(
+            aggregate['timezone']
+        ).ceil(aggregate_interval)
+
         request_index = pd.date_range(
-            start_midnight,
+            index_start,
             end.tz_convert(aggregate['timezone']),
-            freq=f"{aggregate['interval_length']}min"
+            freq=aggregate_interval,
         )
-        request_index = request_index[request_index >= start]
 
         # compute agg
         try:
             values = compute_aggregate(
-                indv_obs, f"{aggregate['interval_length']}min",
+                indv_obs, aggregate_interval,
                 aggregate['interval_label'], aggregate['timezone'],
                 aggregate['aggregate_type'], aggregate['observations'],
                 request_index)

--- a/sfa_api/aggregates.py
+++ b/sfa_api/aggregates.py
@@ -189,19 +189,15 @@ class AggregateValuesView(MethodView):
         timezone = aggregate['timezone']
 
         if interval_label == 'ending':
-            index_start = start.tz_convert(
-                timezone
-            ).ceil(interval_length)
-            index_end = end.tz_convert(timezone)
+            index_start = start.ceil(interval_length)
+            index_end = end.ceil(interval_length)
         else:
-            index_start = start.tz_convert(timezone)
-            index_end = end.tz_convert(
-                timezone
-            ).floor(interval_length)
+            index_start = start.floor(interval_length)
+            index_end = end.floor(interval_length)
 
         request_index = pd.date_range(
-            index_start,
-            index_end,
+            index_start.tz_convert(timezone),
+            index_end.tz_convert(timezone),
             freq=interval_length,
         )
 

--- a/sfa_api/aggregates.py
+++ b/sfa_api/aggregates.py
@@ -191,15 +191,20 @@ class AggregateValuesView(MethodView):
         # outside of start/end when aggregating
         interval_offset = pd.Timedelta(interval_length) - pd.Timedelta('1ns')
 
-        index_start = start.ceil(interval_length)
-        index_end = end.floor(interval_length)
-
         if interval_label == 'ending':
+            index_start = start.ceil(interval_length)
+            index_end = end.ceil(interval_length)
+
             # adjust start to include all values in the previous interval
             start = index_start - interval_offset
+            end = index_end
         else:
+            index_start = start.floor(interval_length)
+            index_end = end.floor(interval_length)
+
             # adjust end to include all values in the final interval
             end = index_end + interval_offset
+            start = index_start
 
         indv_obs = storage.read_aggregate_values(aggregate_id, start, end)
 

--- a/sfa_api/aggregates.py
+++ b/sfa_api/aggregates.py
@@ -191,15 +191,13 @@ class AggregateValuesView(MethodView):
         # outside of start/end when aggregating
         interval_offset = pd.Timedelta(interval_length) - pd.Timedelta('1ns')
 
-        if interval_label == 'ending':
-            index_start = start.ceil(interval_length)
-            index_end = end.ceil(interval_length)
+        index_start = start.ceil(interval_length)
+        index_end = end.floor(interval_length)
 
+        if interval_label == 'ending':
             # adjust start to include all values in the previous interval
             start = index_start - interval_offset
         else:
-            index_start = start.floor(interval_length)
-            index_end = end.floor(interval_length)
             # adjust end to include all values in the final interval
             end = index_end + interval_offset
 

--- a/sfa_api/schema.py
+++ b/sfa_api/schema.py
@@ -10,7 +10,8 @@ import pytz
 from sfa_api import spec, ma, json
 from sfa_api.utils.validators import (
     TimeFormat, UserstringValidator, TimezoneValidator, TimeLimitValidator,
-    UncertaintyValidator, validate_if_event, ensure_pair_compatibility)
+    UncertaintyValidator, validate_if_event, ensure_pair_compatibility,
+    AggregateIntervalValidator)
 from solarforecastarbiter.datamodel import (
     ALLOWED_VARIABLES, ALLOWED_CATEGORIES, ALLOWED_DETERMINISTIC_METRICS,
     ALLOWED_EVENT_METRICS, ALLOWED_PROBABILISTIC_METRICS,
@@ -1567,7 +1568,8 @@ class AggregatePostSchema(ma.Schema):
                      'This aggregate interval length must be greater than or '
                      'equal to the interval length of the observations that go'
                      ' into it.'),
-        required=True)
+        required=True,
+        validate=AggregateIntervalValidator())
 
     aggregate_type = ma.String(
         title='Aggregation Type',

--- a/sfa_api/tests/test_aggregates.py
+++ b/sfa_api/tests/test_aggregates.py
@@ -31,7 +31,9 @@ def test_post_aggregate_success(api):
      f'{{"aggregate_type":["Must be one of: {agg_types}."]}}'),
     (copy_update(VALID_AGG_JSON, 'interval_label', 'instant'),
      '{"interval_label":["Must be one of: beginning, ending."]}'),
-    ({}, '{"aggregate_type":["Missing data for required field."],"description":["Missing data for required field."],"interval_label":["Missing data for required field."],"interval_length":["Missing data for required field."],"name":["Missing data for required field."],"timezone":["Missing data for required field."],"variable":["Missing data for required field."]}')  # NOQA
+    ({}, '{"aggregate_type":["Missing data for required field."],"description":["Missing data for required field."],"interval_label":["Missing data for required field."],"interval_length":["Missing data for required field."],"name":["Missing data for required field."],"timezone":["Missing data for required field."],"variable":["Missing data for required field."]}'),  # NOQA
+    (copy_update(VALID_AGG_JSON, 'interval_length', '61'),
+     f'{{"interval_length":["Must be a divisor of one day."]}}'),
 ])
 def test_post_aggregate_bad_request(api, payload, message):
     res = api.post('/aggregates/',

--- a/sfa_api/tests/test_aggregates.py
+++ b/sfa_api/tests/test_aggregates.py
@@ -1,6 +1,3 @@
-import math
-
-
 import pytest
 
 
@@ -378,7 +375,7 @@ def test_get_aggregate_values_limited_effective(api, aggregate_id, startend):
                   headers={'Accept': 'application/json'},
                   base_url=BASE_URL)
     assert res.status_code == 200
-    assert not math.isnan(res.json['values'][-1]['value'])
+    assert res.json['values'][-1]['value'] is None
 
 
 def test_get_aggregate_values_404(api, missing_id, startend):

--- a/sfa_api/tests/test_aggregates.py
+++ b/sfa_api/tests/test_aggregates.py
@@ -462,8 +462,8 @@ def test_aggregate_values_deleted_observation(api, observation_id, startend):
 
 
 @pytest.mark.parametrize('label,exp1,exp2', [
-    ('beginning', 124.02226667, 251.81885714),
-    ('ending', 132.84051429, 262.83033333),
+    ('beginning', 78.30793, 303.016),
+    ('ending', -0.77138242, 93.286025),
 ])
 def test_aggregate_values_interval_label(
         api, observation_id, label, exp1, exp2):
@@ -484,7 +484,7 @@ def test_aggregate_values_interval_label(
              base_url=BASE_URL)
     r3 = api.get(
         f'/aggregates/{aggregate_id}/values'
-        '?start=2019-04-14T13:30Z&end=2019-04-14T14:30Z',
+        '?start=2019-04-14T13:00Z&end=2019-04-14T14:00Z',
         headers={'Accept': 'application/json'},
         base_url=BASE_URL)
     values = r3.json['values']

--- a/sfa_api/tests/test_aggregates.py
+++ b/sfa_api/tests/test_aggregates.py
@@ -380,6 +380,16 @@ def test_get_aggregate_values_limited_effective(api, aggregate_id, startend):
     assert res.json['values'][-1]['value'] is None
 
 
+def test_get_aggregate_values_outside_effective(api, aggregate_id):
+    startend = '?start=2018-12-25T00:00Z&end=2018-12-30T00:00Z'
+    res = api.get(f'/aggregates/{aggregate_id}/values{startend}',
+                  headers={'Accept': 'application/json'},
+                  base_url=BASE_URL)
+    assert res.status_code == 422
+    assert res.json['errors']['values'] == [
+        'No effective observations in data']
+
+
 def test_get_aggregate_values_404(api, missing_id, startend):
     res = api.get(f'/aggregates/{missing_id}/values{startend}',
                   headers={'Accept': 'application/json'},

--- a/sfa_api/tests/test_aggregates.py
+++ b/sfa_api/tests/test_aggregates.py
@@ -462,8 +462,8 @@ def test_aggregate_values_deleted_observation(api, observation_id, startend):
 
 
 @pytest.mark.parametrize('label,exp1,exp2', [
-    ('beginning', 78.30793, 185.75),
-    ('ending', 6.01286, 93.286025),
+    ('beginning', 124.02226667, 251.81885714),
+    ('ending', 132.84051429, 262.83033333),
 ])
 def test_aggregate_values_interval_label(
         api, observation_id, label, exp1, exp2):
@@ -484,7 +484,7 @@ def test_aggregate_values_interval_label(
              base_url=BASE_URL)
     r3 = api.get(
         f'/aggregates/{aggregate_id}/values'
-        '?start=2019-04-14T13:00Z&end=2019-04-14T14:00Z',
+        '?start=2019-04-14T13:30Z&end=2019-04-14T14:30Z',
         headers={'Accept': 'application/json'},
         base_url=BASE_URL)
     values = r3.json['values']

--- a/sfa_api/utils/tests/test_validators.py
+++ b/sfa_api/utils/tests/test_validators.py
@@ -449,9 +449,9 @@ def test_ensure_pair_compatibility_object_dne(
 @pytest.mark.parametrize("data", [13, 17, 52])
 def test_AggregateIntervalValidator_errors(data):
     with pytest.raises(ValidationError):
-        validators.AggregateIntervalValidators()(data)
+        validators.AggregateIntervalValidator()(data)
 
 
 @pytest.mark.parametrize("data", [1, 3, 5, 15, 30, 60, 90])
 def test_AggregateIntervalValidator(data):
-    validators.AggregateIntervalValidators()(data)
+    validators.AggregateIntervalValidator()(data)

--- a/sfa_api/utils/tests/test_validators.py
+++ b/sfa_api/utils/tests/test_validators.py
@@ -444,3 +444,14 @@ def test_ensure_pair_compatibility_object_dne(
         validators.ensure_pair_compatibility(pair)
     errors = e.value.messages
     assert errors[failure_mode] == 'Does not exist.'
+
+
+@pytest.mark.parametrize("data", [13, 17, 52])
+def test_AggregateIntervalValidator_errors(data):
+    with pytest.raises(ValidationError):
+        validators.AggregateIntervalValidators()(data)
+
+
+@pytest.mark.parametrize("data", [1, 3, 5, 15, 30, 60, 90])
+def test_AggregateIntervalValidator(data):
+    validators.AggregateIntervalValidators()(data)

--- a/sfa_api/utils/validators.py
+++ b/sfa_api/utils/validators.py
@@ -316,5 +316,5 @@ def ensure_pair_compatibility(data):
 class AggregateIntervalValidator(Validator):
     """Ensures aggregate interval length is a divisor of one day."""
     def __call__(self, value):
-        if 86400 % pd.Timedemta(value).total_seconds() != 0:
+        if 86400 % pd.Timedelta(f'{value}min').total_seconds() != 0:
             raise ValidationError('Must be a divisor of one day.')

--- a/sfa_api/utils/validators.py
+++ b/sfa_api/utils/validators.py
@@ -5,6 +5,7 @@ import time
 
 from marshmallow.validate import Validator
 from marshmallow.exceptions import ValidationError
+import pandas as pd
 import pytz
 
 
@@ -310,3 +311,10 @@ def ensure_pair_compatibility(data):
 
     if errors:
         raise ValidationError(errors)
+
+
+class AggregateIntervalValidator(Validator):
+    """Ensures aggregate interval length is a divisor of one day."""
+    def __call__(self, value):
+        if 86400 % pd.Timedemta(value).total_seconds() != 0:
+            raise ValidationError('Must be a divisor of one day.')


### PR DESCRIPTION
Creates and passes an index for computing aggregate values to the `solarforecastarbiter.utils.compute_aggregate` function updated in https://github.com/SolarArbiter/solarforecastarbiter-core/pull/590

The `_make aggregate_index` function was enforcing a rule that aggregate interval lengths are divisors of one day, So I've added a validator for the aggregate schema to enforce this. 
closes #255 
closes #219 