### PR TITLE
Return error when empty data is posted.

### DIFF
--- a/sfa_api/tests/test_cdf_forecast.py
+++ b/sfa_api/tests/test_cdf_forecast.py
@@ -658,3 +658,25 @@ def test_post_file_invalid_mimetype(api, cdf_forecast_id):
     assert file_post.status_code == 400
     expected = '{"errors":{"error":["Unsupported Content-Type or MIME type."]}}\n' # noqa
     assert file_post.get_data(as_text=True) == expected
+
+
+def test_post_cdf_forecast_values_empty_json(api, cdf_forecast_id):
+    vals = {'values': []}
+    res = api.post(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
+                   base_url=BASE_URL,
+                   json=vals)
+    assert res.status_code == 400
+    assert res.json['errors'] == {
+        "error": ["Posted data contained no values."],
+    }
+
+
+def test_post_cdf_forecast_values_empty_csv(api, cdf_forecast_id):
+    res = api.post(f'/forecasts/cdf/single/{cdf_forecast_id}/values',
+                   base_url=BASE_URL,
+                   headers={'Content-Type': 'text/csv'},
+                   data="timestamp,value\n")
+    assert res.status_code == 400
+    assert res.json['errors'] == {
+        "error": ["Posted data contained no values."],
+    }

--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -785,3 +785,33 @@ def test_post_forecast_values_empty_csv(api, forecast_id):
     assert res.json['errors'] == {
         "error": ["Posted data contained no values."],
     }
+
+
+@pytest.mark.parametrize('missing', ['timestamp', 'value'])
+def test_post_forecast_values_json_missing_field(api, forecast_id, missing):
+    single_value = {'timestamp': '2020-01-01T00:00Z', 'value': 0}
+    single_value.pop(missing)
+    vals = {'values': [single_value]}
+    res = api.post(f'/forecasts/single/{forecast_id}/values',
+                   base_url=BASE_URL,
+                   json=vals)
+    assert res.status_code == 400
+    assert res.json['errors'] == {
+        missing: [f'Missing "{missing}" field.'],
+    }
+
+
+@pytest.mark.parametrize('csv,missing', [
+    ('timestamp\n2020-01-01T00:00Z', 'value'),
+    ('value\n5', 'timestamp'),
+])
+def test_post_forecast_values_csv_missing_field(
+        api, forecast_id, csv, missing):
+    res = api.post(f'/forecasts/single/{forecast_id}/values',
+                   base_url=BASE_URL,
+                   headers={'Content-Type': 'text/csv'},
+                   data=csv)
+    assert res.status_code == 400
+    assert res.json['errors'] == {
+        missing: [f'Missing "{missing}" field.'],
+    }

--- a/sfa_api/tests/test_forecast.py
+++ b/sfa_api/tests/test_forecast.py
@@ -763,3 +763,25 @@ def test_cdf_forecast_update_bad_request(api, cdf_forecast_group_id,
                  json=payload)
     assert r.status_code == 400
     assert r.get_data(as_text=True) == f'{{"errors":{message}}}\n'
+
+
+def test_post_forecast_values_empty_json(api, forecast_id):
+    vals = {'values': []}
+    res = api.post(f'/forecasts/single/{forecast_id}/values',
+                   base_url=BASE_URL,
+                   json=vals)
+    assert res.status_code == 400
+    assert res.json['errors'] == {
+        "error": ["Posted data contained no values."],
+    }
+
+
+def test_post_forecast_values_empty_csv(api, forecast_id):
+    res = api.post(f'/forecasts/single/{forecast_id}/values',
+                   base_url=BASE_URL,
+                   headers={'Content-Type': 'text/csv'},
+                   data="timestamp,value\n")
+    assert res.status_code == 400
+    assert res.json['errors'] == {
+        "error": ["Posted data contained no values."],
+    }

--- a/sfa_api/tests/test_observations.py
+++ b/sfa_api/tests/test_observations.py
@@ -748,3 +748,25 @@ def test_observation_update_bad_request(api, observation_id, payload, message):
                  json=payload)
     assert r.status_code == 400
     assert r.get_data(as_text=True) == f'{{"errors":{message}}}\n'
+
+
+def test_post_observation_values_empty_json(api, observation_id):
+    vals = {'values': []}
+    res = api.post(f'/observations/{observation_id}/values',
+                   base_url=BASE_URL,
+                   json=vals)
+    assert res.status_code == 400
+    assert res.json['errors'] == {
+        "error": ["Posted data contained no values."],
+    }
+
+
+def test_post_observation_values_empty_csv(api, observation_id):
+    res = api.post(f'/observations/{observation_id}/values',
+                   base_url=BASE_URL,
+                   headers={'Content-Type': 'text/csv'},
+                   data="timestamp,value,quality_flag\n")
+    assert res.status_code == 400
+    assert res.json['errors'] == {
+        "error": ["Posted data contained no values."],
+    }

--- a/sfa_api/utils/request_handling.py
+++ b/sfa_api/utils/request_handling.py
@@ -246,6 +246,11 @@ def validate_parsable_values():
         decoded_data = request.get_data(as_text=True)
         mimetype = request.mimetype
     value_df = parse_values(decoded_data, mimetype)
+
+    if value_df.size == 0:
+        raise BadAPIRequest({
+            'error': ("Posted data contained no values."),
+        })
     return value_df
 
 


### PR DESCRIPTION
Adds a check for a size 0 DataFrame when parsing posted values to avoid the indexerror raised for forecasts. Also helpful for observations to return a more precise error message. Observation endpoint previously complained about missing "quality_flag" field when data was empty.