### PR TITLE
Remove test and dev from the url listings in docs

### DIFF
--- a/sfa_api/spec.py
+++ b/sfa_api/spec.py
@@ -379,10 +379,6 @@ spec = APISpec(
          'description': 'Access and update Permissions in your organization.'},
     ],
     servers=[
-        {'url': '//dev-api.solarforecastarbiter.org/',
-         'description': 'Development server'},
-        {'url': '//testing-api.solarforecastarbiter.org/',
-         'description': 'Testing server'},
         {'url': '//api.solarforecastarbiter.org/',
          'description': 'Production server'}
     ]


### PR DESCRIPTION
We had a user think that they should be able to test or develop against these APIs, so probably best not to advertise their existence publicly.