### PR TITLE
Convert None to NaN in timeseries before calling compute_aggregate

### DIFF
--- a/sfa_api/aggregates.py
+++ b/sfa_api/aggregates.py
@@ -5,6 +5,7 @@ from functools import partial
 from flask import Blueprint, request, jsonify, make_response, url_for
 from flask.views import MethodView
 from marshmallow import ValidationError
+import numpy as np
 import pandas as pd
 from solarforecastarbiter.utils import compute_aggregate
 
@@ -25,7 +26,7 @@ from sfa_api.schema import (AggregateSchema,
 class AllAggregatesView(MethodView):
     def get(self, *args):
         """
-        ---
+ nan)       ---
         summary: List aggregates.
         description: List all aggregates that the user has access to.
         tags:
@@ -207,6 +208,10 @@ class AggregateValuesView(MethodView):
             start = index_start
 
         indv_obs = storage.read_aggregate_values(aggregate_id, start, end)
+
+        # ensure Null values are set to NaN before computing aggregate
+        for obs_id, data in indv_obs.items():
+            indv_obs[obs_id] = data.fillna(value=np.nan)
 
         request_index = pd.date_range(
             index_start.tz_convert(timezone),

--- a/sfa_api/aggregates.py
+++ b/sfa_api/aggregates.py
@@ -26,7 +26,7 @@ from sfa_api.schema import (AggregateSchema,
 class AllAggregatesView(MethodView):
     def get(self, *args):
         """
- nan)       ---
+        ---
         summary: List aggregates.
         description: List all aggregates that the user has access to.
         tags:

--- a/sfa_api/aggregates.py
+++ b/sfa_api/aggregates.py
@@ -5,7 +5,6 @@ from functools import partial
 from flask import Blueprint, request, jsonify, make_response, url_for
 from flask.views import MethodView
 from marshmallow import ValidationError
-import numpy as np
 import pandas as pd
 from solarforecastarbiter.utils import compute_aggregate
 
@@ -208,10 +207,6 @@ class AggregateValuesView(MethodView):
             start = index_start
 
         indv_obs = storage.read_aggregate_values(aggregate_id, start, end)
-
-        # ensure Null values are set to NaN before computing aggregate
-        for obs_id, data in indv_obs.items():
-            indv_obs[obs_id] = data.fillna(value=np.nan)
 
         request_index = pd.date_range(
             index_start.tz_convert(timezone),

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -339,9 +339,10 @@ def read_observation_values(observation_id, start=None, end=None):
     obs_vals = _call_procedure('read_observation_values', observation_id,
                                start, end, cursor_type='standard')
     df = pd.DataFrame.from_records(
-        list(obs_vals), columns=['observation_id', 'timestamp',
-                                 'value', 'quality_flag']
-    ).drop(columns='observation_id').set_index('timestamp')
+        list(obs_vals),
+        columns=['observation_id', 'timestamp', 'value', 'quality_flag'],
+    ).drop(columns='observation_id').set_index('timestamp').astype(
+        {'value': 'float', 'quality_flag': 'int64'})
     return df
 
 
@@ -530,7 +531,8 @@ def _read_fx_values(procedure_name, forecast_id, start, end):
                               start, end, cursor_type='standard')
     df = pd.DataFrame.from_records(
         list(fx_vals), columns=['forecast_id', 'timestamp', 'value']
-    ).drop(columns='forecast_id').set_index('timestamp')
+    ).drop(columns='forecast_id').set_index('timestamp').astype(
+        {'value': 'float'})
     return df
 
 
@@ -911,7 +913,8 @@ def read_latest_cdf_forecast_value(forecast_id):
                               cursor_type='standard')
     df = pd.DataFrame.from_records(
         list(fx_vals), columns=['forecast_id', 'timestamp', 'value']
-    ).drop(columns='forecast_id').set_index('timestamp')
+    ).drop(columns='forecast_id').set_index('timestamp').astype(
+        {'value': 'float'})
     return df
 
 
@@ -2075,7 +2078,8 @@ def read_aggregate_values(aggregate_id, start=None, end=None):
     out = {}
     for obs_id, df in groups:
         out[obs_id] = df.drop(columns='observation_id').drop_duplicates(
-        ).set_index('timestamp').sort_index()
+        ).set_index('timestamp').sort_index().astype(
+            {'value': 'float', 'quality_flag': 'int64'})
     return out
 
 

--- a/sfa_api/utils/storage_interface.py
+++ b/sfa_api/utils/storage_interface.py
@@ -364,7 +364,8 @@ def read_latest_observation_value(observation_id):
     df = pd.DataFrame.from_records(
         list(obs_vals), columns=[
             'observation_id', 'timestamp', 'value', 'quality_flag']
-    ).drop(columns='observation_id').set_index('timestamp')
+    ).drop(columns='observation_id').set_index('timestamp').astype(
+        {'value': 'float', 'quality_flag': 'int64'})
     return df
 
 
@@ -574,7 +575,8 @@ def read_latest_forecast_value(forecast_id):
                               cursor_type='standard')
     df = pd.DataFrame.from_records(
         list(fx_vals), columns=['forecast_id', 'timestamp', 'value']
-    ).drop(columns='forecast_id').set_index('timestamp')
+    ).drop(columns='forecast_id').set_index('timestamp').astype(
+        {'value': 'float'})
     return df
 
 


### PR DESCRIPTION
closes #296 
Converts None values to NaNs to avoid pandas resampling choking with "No numeric types to aggregate" error in core. I've done this here because the core api module handles this conversion for users, so I think this is something the api should take care of. This could also be handled at the storage interface level if there's any concern the issue might crop up elsewhere. 